### PR TITLE
[JENKINS-43725] Avoid test scope dependencies already present

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -681,10 +681,15 @@ public class PluginCompatTester {
             }
 
             List<String> convertFromTestDep = new ArrayList<String>();
-            checkDefinedDeps(pluginDeps, toAdd, toReplace, otherPlugins, new ArrayList<String>(pluginDepsTest.keySet()), convertFromTestDep);
+            checkDefinedDeps(pluginDeps, toAdd, toReplace, otherPlugins, new ArrayList<>(pluginDepsTest.keySet()), convertFromTestDep);
             pluginDepsTest.putAll(difference(pluginDepsTest, toAdd));
             pluginDepsTest.putAll(difference(pluginDepsTest, toReplace));
             checkDefinedDeps(pluginDepsTest, toAddTest, toReplaceTest, otherPlugins);
+
+            // Could contain transitive dependencies which were part of the plugin's dependencies or to be added
+            toAddTest = difference(pluginDeps, toAddTest);
+            toAddTest = difference(toAdd, toAddTest);
+
             if (!toAdd.isEmpty() || !toReplace.isEmpty() || !toAddTest.isEmpty() || !toReplaceTest.isEmpty()) {
                 System.out.println("Adding/replacing plugin dependencies for compatibility: " + toAdd + " " + toReplace + "\nFor test: " + toAddTest + " " + toReplaceTest);
                 pom.addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, convertFromTestDep);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -27,6 +27,7 @@ package org.jenkins.tools.test.model;
 
 import hudson.util.VersionNumber;
 import org.codehaus.plexus.util.FileUtils;
+import org.dom4j.io.XMLWriter;
 import org.jenkins.tools.test.exception.PomTransformationException;
 import org.springframework.core.io.ClassPathResource;
 
@@ -44,6 +45,7 @@ import java.util.Map;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
+import org.dom4j.io.OutputFormat;
 import org.dom4j.io.SAXReader;
 
 /**
@@ -156,13 +158,16 @@ public class MavenPom {
         toAddTest.putAll(toReplaceTest);
 
         dependencies.addComment("SYNTHETIC");
-        addPlugins(toAdd, pluginGroupIds, dependencies, "");
+        addPlugins(toAdd, pluginGroupIds, dependencies, null);
         addPlugins(toAddTest, pluginGroupIds, dependencies, "test");
 
         FileWriter w = new FileWriter(pom);
+        OutputFormat format = OutputFormat.createPrettyPrint();
+        XMLWriter writer = new XMLWriter(w, format);
         try {
-            doc.write(w);
+            writer.write(doc);
         } finally {
+            writer.close();
             w.close();
         }
     }
@@ -196,7 +201,7 @@ public class MavenPom {
             dependency.addElement("version").addText(dep.getValue().toString());
 
             // Add required scope
-            if(scope != null && !scope.isEmpty()) {
+            if(scope != null) {
                 dependency.addElement("scope").addText(scope);
             }
             excludeSecurity144Compat(dependency);


### PR DESCRIPTION
[JENKINS-42877](https://issues.jenkins-ci.org/browse/JENKINS-42877)

Due to transitive dependencies, some plugin dependencies could be added with test scope when they were already present as the direct dependencies.

Also improved the output format for the POM file so that it can be read easily.

@reviewbybees esp. @andresrc @kwhetstone @jglick @raul-arabaolaza 