### PR TITLE
Need to exclude transitive SECURITY-144-compat deps on all dependencies

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -119,6 +119,7 @@ public class MavenPom {
             if (artifactId == null) {
                 continue;
             }
+            excludeSecurity144Compat(mavenDependency);
             VersionNumber replacement = toReplace.get(artifactId.getTextTrim());
             if (replacement == null) {
                 continue;
@@ -129,7 +130,6 @@ public class MavenPom {
             }
             version = mavenDependency.addElement("version");
             version.addText(replacement.toString());
-            excludeSecurity144Compat(mavenDependency);
         }
         dependencies.addComment("SYNTHETIC");
         for (Map.Entry<String,VersionNumber> dep : toAdd.entrySet()) {


### PR DESCRIPTION
Should correct failures like this one in `SSHLauncherTest.testConfigurationRoundtrip` against 1.609.1:

```
java.lang.SecurityException: class "org.jenkinsci.remoting.CallableDecorator"'s signer information does not match signer information of other classes in the same package
…
com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException: 500 Internal Server Error for http://localhost:38708/computer/slave/configSubmit
	at com.gargoylesoftware.htmlunit.WebClient.throwFailingHttpStatusCodeExceptionIfNecessary(WebClient.java:549)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:333)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:357)
	at com.gargoylesoftware.htmlunit.html.HtmlForm.submit(HtmlForm.java:196)
	at org.jvnet.hudson.test.HudsonTestCase.submit(HudsonTestCase.java:1163)
	at hudson.plugins.sshslaves.SSHLauncherTest.testConfigurationRoundtrip(SSHLauncherTest.java:103)
```

@reviewbybees