### PR TITLE
Support xx.yy.zz-DATE-SNAPSHOT format in the jenkins-core.jar locator

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -449,7 +449,7 @@ public class PluginCompatTester {
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
                 String name = entry.getName();
-                Matcher m = Pattern.compile("WEB-INF/lib/jenkins-core-([0-9.]+(?:-SNAPSHOT)?)[.]jar").matcher(name);
+                Matcher m = Pattern.compile("WEB-INF/lib/jenkins-core-([0-9.]+(?:-[0-9.]+)?(?:-SNAPSHOT)?)[.]jar").matcher(name);
                 if (m.matches()) {
                     if (top.has("core")) {
                         throw new IOException(">1 jenkins-core.jar in " + war);


### PR DESCRIPTION
This change extends the supported formats, which is sensitive for daily builds

@reviewbybees (esp. @rsandell and @mslusarczyk)