### PR TITLE
Only update the Jenkins plugin in the parent pom

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -118,9 +118,16 @@ public class MavenPom {
         }
         for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {
             Element artifactId = mavenDependency.element("artifactId");
-            if (artifactId == null) {
+            Element groupId = mavenDependency.element("groupId");
+            if (artifactId == null || groupId == null) {
                 continue;
             }
+
+            String expectedGroupId = pluginGroupIds.get(artifactId.getTextTrim());
+            if(expectedGroupId == null || !groupId.getTextTrim().equals(expectedGroupId)) {
+                continue;
+            }
+            
             excludeSecurity144Compat(mavenDependency);
             VersionNumber replacement = toReplace.get(artifactId.getTextTrim());
             if (replacement == null) {


### PR DESCRIPTION
In 99% of cases, the Jenkins plugin artifactId is the only identifier needed when updating the parent pom since plugin names are fairly unique.  For that last 1% (notably `junit`), the plugin compat tester "upgrades" a maven dependency that's not actually a plugin.  I simply added a check for the groupId; only upgrade a dependency that matches artifactId and groupId.

@reviewbybees  esp @andresrc 