### PR TITLE
[JENKINS-45149] PCT should be able to exercise blueocean plugins

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -379,7 +379,7 @@ public class PluginCompatTester {
                 }
             } else {
                 // If the plugin exists in a different directory (multimodule plugins)
-                if(beforeCheckout.get("pluginDir") != null){
+                if (beforeCheckout.get("pluginDir") != null) {
                     pluginCheckoutDir = (File)beforeCheckout.get("checkoutDir");
                 }
                 System.out.println("The plugin has already been checked out, likely due to a multimodule situation. Continue.");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -22,10 +22,10 @@ import java.util.Map;
  * 
  */
 public class BlueOceanHook extends PluginCompatTesterHookBeforeCheckout {
-    private String parentUrl = "scm:git:git://github.com/jenkinsci/blueocean-plugin.git";
-    private String parentName = "blueocean";
-    private String parentProjectName = "blueocean-parent";
-    private List<String> allBundlePlugins = Arrays.asList("blueocean", "blueocean-commons", "blueocean-config", "blueocean-dashboard", "blueocean-events", "blueocean-git-pipeline", "blueocean-github-pipeline", "blueocean-i18n", "blueocean-jwt", "blueocean-personalization", "blueocean-pipeline-api-impl", "blueocean-rest", "blueocean-rest-impl", "blueocean-web");
+    private static final String parentUrl = "scm:git:git://github.com/jenkinsci/blueocean-plugin.git";
+    private static final String parentName = "blueocean";
+    private static final String parentProjectName = "blueocean-parent";
+    private static final List<String> allBundlePlugins = Arrays.asList("blueocean", "blueocean-commons", "blueocean-config", "blueocean-dashboard", "blueocean-events", "blueocean-git-pipeline", "blueocean-github-pipeline", "blueocean-i18n", "blueocean-jwt", "blueocean-personalization", "blueocean-pipeline-api-impl", "blueocean-rest", "blueocean-rest-impl", "blueocean-web");
     boolean firstRun = true;
 
     public BlueOceanHook() {}
@@ -36,11 +36,6 @@ public class BlueOceanHook extends PluginCompatTesterHookBeforeCheckout {
     public List<String> transformedPlugins() {
         return allBundlePlugins;
     }
-
-    /*
-     * No check implementation is required because transformedPlugins
-     * returns the specific list.
-     */
 
     /**
      * Perform the checkout from the common repository. Since trying to work this into the PluginCompatTester

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -1,0 +1,88 @@
+package org.jenkins.tools.test.hook;
+
+import org.jenkins.tools.test.SCMManagerFactory;
+import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTag;
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.repository.ScmRepository;
+import hudson.model.UpdateSite.Plugin;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Workaround for the blueocean plugins since they are
+ * stored in a central repository.
+ * 
+ */
+public class BlueOceanHook extends PluginCompatTesterHookBeforeCheckout {
+    private String parentUrl = "scm:git:git://github.com/jenkinsci/blueocean-plugin.git";
+    private String parentName = "blueocean";
+    private String parentProjectName = "blueocean-parent";
+    private List<String> allBundlePlugins = Arrays.asList("blueocean", "blueocean-commons", "blueocean-config", "blueocean-dashboard", "blueocean-events", "blueocean-git-pipeline", "blueocean-github-pipeline", "blueocean-i18n", "blueocean-jwt", "blueocean-personalization", "blueocean-pipeline-api-impl", "blueocean-rest", "blueocean-rest-impl", "blueocean-web");
+    boolean firstRun = true;
+
+    public BlueOceanHook() {}
+
+    /**
+     * All the plugins that are part of this repository.
+     */
+    public List<String> transformedPlugins() {
+        return allBundlePlugins;
+    }
+
+    /*
+     * No check implementation is required because transformedPlugins
+     * returns the specific list.
+     */
+
+    /**
+     * Perform the checkout from the common repository. Since trying to work this into the PluginCompatTester
+     * class pretty much requires a specific rewrite, perform the checkout here and skip the main class.
+     */
+    public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
+        PluginCompatTesterConfig config = (PluginCompatTesterConfig)moreInfo.get("config");
+        Plugin currentPlugin = (Plugin)moreInfo.get("plugin");
+        // We should not execute the hook if using localCheckoutDir
+        boolean shouldExecuteHook = config.getLocalCheckoutDir() == null || !config.getLocalCheckoutDir().exists();
+
+        if (shouldExecuteHook) {
+            System.out.println("Executing Blue Ocean Hook");
+            // Determine if we need to run the download; only run for first identified plugin in the series
+            if (firstRun) {
+                System.out.println("Preparing for Multimodule checkout");
+
+                // Checkout to the parent directory. All other processes will be on the child directory
+                File parentPath = new File(config.workDirectory.getAbsolutePath() + "/" + parentName);
+
+                System.out.println("Checking out from SCM connection URL: " + parentUrl + " (" + parentProjectName + "-" + currentPlugin.version + ")");
+                ScmManager scmManager = SCMManagerFactory.getInstance().createScmManager();
+                ScmRepository repository = scmManager.makeScmRepository(parentUrl);
+                CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(parentPath), new ScmTag(parentProjectName + "-" + currentPlugin.version));
+
+                if (!result.isSuccess()) {
+                    // Throw an exception if there are any download errors.
+                    throw new RuntimeException(result.getProviderMessage() + "||" + result.getCommandOutput());
+                }
+            }
+
+            // Checkout already happened, don't run through again
+            moreInfo.put("runCheckout", false);
+            firstRun = false;
+
+            // Change the "download"" directory; after download, it's simply used for reference
+            File childPath = new File(config.workDirectory.getAbsolutePath() + "/" + parentName + "/" + currentPlugin.name);
+            System.out.println("Child path for " + currentPlugin.getDisplayName() + " " + childPath);
+            moreInfo.put("checkoutDir", childPath);
+            moreInfo.put("pluginDir", childPath);
+        }
+
+        return moreInfo;
+    }
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -29,11 +29,12 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
                 // TODO ought to analyze the chain of parent POMs, which would lead to com.cloudbees.jenkins.plugins:jenkins-plugins in this case:
                 parent.matches("com.cloudbees.operations-center.common", "operations-center-parent") ||
                 parent.matches("com.cloudbees.operations-center.client", "operations-center-parent-client");
+        boolean isBO = parent.matches("io.jenkins.blueocean", "blueocean-parent");
         boolean pluginPOM = parent.matches("org.jenkins-ci.plugins", "plugin");
         boolean parentV2 = parent.compareVersionTo("2.0") >= 0;
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
 
-        if ( isCB || (pluginPOM && parentV2)) {
+        if (isBO || isCB || (pluginPOM && parentV2)) {
             List<String> argsToMod = (List<String>)info.get("args");
             argsToMod.add("-Djenkins.version=" + coreCoordinates.version);
             // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores


### PR DESCRIPTION
[JENKINS-45149](https://issues.jenkins-ci.org/browse/JENKINS-45149)

- Added a hook for BO plugins that gets automatically fired unless `localCheckoutDir` is specified. The hook simply solves the problem of checking out from an unknown source
- Make the PCT able to recognize BO parent so when using 'localCheckoutDir' or pom is transformed it works as expected

@reviewbybees specially @varyvol and @kwhetstone 

cc @abayer 