### PR TITLE
Handle plugins under the test scope

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -391,7 +391,7 @@ public class PluginCompatTester {
             // This defends against source incompatibilities (which we do not care about for this purpose);
             // and ensures that we are testing a plugin binary as close as possible to what was actually released.
             // We also skip potential javadoc execution to avoid general test failure.
-            //runner.run(mconfig, pluginCheckoutDir, buildLogFile, "clean", "process-test-classes", "-Dmaven.javadoc.skip");
+            runner.run(mconfig, pluginCheckoutDir, buildLogFile, "clean", "process-test-classes", "-Dmaven.javadoc.skip");
             ranCompile = true;
 
             // Then transform the POM and run tests against that.
@@ -670,8 +670,8 @@ public class PluginCompatTester {
                     toAdd.put(plugin, declaredMinimum);
                 }
             }
-//TESTING
-List<String> convertFromTestDep = new ArrayList<String>();
+
+            List<String> convertFromTestDep = new ArrayList<String>();
             checkDefinedDeps(pluginDeps, toAdd, toReplace, otherPlugins, new ArrayList<String>(pluginDepsTest.keySet()), convertFromTestDep);
             pluginDepsTest.putAll(toAdd);
             pluginDepsTest.putAll(toReplace);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -341,7 +341,6 @@ public class PluginCompatTester {
 			ScmManager scmManager = SCMManagerFactory.getInstance().createScmManager();
 			ScmRepository repository = scmManager.makeScmRepository(pomData.getConnectionUrl());
 			CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(pluginCheckoutDir), new ScmTag(plugin.name+"-"+plugin.version));
-			System.out.println("DONE?");
 			if(!result.isSuccess()){
                 if(result.getCommandOutput().contains("error: pathspec") && result.getCommandOutput().contains("did not match any file(s) known to git.")){
                     // Trying to look for existing branch that looks like the one we are looking for
@@ -357,7 +356,6 @@ public class PluginCompatTester {
 			System.err.println("Error : " + e.getMessage());
 			throw new PluginSourcesUnavailableException("Problem while checking out plugin sources!", e);
 		}
-        System.out.println("DID I GET HERE");
         
         List<String> args = new ArrayList<String>();
         boolean mustTransformPom = false;
@@ -540,7 +538,6 @@ public class PluginCompatTester {
     }
 
     private void addSplitPluginDependencies(String thisPlugin, MavenRunner.Config mconfig, File pluginCheckoutDir, MavenPom pom, Map<String,Plugin> otherPlugins, Map<String, String> pluginGroupIds) throws PomExecutionException, IOException {
-        System.out.println("STARTING PLUGIN DEPS");
         File tmp = File.createTempFile("dependencies", ".log");
         VersionNumber coreDep = null;
         Map<String,VersionNumber> pluginDeps = new HashMap<String,VersionNumber>();
@@ -705,19 +702,39 @@ public class PluginCompatTester {
                     // We ignore the declared dependency version and go with the bundled version:
                     Plugin depBundledP = otherPlugins.get(depPlugin);
                     if (depBundledP != null) {
-                        // Check if this exists with an undesired scope
-                        if(inTest.contains(depPlugin)) {
-                            System.out.println("Converting " + depPlugin + " from the test scope since it was a dependency of " + plugin);
-                            toConvertFromTest.add(depPlugin);
-                            replacing.put(depPlugin, new VersionNumber(depBundledP.version));
-                            continue; // becomes a replacement 
-                        }
-                        System.out.println("Adding " + depPlugin + " since it was a dependency of " + plugin);
-                        adding.put(depPlugin, new VersionNumber(depBundledP.version));
+                        updateAllDependents(plugin, depBundledP, pluginList, adding, replacing, otherPlugins, inTest, toConvertFromTest);
                     }
                 }
             }
         }
     }
 
