### PR TITLE
Fix boolean condition when transforming POM

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -41,7 +41,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
             // the plugin may be Java 6 and the dependencies bring Java 7
             argsToMod.add("-Denforcer.skip=true");
             info.put("args", argsToMod);
-        } else if (coreRequiresNewParentPOM && pluginPOM && parentV2) {
+        } else if (coreRequiresNewParentPOM && pluginPOM && !parentV2) {
             throw new RuntimeException("New parent POM required for core >= 1.646");
         } else {
             mustTransformPom = true;


### PR DESCRIPTION
Boolean condition was wrong, which was making some plugins to be transformed instead of an exception being thrown.

@reviewbybees @kwhetstone @jglick @andresrc @raul-arabaolaza 