### PR TITLE
Add flag to skip javadoc.

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -389,7 +389,8 @@ public class PluginCompatTester {
             // First build against the original POM.
             // This defends against source incompatibilities (which we do not care about for this purpose);
             // and ensures that we are testing a plugin binary as close as possible to what was actually released.
-            runner.run(mconfig, pluginCheckoutDir, buildLogFile, "clean", "process-test-classes");
+            // We also skip potential javadoc execution to avoid general test failure.
+            runner.run(mconfig, pluginCheckoutDir, buildLogFile, "clean", "process-test-classes", "-Dmaven.javadoc.skip");
             ranCompile = true;
 
             // Then transform the POM and run tests against that.


### PR DESCRIPTION
Note: we never actually call `site` or any process beyond `test` so, several of the plugins that use javadoc in `jar` or `reporting` won't generate Javadoc during the pct.  This prevents issues with Javadoc generation from stopping the tests of any given plugin.  If javadoc isn't generated, this has no effect, and testing can continue as normal.

@reviewbybees esp. @andresrc 