+    /**
+     * Search the dependents of a given plugin to determine if they need to be converted.
+     */
+    private void updateAllDependents(String parent, Plugin dependent, Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,Plugin> otherPlugins, List<String> inTest, List<String> toConvertFromTest) {
+        // Check if this exists with an undesired scope
+        String pluginName = dependent.name;
+        if(inTest.contains(pluginName)) { // becomes a replacement 
+            System.out.println("Converting " + pluginName + " from the test scope since it was a dependency of " + parent);
+            toConvertFromTest.add(pluginName);
+            replacing.put(pluginName, new VersionNumber(dependent.version));
+        } else {
+            System.out.println("Adding " + pluginName + " since it was a dependency of " + parent);
+            adding.put(pluginName, new VersionNumber(dependent.version));
+        }
+        // Also check any dependencies
+        for (Map.Entry<String,String> dependency : dependent.dependencies.entrySet()) {
+            String depPlugin = dependency.getKey();
+            if (pluginList.containsKey(depPlugin)) {
+                continue; // already handled
+            }
+
+            // We ignore the declared dependency version and go with the bundled version:
+            Plugin depBundledP = otherPlugins.get(depPlugin);
+            if (depBundledP != null) {
+                updateAllDependents(pluginName, depBundledP, pluginList, adding, replacing, otherPlugins, inTest, toConvertFromTest);
+            }
+        }
+    }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -598,6 +598,7 @@ public class PluginCompatTester {
                 "antisamy-markup-formatter:1.553.*:1.0",
                 "matrix-project:1.561.*:1.0",
                 "junit:1.577.*:1.0",
+                "bouncycastle-api:2.16.*:2.16.0",
             };
             // Synchronize with ClassicPluginStrategy.BREAK_CYCLES:
             String[] exceptions = {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -671,9 +671,11 @@ public class PluginCompatTester {
             }
 
             checkDefinedDeps(pluginDeps, toAdd, toReplace, otherPlugins);
+            pluginDepsTest.putAll(toAdd);
+            pluginDepsTest.putAll(toReplace);
             checkDefinedDeps(pluginDepsTest, toAddTest, toReplaceTest, otherPlugins);
             if (!toAdd.isEmpty() || !toReplace.isEmpty()) {
-                System.out.println("Adding/replacing plugin dependencies for compatibility: " + toAdd + " " + toReplace + "\n" + toAddTest + " " + toReplaceTest);
+                System.out.println("Adding/replacing plugin dependencies for compatibility: " + toAdd + " " + toReplace + "\nFor test: " + toAddTest + " " + toReplaceTest);
                 pom.addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds);
             }
         }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -710,12 +710,15 @@ public class PluginCompatTester {
     }
 
     /**
-     * Search the dependents of a given plugin to determine if they need to be converted.
+     * Search the dependents of a given plugin to determine if we need to use the bundled version.
+     * This helps in cases where tests fail due to new insufficient versions as well as more 
+     * accurtely representing the totality of upgraded plugins for provided war files.
      */
     private void updateAllDependents(String parent, Plugin dependent, Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,Plugin> otherPlugins, List<String> inTest, List<String> toConvertFromTest) {
         // Check if this exists with an undesired scope
         String pluginName = dependent.name;
-        if(inTest.contains(pluginName)) { // becomes a replacement 
+        if(inTest.contains(pluginName)) { 
+            // This is now required in the compile scope.  For example: copyartifact's dependency matrix-project requires junit
             System.out.println("Converting " + pluginName + " from the test scope since it was a dependency of " + parent);
             toConvertFromTest.add(pluginName);
             replacing.put(pluginName, new VersionNumber(dependent.version));

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -123,7 +123,10 @@ public class MavenPom {
             VersionNumber replacement = toReplace.get(artifactId.getTextTrim());
             if (replacement == null) {
                 replacement = toReplaceTest.get(artifactId.getTextTrim());
-                continue;
+                if (replacement == null) {
+                    continue;
+                }
+                toReplaceTest.remove(artifactId.getTextTrim());
             }
             Element version = mavenDependency.element("version");
             if (version != null) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -130,7 +130,11 @@ public class MavenPom {
             }
             version = mavenDependency.addElement("version");
             version.addText(replacement.toString());
+            toReplace.remove(artifactId.getTextTrim());
         }
+        // If the replacement dependencies weren't explicitly present in the pom, add them directly now
+        toAdd.putAll(toReplace);
+
         dependencies.addComment("SYNTHETIC");
         for (Map.Entry<String,VersionNumber> dep : toAdd.entrySet()) {
             Element dependency = dependencies.addElement("dependency");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -87,7 +87,9 @@ public class MavenPom {
 		
 	}
 
-    public void addDependencies(Map<String,VersionNumber> toAdd, Map<String,VersionNumber> toReplace, Map<String,VersionNumber> toAddTest, Map<String,VersionNumber> toReplaceTest, VersionNumber coreDep, Map<String,String> pluginGroupIds) throws IOException {
+    public void addDependencies(Map<String,VersionNumber> toAdd, Map<String,VersionNumber> toReplace, Map<String,VersionNumber> toAddTest, Map<String,VersionNumber> toReplaceTest, VersionNumber coreDep, Map<String,String> pluginGroupIds, List<String> toConvert) 
+        throws IOException 
+    {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
         try {
@@ -133,6 +135,12 @@ public class MavenPom {
                 mavenDependency.remove(version);
             }
             version = mavenDependency.addElement("version");
+            if (toConvert.contains(artifactId)) { // Remove the test scope
+                Element scope = mavenDependency.element("scope");
+                if (scope != null) {
+                    mavenDependency.remove(scope);
+                }
+            }
             version.addText(replacement.toString());
             toReplace.remove(artifactId.getTextTrim());
         }


### PR DESCRIPTION
Some of the plugins are failing on the newer versions of Jenkins because their test elements need to be updated.  These were failing pretty much immediately, so I changed the scope to also cover the tests.

Also found that there are instances where the bundled elements are supposed to be upgraded but aren't actually upgraded because they weren't included in the base pom.  These are now explicitly added.

@reviewbybees 