### PR TITLE
[JENKINS-44576] Use local clone instead of checking out from SCM

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -104,6 +104,9 @@ public class CliOptions {
     @Parameter(names="-hookPrefixes", description = "Prefixes of the extra hooks' classes")
     private String hookPrefixes;
 
+    @Parameter(names="-localCheckoutDir", description = "Folder containing a local (possibly modified) clone of a plugin repository")
+    private String localCheckoutDir;
+
     public String getUpdateCenterUrl() {
         return updateCenterUrl;
     }
@@ -166,5 +169,9 @@ public class CliOptions {
 
     public String getHookPrefixes() {
         return hookPrefixes;
+    }
+
+    public String getLocalCheckoutDir() {
+        return localCheckoutDir;
     }
 }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -108,6 +108,9 @@ public class PluginCompatTesterCli {
         if(options.getHookPrefixes() != null && !options.getHookPrefixes().isEmpty()){
             config.setHookPrefixes(Arrays.asList(options.getHookPrefixes().split(",")));
         }
+        if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
+            config.setLocalCheckoutDir(options.getLocalCheckoutDir());
+        }
 
         PluginCompatTester tester = new PluginCompatTester(config);
         tester.testPlugins();

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -105,6 +105,9 @@ public class PluginCompatTesterConfig {
     // Classpath prefixes of the extra hooks
     private List<String> hookPrefixes = new ArrayList<String>(Arrays.asList("org.jenkins"));
 
+    // Path for a folder containing a local (possibly modified) clone of a plugin repository
+    private File localCheckoutDir;
+
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
                 workDirectory, reportFile, m2SettingsFile);
@@ -250,5 +253,13 @@ public class PluginCompatTesterConfig {
     public void setHookPrefixes(List<String> hookPrefixes) {
         // Want to also process the default
         this.hookPrefixes.addAll(hookPrefixes);
+    }
+
+    public File getLocalCheckoutDir() {
+        return localCheckoutDir;
+    }
+
+    public void setLocalCheckoutDir(String localCheckoutDir) {
+        this.localCheckoutDir = new File(localCheckoutDir);
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -353,7 +353,11 @@ public class PluginCompatTester {
                 pluginCheckoutDir.mkdir();
                 System.out.println("Created plugin checkout dir : "+pluginCheckoutDir.getAbsolutePath());
 
-                if (shouldUseLocalCheckout()) {
+                if (localCheckoutProvided()) {
+                    if (!onlyOnePluginIncluded()) {
+                        throw new RuntimeException("You specified a local clone but did not choose only one plugin to execute PCT against it");
+                    }
+
                     FileUtils.copyDirectoryStructure(config.getLocalCheckoutDir(), pluginCheckoutDir);
                 } else {
                     // These hooks could redirect the SCM, skip checkout (if multiple plugins use the same preloaded repo)
@@ -438,10 +442,12 @@ public class PluginCompatTester {
         }
 	}
 
-    private boolean shouldUseLocalCheckout() {
-        boolean properLocalCheckoutDir = config.getLocalCheckoutDir() != null && config.getLocalCheckoutDir().exists();
-        boolean onlyOnePlugin = config.getIncludePlugins() != null && config.getIncludePlugins().size() == 1;
-        return properLocalCheckoutDir && onlyOnePlugin;
+    private boolean localCheckoutProvided() {
+        return config.getLocalCheckoutDir() != null && config.getLocalCheckoutDir().exists();
+    }
+
+    private boolean onlyOnePluginIncluded() {
+        return config.getIncludePlugins() != null && config.getIncludePlugins().size() == 1;
     }
 
     private UpdateSite.Data extractUpdateCenterData(){

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -440,7 +440,8 @@ public class PluginCompatTester {
 
 	private boolean shouldUseLocalCheckout() {
         boolean properLocalCheckoutDir = config.getLocalCheckoutDir() != null && config.getLocalCheckoutDir().exists();
-        return properLocalCheckoutDir && config.getIncludePlugins().size() == 1;
+        boolean onlyOnePlugin = config.getIncludePlugins() != null && config.getIncludePlugins().size() == 1;
+        return properLocalCheckoutDir && onlyOnePlugin;
     }
 
     private UpdateSite.Data extractUpdateCenterData(){

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -438,7 +438,7 @@ public class PluginCompatTester {
         }
 	}
 
-	private boolean shouldUseLocalCheckout() {
+    private boolean shouldUseLocalCheckout() {
         boolean properLocalCheckoutDir = config.getLocalCheckoutDir() != null && config.getLocalCheckoutDir().exists();
         boolean onlyOnePlugin = config.getIncludePlugins() != null && config.getIncludePlugins().size() == 1;
         return properLocalCheckoutDir && onlyOnePlugin;


### PR DESCRIPTION
[JENKINS-44576](https://issues.jenkins-ci.org/browse/JENKINS-44576)

- Allow specifying the folder through a CLI option.
- Set that folder in the configuration.
- If properly set and executing only for one plugin, copy contents from the folder instead of checking out from SCM.

@reviewbybees @jglick @andresrc 