### PR TITLE
Change split point to use the coreCoordinate

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -405,7 +405,7 @@ public class PluginCompatTester {
             // Much simpler to do use the parent POM to set up the test classpath. 
             MavenPom pom = new MavenPom(pluginCheckoutDir);
             try {
-                addSplitPluginDependencies(plugin.name, mconfig, pluginCheckoutDir, pom, otherPlugins, pluginGroupIds);
+                addSplitPluginDependencies(plugin.name, mconfig, pluginCheckoutDir, pom, otherPlugins, pluginGroupIds, coreCoordinates);
             } catch (Exception x) {
                 x.printStackTrace();
                 pomData.getWarningMessages().add(Functions.printThrowable(x));
@@ -549,7 +549,7 @@ public class PluginCompatTester {
         }
     }
 
-    private void addSplitPluginDependencies(String thisPlugin, MavenRunner.Config mconfig, File pluginCheckoutDir, MavenPom pom, Map<String,Plugin> otherPlugins, Map<String, String> pluginGroupIds) throws PomExecutionException, IOException {
+    private void addSplitPluginDependencies(String thisPlugin, MavenRunner.Config mconfig, File pluginCheckoutDir, MavenPom pom, Map<String,Plugin> otherPlugins, Map<String, String> pluginGroupIds, MavenCoordinates coreCoordinates) throws PomExecutionException, IOException {
         File tmp = File.createTempFile("dependencies", ".log");
         VersionNumber coreDep = null;
         Map<String,VersionNumber> pluginDeps = new HashMap<String,VersionNumber>();
@@ -619,7 +619,7 @@ public class PluginCompatTester {
             tmp.delete();
         }
         System.out.println("Analysis: coreDep=" + coreDep + " pluginDeps=" + pluginDeps + " pluginDepsTest=" + pluginDepsTest);
-        if (coreDep != null) {
+        if (coreCoordinates != null) {
             // Synchronize with ClassicPluginStrategy.DETACHED_LIST:
             String[] splits = {
                 "maven-plugin:1.296:1.296",
@@ -658,10 +658,9 @@ public class PluginCompatTester {
                     System.out.println("Skipping implicit dep " + thisPlugin + " → " + plugin);
                     continue;
                 }
-                VersionNumber splitPoint = new VersionNumber(pieces[1]);
+                String splitPoint = pieces[1];
                 VersionNumber declaredMinimum = new VersionNumber(pieces[2]);
-                // TODO this should only happen if the tested core version is ≥ splitPoint
-                if (coreDep.compareTo(splitPoint) <= 0 && !pluginDeps.containsKey(plugin)) {
+                if (coreCoordinates.compareVersionTo(splitPoint) >= 0 && !pluginDeps.containsKey(plugin)) {
                     Plugin bundledP = otherPlugins.get(plugin);
                     if (bundledP != null) {
                         VersionNumber bundledV;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -426,6 +426,7 @@ public class PluginCompatTester {
             forExecutionHooks.put("pomData", pomData);
             forExecutionHooks.put("pom", pom);
             forExecutionHooks.put("coreCoordinates", coreCoordinates);
+            forExecutionHooks.put("pluginCheckoutDir", pluginCheckoutDir);
             pcth.runBeforeExecution(forExecutionHooks);
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, ((List<String>)forExecutionHooks.get("args")).toArray(new String[args.size()]));
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -101,21 +101,19 @@ public class MavenPom {
         if (dependencies == null) {
             dependencies = doc.getRootElement().addElement("dependencies");
         }
-        if(coreDep != null) {
-            for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {
-                Element artifactId = mavenDependency.element("artifactId");
-                if (artifactId == null || !"maven-plugin".equals(artifactId.getTextTrim())) {
-                    continue;
+        for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {
+            Element artifactId = mavenDependency.element("artifactId");
+            if (artifactId == null || !"maven-plugin".equals(artifactId.getTextTrim())) {
+                continue;
+            }
+            Element version = mavenDependency.element("version");
+            if (version == null || version.getTextTrim().startsWith("${")) {
+                // Prior to 1.532, plugins sometimes assumed they could pick up the Maven plugin version from their parent POM.
+                if (version != null) {
+                    mavenDependency.remove(version);
                 }
-                Element version = mavenDependency.element("version");
-                if (version == null || version.getTextTrim().startsWith("${")) {
-                    // Prior to 1.532, plugins sometimes assumed they could pick up the Maven plugin version from their parent POM.
-                    if (version != null) {
-                        mavenDependency.remove(version);
-                    }
-                    version = mavenDependency.addElement("version");
-                    version.addText(coreDep.toString());
-                }
+                version = mavenDependency.addElement("version");
+                version.addText(coreDep.toString());
             }
         }
         for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -101,19 +101,21 @@ public class MavenPom {
         if (dependencies == null) {
             dependencies = doc.getRootElement().addElement("dependencies");
         }
-        for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {
-            Element artifactId = mavenDependency.element("artifactId");
-            if (artifactId == null || !"maven-plugin".equals(artifactId.getTextTrim())) {
-                continue;
-            }
-            Element version = mavenDependency.element("version");
-            if (version == null || version.getTextTrim().startsWith("${")) {
-                // Prior to 1.532, plugins sometimes assumed they could pick up the Maven plugin version from their parent POM.
-                if (version != null) {
-                    mavenDependency.remove(version);
+        if(coreDep != null) {
+            for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {
+                Element artifactId = mavenDependency.element("artifactId");
+                if (artifactId == null || !"maven-plugin".equals(artifactId.getTextTrim())) {
+                    continue;
                 }
-                version = mavenDependency.addElement("version");
-                version.addText(coreDep.toString());
+                Element version = mavenDependency.element("version");
+                if (version == null || version.getTextTrim().startsWith("${")) {
+                    // Prior to 1.532, plugins sometimes assumed they could pick up the Maven plugin version from their parent POM.
+                    if (version != null) {
+                        mavenDependency.remove(version);
+                    }
+                    version = mavenDependency.addElement("version");
+                    version.addText(coreDep.toString());
+                }
             }
         }
         for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {


### PR DESCRIPTION
This was an important TODO that is being addressed now.  Instead of using the plugin's jenkins/version, we need to check against the coreCoordinates that we're actually going to be testing.  There is the chance that something was split out of core after the plugin's jenkins.version and it could cause the coreCoordinates to fail.

Importantly the sign change here: `coreCoordinates.compareVersionTo(splitPoint) >= 0`  With that change, it now will add the plugin if the coreCoordinates is greater than the splitPoint.  Which makes sense, it's no longer in core, so we need to track that plugin.

@reviewbybees 