### PR TITLE
Do not override hpi-plugin.version

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -36,7 +36,6 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         if ( isCB || (pluginPOM && parentV2)) {
             List<String> argsToMod = (List<String>)info.get("args");
             argsToMod.add("-Djenkins.version=" + coreCoordinates.version);
-            argsToMod.add("-Dhpi-plugin.version=1.117"); // TODO would ideally pick up exact version from org.jenkins-ci.main:pom
             // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores
             // the plugin may be Java 6 and the dependencies bring Java 7
             argsToMod.add("-Denforcer.skip=true");


### PR DESCRIPTION
Breaks testing of any plugin using 2.30+ parent POM, since https://github.com/jenkinsci/plugin-pom/pull/65 requires `hpi-plugin.version` 2.0+. I am not sure what the purpose of this override was to begin with.

@reviewbybees