### PR TITLE
[JENKINS-44275] Not ignore failures when checking out plugins.

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -361,12 +361,7 @@ public class PluginCompatTester {
                 CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(pluginCheckoutDir), new ScmTag(plugin.name+"-"+plugin.version));
                 
                 if(!result.isSuccess()){
-                    if(result.getCommandOutput().contains("error: pathspec") && result.getCommandOutput().contains("did not match any file(s) known to git.")){
-                        // Trying to look for existing branch that looks like the one we are looking for
-                        // TODO ???
-                    } else {
-                        throw new RuntimeException(result.getProviderMessage() + "||" + result.getCommandOutput());
-                    }
+                    throw new RuntimeException(result.getProviderMessage() + " || " + result.getCommandOutput());
                 }
 
             } else {


### PR DESCRIPTION
[JENKINS-44275](https://issues.jenkins-ci.org/browse/JENKINS-44275)

When trying to checkout a snapshot (which is not obviously a tag) a failure happens, but it is being ignored and therefore trunk is being used, which is not the expected behaviour.

@reviewbybees @kwhetstone @jglick @andresrc 