### PR TITLE
[JENKINS-45330] More flexibility on core versions (test).

### DIFF
--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -170,7 +170,8 @@ public class PluginCompatTesterTest {
 
 		fileName = "WEB-INF/lib/jenkins-core-2.7.3-milestone.jar";
 		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertFalse("Invalid match",m.matches());
+		assertTrue("No matches",m.matches());
+		assertTrue("Invalid group", m.group(1).equals("2.7.3-milestone"));
 
 		fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-milestone.jar";
 		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/plugin-compat-tester/pull/39, the test was missing.