### PR TITLE
[JENKINS-28816] test-scoped dependencies should not be considered

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -519,7 +519,8 @@ public class PluginCompatTester {
             Reader r = new FileReader(tmp);
             try {
                 BufferedReader br = new BufferedReader(r);
-                Pattern p = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):([^:]+):(provided|compile|runtime|test|system)");
+                // TODO could include |test but only if pom.addDependencies would add as <scope>test</scope>
+                Pattern p = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):([^:]+):(provided|compile|runtime|system)");
                 String line;
                 while ((line = br.readLine()) != null) {
                     Matcher m = p.matcher(line);


### PR DESCRIPTION
[JENKINS-28816](https://issues.jenkins-ci.org/browse/JENKINS-28816)

The modified POM was getting too much stuff, which led in turn to problems for the `windows-slaves` plugin.

@reviewbybees esp. @rsandell