### PR TITLE
[JENKINS-44279] Ignore transitive optional dependencies

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -507,7 +507,7 @@ public class PluginCompatTester {
                             if (dependencies != null) {
                                 // e.g. matrix-auth:1.0.2;resolution:=optional,credentials:1.8.3;resolution:=optional
                                 for (String pair : dependencies.split(",")) {
-                                    boolean optional = pair.contains("resolution:=optional");
+                                    boolean optional = pair.endsWith("resolution:=optional");
                                     String[] nameVer = pair.replace(";resolution:=optional", "").split(":");
                                     assert nameVer.length == 2;
                                     dependenciesA.add(new JSONObject().accumulate("name", nameVer[0]).accumulate("version", nameVer[1]).accumulate("optional", String.valueOf(optional)));

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -507,11 +507,7 @@ public class PluginCompatTester {
                             if (dependencies != null) {
                                 // e.g. matrix-auth:1.0.2;resolution:=optional,credentials:1.8.3;resolution:=optional
                                 for (String pair : dependencies.split(",")) {
-                                    boolean optional = false;
-                                    if (pair.split(";").length > 1) {
-                                        optional = true;
-                                    }
-
+                                    boolean optional = pair.contains("resolution:=optional");
                                     String[] nameVer = pair.replace(";resolution:=optional", "").split(":");
                                     assert nameVer.length == 2;
                                     dependenciesA.add(new JSONObject().accumulate("name", nameVer[0]).accumulate("version", nameVer[1]).accumulate("optional", String.valueOf(optional)));

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -506,10 +506,15 @@ public class PluginCompatTester {
                             String dependencies = manifest.getMainAttributes().getValue("Plugin-Dependencies");
                             if (dependencies != null) {
                                 // e.g. matrix-auth:1.0.2;resolution:=optional,credentials:1.8.3;resolution:=optional
-                                for (String pair : dependencies.replace(";resolution:=optional", "").split(",")) {
-                                    String[] nameVer = pair.split(":");
+                                for (String pair : dependencies.split(",")) {
+                                    boolean optional = false;
+                                    if (pair.split(";").length > 1) {
+                                        optional = true;
+                                    }
+
+                                    String[] nameVer = pair.replace(";resolution:=optional", "").split(":");
                                     assert nameVer.length == 2;
-                                    dependenciesA.add(new JSONObject().accumulate("name", nameVer[0]).accumulate("version", nameVer[1])./* we do care about even optional deps here */accumulate("optional", "false"));
+                                    dependenciesA.add(new JSONObject().accumulate("name", nameVer[0]).accumulate("version", nameVer[1]).accumulate("optional", String.valueOf(optional)));
                                 }
                             }
                             plugin.accumulate("dependencies", dependenciesA);


### PR DESCRIPTION
[JENKINS-44279](https://issues.jenkins-ci.org/browse/JENKINS-44279)

Transitive optional dependencies do not need to be included by PCT, as they would be present in the plugin's own dependencies if they were really necessary for the tests to execute properly.

Marking them properly as optional (or not), makes the check in UpdateSite class from Hudson not to take them into account:

````
@DataBoundConstructor
        public Plugin(String sourceId, JSONObject o) {
            super(sourceId, o);
            this.wiki = get(o,"wiki");
            this.title = get(o,"title");
            this.excerpt = get(o,"excerpt");
            this.compatibleSinceVersion = get(o,"compatibleSinceVersion");
            this.requiredCore = get(o,"requiredCore");
            this.categories = o.has("labels") ? (String[])o.getJSONArray("labels").toArray(new String[0]) : null;
            for(Object jo : o.getJSONArray("dependencies")) {
                JSONObject depObj = (JSONObject) jo;
                // Make sure there's a name attribute, that that name isn't maven-plugin - we ignore that one -
                // and that the optional value isn't true.
                if (get(depObj,"name")!=null
                    && !get(depObj,"name").equals("maven-plugin")
                    && get(depObj,"optional").equals("false")) {
                    dependencies.put(get(depObj,"name"), get(depObj,"version"));
                }   
            }
        }
````

@reviewbybees @jglick @kwhetstone @andresrc 