### PR TITLE
[JENKINS-34312] Support plugins based on new parent POM.

### DIFF
--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
@@ -72,9 +72,17 @@ public class MavenCoordinates implements Comparable<MavenCoordinates> {
 
     public int compareTo(MavenCoordinates o) {
         if((groupId+":"+artifactId).equals(o.groupId+":"+o.artifactId)){
-            return new VersionComparator().compare(version, o.version);
+            return compareVersionTo(o.version);
         } else {
             return (groupId+":"+artifactId).compareTo(o.groupId+":"+o.artifactId);
         }
+    }
+
+    public boolean matches(String groupId, String artifactId) {
+        return this.groupId.equals(groupId) && this.artifactId.equals(artifactId);
+    }
+
+    public int compareVersionTo(String version) {
+        return new VersionComparator().compare(this.version, version);
     }
 }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class PluginCompatTesterConfig {
 
-    public static final String DEFAULT_UPDATE_CENTER_URL = "http://updates.jenkins-ci.org/update-center.json?version=build";
+    public static final String DEFAULT_UPDATE_CENTER_URL = "http://updates.jenkins-ci.org/update-center.json";
     public static final String DEFAULT_PARENT_GROUP = "org.jenkins-ci.plugins";
     public static final String DEFAULT_PARENT_ARTIFACT = "plugin";
     public static final String DEFAULT_PARENT_GAV = DEFAULT_PARENT_GROUP + ":" + DEFAULT_PARENT_ARTIFACT;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -356,13 +356,17 @@ public class PluginCompatTester {
         List<String> args = new ArrayList<String>();
         boolean mustTransformPom = false;
         // TODO future versions of DEFAULT_PARENT_GROUP/ARTIFACT may be able to use this as well
-        if (pomData.parent.groupId.equals("com.cloudbees.jenkins.plugins") && pomData.parent.artifactId.equals("jenkins-plugins") ||
+        final MavenCoordinates parent = pomData.parent;
+        if (parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
                 // TODO ought to analyze the chain of parent POMs, which would lead to com.cloudbees.jenkins.plugins:jenkins-plugins in this case:
-                pomData.parent.groupId.equals("com.cloudbees.operations-center.common") && pomData.parent.artifactId.equals("operations-center-parent") ||
-                pomData.parent.groupId.equals("com.cloudbees.operations-center.client") && pomData.parent.artifactId.equals("operations-center-parent-client") ||
-                pomData.parent.groupId.equals("org.jenkins-ci.plugins") && pomData.parent.artifactId.equals("plugin") && !pomData.parent.version.startsWith("1")) {
+                parent.matches("com.cloudbees.operations-center.common", "operations-center-parent") ||
+                parent.matches("com.cloudbees.operations-center.client", "operations-center-parent-client") ||
+                (parent.matches("org.jenkins-ci.plugins", "plugin") && parent.compareVersionTo("2.0") >= 0)) {
             args.add("-Djenkins.version=" + coreCoordinates.version);
-            args.add("-Dhpi-plugin.version=1.99"); // TODO would ideally pick up exact version from org.jenkins-ci.main:pom
+            args.add("-Dhpi-plugin.version=1.117"); // TODO would ideally pick up exact version from org.jenkins-ci.main:pom
+            // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores
+            // the plugin may be Java 6 and the dependencies bring Java 7
+            args.add("-Denforcer.skip=true");
         } else {
             mustTransformPom = true;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,14 @@
   <repositories>
     <repository>
         <id>repo.jenkins-ci.org</id>
-        <url>http://repo.jenkins-ci.org/public/</url>
+        <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
         <id>repo.jenkins-ci.org</id>
-        <url>http://repo.jenkins-ci.org/public/</url>
+        <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -84,7 +84,7 @@
                     <exclude>org.codehaus.plexus:plexus-container-default</exclude>
                   </excludes>
                   <message>
-                  ensure-no-plexus-container doesn't work anymore with maven 3 librairies. you have to add some exclusions.
+                  ensure-no-plexus-container doesn't work anymore with maven 3 libraries. you have to add some exclusions.
                   </message>
                 </bannedDependencies>
               </rules>
@@ -92,6 +92,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
       </plugin>
     </plugins>
 


### PR DESCRIPTION
See [JENKINS-34312](https://issues.jenkins-ci.org/browse/JENKINS-34312)

* Includes https://github.com/jenkinsci/plugin-compat-tester/pull/9
* Some small refactoring included.

@reviewbybees 