### PR TITLE
[JENKINS-45296] Hooks for BO and DP should use effective pom instead of current one

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -396,6 +396,14 @@ public class PluginCompatTester {
         FileUtils.forceMkdir(buildLogFile.getParentFile()); // Creating log directory
         FileUtils.fileWrite(buildLogFile.getAbsolutePath(), ""); // Creating log file
 
+        // Ran the BeforeCompileHooks
+        Map<String, Object> beforeCompile = new HashMap<String, Object>();
+        beforeCompile.put("pluginName", plugin.name);
+        beforeCompile.put("plugin", plugin);
+        beforeCompile.put("pluginDir", pluginCheckoutDir);
+        beforeCompile.put("pomData", pomData);
+        beforeCompile.put("config", config);
+        pcth.runBeforeCompilation(beforeCompile);
         boolean ranCompile = false;
         try {
             // First build against the original POM.
@@ -434,6 +442,7 @@ public class PluginCompatTester {
             forExecutionHooks.put("pomData", pomData);
             forExecutionHooks.put("pom", pom);
             forExecutionHooks.put("coreCoordinates", coreCoordinates);
+            forExecutionHooks.put("config", config);
             pcth.runBeforeExecution(forExecutionHooks);
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, ((List<String>)forExecutionHooks.get("args")).toArray(new String[args.size()]));
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -32,6 +32,8 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         PluginCompatTesterConfig config = (PluginCompatTesterConfig)moreInfo.get("config");
         UpdateSite.Plugin currentPlugin = (UpdateSite.Plugin)moreInfo.get("plugin");
+
+
         // We should not execute the hook if using localCheckoutDir
         boolean shouldExecuteHook = config.getLocalCheckoutDir() == null || !config.getLocalCheckoutDir().exists();
 
@@ -61,6 +63,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
 
             // Change the "download"" directory; after download, it's simply used for reference
             File childPath = new File(config.workDirectory.getAbsolutePath() + "/" + getParentFolder() + "/" + currentPlugin.name);
+
             System.out.println("Child path for " + currentPlugin.getDisplayName() + " " + childPath);
             moreInfo.put("checkoutDir", childPath);
             moreInfo.put("pluginDir", childPath);
@@ -88,6 +91,5 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
      * Returns the parent project name, this will be used to form the checkout tag with the format parentProjectName-version
      */
     protected abstract String getParentProjectName();
-
 
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -23,9 +23,11 @@ import java.util.Map;
  */
 public class BlueOceanHook extends AbstractMultiParentHook {
 
+    public static final List<String> BO_PLUGINS = Arrays.asList("blueocean", "blueocean-commons", "blueocean-config", "blueocean-dashboard", "blueocean-events", "blueocean-git-pipeline", "blueocean-github-pipeline", "blueocean-i18n", "blueocean-jwt", "blueocean-personalization", "blueocean-pipeline-api-impl", "blueocean-rest", "blueocean-rest-impl", "blueocean-web");
+
     @Override
     protected List<String> getBundledPlugins() {
-        return Arrays.asList("blueocean", "blueocean-commons", "blueocean-config", "blueocean-dashboard", "blueocean-events", "blueocean-git-pipeline", "blueocean-github-pipeline", "blueocean-i18n", "blueocean-jwt", "blueocean-personalization", "blueocean-pipeline-api-impl", "blueocean-rest", "blueocean-rest-impl", "blueocean-web");
+        return BO_PLUGINS;
     }
 
     @Override

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -22,9 +22,11 @@ import java.util.Map;
  */
 public class DeclarativePipelineHook extends AbstractMultiParentHook {
 
+    public static final List<String> DP_PLUGINS = Arrays.asList("pipeline-model-api", "pipeline-model-definition", "pipeline-model-extensions", "pipeline-model-json-shaded", "pipeline-stage-tags-metadata");
+
     @Override
     protected List<String> getBundledPlugins() {
-        return Arrays.asList("pipeline-model-api", "pipeline-model-definition", "pipeline-model-extensions", "pipeline-model-json-shaded", "pipeline-stage-tags-metadata");
+        return DP_PLUGINS;
     }
 
     @Override

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPomToEffectiveOne.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPomToEffectiveOne.java
@@ -1,0 +1,106 @@
+package org.jenkins.tools.test.hook;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkins.tools.test.exception.PomExecutionException;
+import org.jenkins.tools.test.maven.ExternalMavenRunner;
+import org.jenkins.tools.test.maven.InternalMavenRunner;
+import org.jenkins.tools.test.maven.MavenRunner;
+import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+public class TransformPomToEffectiveOne extends PluginCompatTesterHookBeforeCompile {
+
+    protected MavenRunner runner;
+    protected MavenRunner.Config mavenConfig;
+
+
+    public TransformPomToEffectiveOne() {
+        System.out.println("Loaded TransformPomToEffectiveOne");
+    }
+
+    /**
+     * Check if the pom should be transformed for the given plugin.
+     */
+    /*public boolean check(Map<String, Object> info) {
+        UpdateSite.Plugin currentPlugin = (UpdateSite.Plugin)info.get("plugin");
+        boolean shouldProceed = BlueOceanHook.BO_PLUGINS.contains(currentPlugin.name) || DeclarativePipelineHook.DP_PLUGINS.contains(currentPlugin.name);
+        System.out.println("TransformPomToEffective: " + shouldProceed);
+        return shouldProceed;
+    }
+    */
+    @Override
+    public List<String> transformedPlugins() {
+        List<String> transformedPlugins = new LinkedList<>();
+        transformedPlugins.addAll(BlueOceanHook.BO_PLUGINS);
+        transformedPlugins.addAll(DeclarativePipelineHook.DP_PLUGINS);
+        return transformedPlugins;
+    }
+
+    @Override
+    public void validate(Map<String, Object> toCheck) throws Exception {
+        //Empty by design
+    }
+
+    public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
+        try {
+            System.out.println("Executing tarnsformtoeffective hook");
+            PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
+
+            runner = config.getExternalMaven() == null ? new InternalMavenRunner() : new ExternalMavenRunner(config.getExternalMaven());
+            mavenConfig = getMavenConfig(config);
+
+            File pluginDir = (File) moreInfo.get("pluginDir");
+            generateEffectivePom(mavenConfig, pluginDir);
+            System.out.println("Executed transform hook");
+            return moreInfo;
+            // Exceptions get swallowed, so we print to console here and rethrow again
+        } catch (Exception e) {
+            System.out.println("Exception executing hook");
+            System.out.println(e);
+            throw e;
+        }
+    }
+
+    private MavenRunner.Config getMavenConfig(PluginCompatTesterConfig config) throws IOException {
+        MavenRunner.Config mconfig = new MavenRunner.Config();
+        mconfig.userSettingsFile = config.getM2SettingsFile();
+        // TODO REMOVE
+        mconfig.userProperties.put( "failIfNoTests", "false" );
+        mconfig.userProperties.put( "argLine", "-XX:MaxPermSize=128m" );
+        String mavenPropertiesFilePath = config.getMavenPropertiesFile();
+        if ( StringUtils.isNotBlank( mavenPropertiesFilePath )) {
+            File file = new File (mavenPropertiesFilePath);
+            if (file.exists()) {
+                FileInputStream fileInputStream = null;
+                try {
+                    fileInputStream = new FileInputStream( file );
+                    Properties properties = new Properties(  );
+                    properties.load( fileInputStream  );
+                    for (Map.Entry<Object,Object> entry : properties.entrySet()) {
+                        mconfig.userProperties.put((String) entry.getKey(), (String) entry.getValue());
+                    }
+                } finally {
+                    IOUtils.closeQuietly( fileInputStream );
+                }
+            } else {
+                System.out.println("File " + mavenPropertiesFilePath + " not exists" );
+            }
+        }
+        return mconfig;
+    }
+
+    private void generateEffectivePom(MavenRunner.Config mavenConfig, File path) throws PomExecutionException {
+        System.out.println("Generating effective pom in " + path);
+        File effectivePomLogfile = new File(path + "/effectivePomTransformationLog.log");
+        runner.run(mavenConfig, path, effectivePomLogfile, "help:effective-pom", "-Doutput=pom.xml");
+    }
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPomToEffectiveOne.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPomToEffectiveOne.java
@@ -21,22 +21,11 @@ public class TransformPomToEffectiveOne extends PluginCompatTesterHookBeforeComp
 
     protected MavenRunner runner;
     protected MavenRunner.Config mavenConfig;
-
-
+    
     public TransformPomToEffectiveOne() {
         System.out.println("Loaded TransformPomToEffectiveOne");
     }
 
-    /**
-     * Check if the pom should be transformed for the given plugin.
-     */
-    /*public boolean check(Map<String, Object> info) {
-        UpdateSite.Plugin currentPlugin = (UpdateSite.Plugin)info.get("plugin");
-        boolean shouldProceed = BlueOceanHook.BO_PLUGINS.contains(currentPlugin.name) || DeclarativePipelineHook.DP_PLUGINS.contains(currentPlugin.name);
-        System.out.println("TransformPomToEffective: " + shouldProceed);
-        return shouldProceed;
-    }
-    */
     @Override
     public List<String> transformedPlugins() {
         List<String> transformedPlugins = new LinkedList<>();


### PR DESCRIPTION
[JENKINS-45296](https://issues.jenkins-ci.org/browse/JENKINS-45296)

Downstream of #37 

Adds a hook to use effective pom instead of actual one in the case of BO and DP plugins

@reviewbybees specially @varyvol and @andresrc 