### PR TITLE
[JENKINS-44843] Parent data from POM not gathered from local checkout

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -202,7 +202,12 @@ public class PluginCompatTester {
                     TestStatus status = null;
 
                     MavenCoordinates actualCoreCoordinates = coreCoordinates;
-                    PluginRemoting remote = new PluginRemoting(plugin.url);
+                    PluginRemoting remote;
+                    if (localCheckoutProvided() && onlyOnePluginIncluded()) {
+                        remote = new PluginRemoting(new File(config.getLocalCheckoutDir(), "pom.xml"));
+                    } else {
+                        remote = new PluginRemoting(plugin.url);
+                    }
                     PomData pomData;
                     try {
                         pomData = remote.retrievePomData();

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -73,22 +73,20 @@ public class PluginRemoting {
     }
 
     private String retrievePomContentFromHpi() throws PluginSourcesUnavailableException {
-        try (InputStream pluginUrlStream = new URL(hpiRemoteUrl).openStream()) {
-            try (ZipInputStream zin = new ZipInputStream(pluginUrlStream)) {
-                ZipEntry zipEntry = zin.getNextEntry();
-                while(!zipEntry.getName().startsWith("META-INF/maven") || !zipEntry.getName().endsWith("pom.xml")){
-                    zin.closeEntry();
-                    zipEntry = zin.getNextEntry();
-                }
-
-                StringBuilder sb = new StringBuilder();
-                byte[] buf = new byte[1024];
-                int n;
-                while ((n = zin.read(buf, 0, 1024)) > -1)
-                    sb.append(new String(buf, 0, n));
-
-                return sb.toString();
+        try (InputStream pluginUrlStream = new URL(hpiRemoteUrl).openStream(); ZipInputStream zin = new ZipInputStream(pluginUrlStream)) {
+            ZipEntry zipEntry = zin.getNextEntry();
+            while(!zipEntry.getName().startsWith("META-INF/maven") || !zipEntry.getName().endsWith("pom.xml")){
+                zin.closeEntry();
+                zipEntry = zin.getNextEntry();
             }
+
+            StringBuilder sb = new StringBuilder();
+            byte[] buf = new byte[1024];
+            int n;
+            while ((n = zin.read(buf, 0, 1024)) > -1)
+                sb.append(new String(buf, 0, n));
+
+            return sb.toString();
         } catch (Exception e) {
             System.err.println("Error : " + e.getMessage());
             throw new PluginSourcesUnavailableException("Problem while retrieving pom content in hpi !", e);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -56,7 +56,6 @@ public class PluginRemoting {
     private String hpiRemoteUrl;
     private File pomFile;
 
-
     public PluginRemoting(String hpiRemoteUrl){
         this.hpiRemoteUrl = hpiRemoteUrl;
     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -65,13 +65,13 @@ public class PluginRemoting {
         this.pomFile = pomFile;
     }
 	
-	private String retrievePomContent() throws PluginSourcesUnavailableException{
-		if (hpiRemoteUrl != null) {
-		    return retrievePomContentFromHpi();
+    private String retrievePomContent() throws PluginSourcesUnavailableException{
+        if (hpiRemoteUrl != null) {
+            return retrievePomContentFromHpi();
         } else {
-		    return retrievePomContentFromXmlFile();
+            return retrievePomContentFromXmlFile();
         }
-	}
+    }
 
     private String retrievePomContentFromHpi() throws PluginSourcesUnavailableException {
         InputStream pluginUrlStream = null;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -25,6 +25,8 @@
  */
 package org.jenkins.tools.test.model;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.tools.ant.filters.StringInputStream;
 import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
 import org.w3c.dom.Document;
@@ -37,48 +39,76 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import javax.xml.xpath.XPath;
 
 /**
- * Utility class providing business for retrieving plugin scm data
+ * Utility class providing business for retrieving plugin POM data
  * @author Frederic Camblor
  */
 public class PluginRemoting {
 
 	private String hpiRemoteUrl;
+	private File pomFile;
+
 	
 	public PluginRemoting(String hpiRemoteUrl){
 		this.hpiRemoteUrl = hpiRemoteUrl;
 	}
+
+    public PluginRemoting(File pomFile){
+        this.pomFile = pomFile;
+    }
 	
 	private String retrievePomContent() throws PluginSourcesUnavailableException{
-		try {
-			URL pluginUrl = new URL(hpiRemoteUrl);
-			ZipInputStream zin = new ZipInputStream(pluginUrl.openStream());
-			ZipEntry zipEntry = zin.getNextEntry();
-			while(!zipEntry.getName().startsWith("META-INF/maven") || !zipEntry.getName().endsWith("pom.xml")){
-				zin.closeEntry();
-				zipEntry = zin.getNextEntry();
-			}
-			
-			StringBuilder sb = new StringBuilder();
-			byte[] buf = new byte[1024];
-			int n;
-			while ((n = zin.read(buf, 0, 1024)) > -1)
-                sb.append(new String(buf, 0, n));
-			
-			String content = sb.toString();
-			return content;
-			
-		}catch(Exception e){
-			System.err.println("Error : " + e.getMessage());
-			throw new PluginSourcesUnavailableException("Problem while retrieving pom content in hpi !", e);
-		}
+		if (hpiRemoteUrl != null) {
+		    return retrievePomContentFromHpi();
+        } else {
+		    return retrievePomContentFromXmlFile();
+        }
 	}
+
+    private String retrievePomContentFromHpi() throws PluginSourcesUnavailableException {
+        InputStream pluginUrlStream = null;
+        ZipInputStream zin = null;
+        try {
+            pluginUrlStream = new URL(hpiRemoteUrl).openStream();
+            zin = new ZipInputStream(pluginUrlStream);
+            ZipEntry zipEntry = zin.getNextEntry();
+            while(!zipEntry.getName().startsWith("META-INF/maven") || !zipEntry.getName().endsWith("pom.xml")){
+                zin.closeEntry();
+                zipEntry = zin.getNextEntry();
+            }
+
+            StringBuilder sb = new StringBuilder();
+            byte[] buf = new byte[1024];
+            int n;
+            while ((n = zin.read(buf, 0, 1024)) > -1)
+                sb.append(new String(buf, 0, n));
+
+            return sb.toString();
+        } catch (Exception e) {
+            System.err.println("Error : " + e.getMessage());
+            throw new PluginSourcesUnavailableException("Problem while retrieving pom content in hpi !", e);
+        } finally {
+            IOUtils.closeQuietly(pluginUrlStream);
+            IOUtils.closeQuietly(zin);
+        }
+    }
+
+    private String retrievePomContentFromXmlFile() throws PluginSourcesUnavailableException{
+        try {
+            return FileUtils.readFileToString(pomFile);
+        } catch(Exception e) {
+            System.err.println("Error : " + e.getMessage());
+            throw new PluginSourcesUnavailableException(String.format("Problem while retrieving pom content from file %s", pomFile), e);
+        }
+    }
 	
 	public PomData retrievePomData() throws PluginSourcesUnavailableException {
 		String scmConnection = null;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -53,13 +53,13 @@ import javax.xml.xpath.XPath;
  */
 public class PluginRemoting {
 
-	private String hpiRemoteUrl;
-	private File pomFile;
+    private String hpiRemoteUrl;
+    private File pomFile;
 
-	
-	public PluginRemoting(String hpiRemoteUrl){
-		this.hpiRemoteUrl = hpiRemoteUrl;
-	}
+
+    public PluginRemoting(String hpiRemoteUrl){
+        this.hpiRemoteUrl = hpiRemoteUrl;
+    }
 
     public PluginRemoting(File pomFile){
         this.pomFile = pomFile;


### PR DESCRIPTION
[JENKINS-44843](https://issues.jenkins-ci.org/browse/JENKINS-44843)

[PR #29](https://github.com/jenkinsci/plugin-compat-tester/pull/29) introduced the use of a local checkout folder when executing PCT for a certain plugin. However, POM data was not being gathered from such checkout.

@reviewbybees @jglick 