### PR TITLE
[JENKINS-44872] Handle correctly versions including '-' character

### DIFF
--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -55,7 +55,7 @@
   	<dependency>
 	    <groupId>org.jenkins-ci.main</groupId>
 		<artifactId>jenkins-core</artifactId>
-	  	<version>1.404</version>
+	  	<version>1.430</version>
   	</dependency>
   	<dependency>
       <groupId>org.apache.maven.scm</groupId>


### PR DESCRIPTION
[JENKINS-44872](https://issues.jenkins-ci.org/browse/JENKINS-44872)

By updating the Core version, a new version of VersionNumber class is used and then the versions are handled properly.

**Before**
![screen shot 2017-06-14 at 11 13 07](https://user-images.githubusercontent.com/6572596/27124830-8f4998b2-50f2-11e7-9edc-62b4f906c37e.png)

**After**
![screen shot 2017-06-14 at 11 15 03](https://user-images.githubusercontent.com/6572596/27124839-9498fdee-50f2-11e7-9e82-0189653311cd.png)

@reviewbybees @jglick 
