### PR TITLE
Add testVersion flag

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -100,6 +100,13 @@ public class CliOptions {
     private String gaeSecurityToken;
     @Parameter(names="-gaeBaseUrl", description = "Allows to pass GAE plugin compat tester base url")
     private String gaeBaseUrl;
+    
+    @Parameter(names = "-testVersion",
+            description = "Allows Jenkins test version specification.\n" +
+                    "Use the Jenkins test classes from the same parent version of this plugin or the most recent release of Jenkins.\n" +
+                    "true= same version; false= most recent version.\n" +
+                    "Default = false")
+    private boolean testVersion = false;
 
 
     public String getUpdateCenterUrl() {
@@ -160,5 +167,9 @@ public class CliOptions {
 
     public String getGaeBaseUrl() {
         return gaeBaseUrl;
+    }
+    
+    public boolean getTestVersion() {
+        return testVersion;
     }
 }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -83,6 +83,7 @@ public class PluginCompatTesterCli {
         config.setWar(war);
 
         config.setExternalMaven(options.getExternalMaven());
+        config.setTestVersion(options.getTestVersion());
 
         if(options.getIncludePlugins() != null && !options.getIncludePlugins().isEmpty()){
             config.setIncludePlugins(Arrays.asList(options.getIncludePlugins().toLowerCase().split(",")));

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -99,6 +99,11 @@ public class PluginCompatTesterConfig {
     private String gaeSecurityToken;
     // GoogleAppEngin base url for plugin compat tester
     private String gaeBaseUrl;
+    
+    //Allows Jenkins test version specification.
+    //Use the Jenkins test classes from the same parent version of this plugin or the most recent release of Jenkins
+    //true= same version; false= most recent version
+    private boolean testVersion = false;
 
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
@@ -236,6 +241,14 @@ public class PluginCompatTesterConfig {
 
     public void setExternalMaven(File externalMaven) {
         this.externalMaven = externalMaven;
+    }
+    
+    public boolean getTestVersion() {
+        return testVersion;
+    }
+
+    public void setTestVersion(boolean testVersion) {
+        this.testVersion = testVersion;
     }
 
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -393,7 +393,7 @@ public class PluginCompatTester {
                 // but continue
             }
             if (mustTransformPom) {
-                pom.transformPom(coreCoordinates);
+                pom.transformPom(coreCoordinates, config.getTestVersion());
             }
             args.add("--define=maven.test.redirectTestOutputToFile=false");
             args.add("--define=concurrency=1");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -64,7 +64,6 @@ public class MavenPom {
 		try {
 			Document doc = new SAXReader().read(pom);
 			FileUtils.rename(pom, backupedPom);
-            System.out.println("Completed rename");
             
             Element parent = doc.getRootElement().element("parent");
             if(testJenkinsVersion){

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -58,15 +58,15 @@ public class MavenPom {
 		this.pomFileName = pomFileName;
 	}
 
-	public void transformPom(MavenCoordinates coreCoordinates, boolean testJenkinsVersion) throws PomTransformationException{
-		File pom = new File(rootDir.getAbsolutePath()+"/"+pomFileName);
-		File backupedPom = new File(rootDir.getAbsolutePath()+"/"+pomFileName+".backup");
-		try {
-			Document doc = new SAXReader().read(pom);
-			FileUtils.rename(pom, backupedPom);
+    public void transformPom(MavenCoordinates coreCoordinates, boolean testJenkinsVersion) throws PomTransformationException{
+        File pom = new File(rootDir.getAbsolutePath()+"/"+pomFileName);
+        File backupedPom = new File(rootDir.getAbsolutePath()+"/"+pomFileName+".backup");
+        try {
+            Document doc = new SAXReader().read(pom);
+            FileUtils.rename(pom, backupedPom);
             
             Element parent = doc.getRootElement().element("parent");
-            if(testJenkinsVersion){
+            if (testJenkinsVersion) {
                 doc = modJenkinsTestVersion(doc, parent);
             }
             
@@ -80,11 +80,10 @@ public class MavenPom {
             } finally {
                 w.close();
             }
-		} catch (Exception e) {
-			throw new PomTransformationException("Error while transforming pom : "+pom.getAbsolutePath(), e);
-		}
-		
-	}
+        } catch (Exception e) {
+            throw new PomTransformationException("Error while transforming pom : "+pom.getAbsolutePath(), e);
+        }
+    }
     
     private Document modJenkinsTestVersion(Document pom, Element parent){
         //in dependencies


### PR DESCRIPTION
Create the option for plugins to use the version of jenkins-test-harness matching their original parent pom.  This prevents failures based on test harness changes.  Right now, this change affects oss plugins.  Usage: -testVersion 
@reviewbybees 