### PR TITLE
[JENKINS-46630] Fix issues with core >= 2.64 with war-for-test

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -11,6 +11,10 @@ import java.util.Map;
 
 public class TransformPom extends PluginCompatTesterHookBeforeExecution {
     private static final String CORE_NEW_PARENT_POM = "1.646";
+    private static final String CORE_WITHOUT_WAR_FOR_TEST = "2.64";
+    private static final String PLUGINS_PARENT_POM_FOR_CORE_WITHOUT_WAR_TEST = "2.33";
+
+    private static final String NEW_PLUGINS_PARENT_VERSION_KEY = "newPluginsParentPom";
 
     public TransformPom() {
         System.out.println("Loaded TransformPom");
@@ -22,7 +26,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
     public boolean check(Map<String, Object> info) {
         boolean mustTransformPom = false;
         // TODO future versions of DEFAULT_PARENT_GROUP/ARTIFACT may be able to use this as well
-        PomData pomData = (PomData)info.get("pomData");        
+        PomData pomData = (PomData)info.get("pomData");
         MavenCoordinates parent = pomData.parent;
         MavenCoordinates coreCoordinates = (MavenCoordinates)info.get("coreCoordinates");
         boolean isDeclarativePipeline = parent.matches("org.jenkinsci.plugins", "pipeline-model-parent");
@@ -33,7 +37,9 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean isBO = parent.matches("io.jenkins.blueocean", "blueocean-parent");
         boolean pluginPOM = parent.matches("org.jenkins-ci.plugins", "plugin");
         boolean parentV2 = parent.compareVersionTo("2.0") >= 0;
+        boolean parentUnder233 = parentV2 && parent.compareVersionTo(PLUGINS_PARENT_POM_FOR_CORE_WITHOUT_WAR_TEST) < 0;
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
+        boolean coreRequiresPluginOver233 = coreCoordinates.compareVersionTo(CORE_WITHOUT_WAR_FOR_TEST) >= 0;
 
         if (isDeclarativePipeline || isBO || isCB || (pluginPOM && parentV2)) {
             List<String> argsToMod = (List<String>)info.get("args");
@@ -42,6 +48,11 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
             // the plugin may be Java 6 and the dependencies bring Java 7
             argsToMod.add("-Denforcer.skip=true");
             info.put("args", argsToMod);
+
+            if (coreRequiresPluginOver233 && pluginPOM && parentUnder233) {
+                info.put(NEW_PLUGINS_PARENT_VERSION_KEY, PLUGINS_PARENT_POM_FOR_CORE_WITHOUT_WAR_TEST);
+                mustTransformPom = true;
+            }
         } else if (coreRequiresNewParentPOM && pluginPOM && !parentV2) {
             throw new RuntimeException("New parent POM required for core >= 1.646");
         } else {
@@ -53,6 +64,12 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
 
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         MavenCoordinates coreCoordinates = (MavenCoordinates)moreInfo.get("coreCoordinates");
+
+        final String pluginsParentVersion = (String) moreInfo.get(NEW_PLUGINS_PARENT_VERSION_KEY);
+        if (pluginsParentVersion != null) {
+            coreCoordinates = new MavenCoordinates(coreCoordinates.groupId, coreCoordinates.artifactId, pluginsParentVersion);
+        }
+
         ((MavenPom)moreInfo.get("pom")).transformPom(coreCoordinates);
         return moreInfo;
     }


### PR DESCRIPTION
[JENKINS-46630](https://issues.jenkins-ci.org/browse/JENKINS-46630)

Check if:
- Jenkins version is >= 2.64.
- Plugin uses new parent POM.

If both conditions hold, then make sure the parent POM is at least 2.33.

**Before**
![screen shot 2017-09-04 at 15 32 08](https://user-images.githubusercontent.com/6572596/30029130-36796d3a-9188-11e7-8763-e0b7d12416e5.png)

**After**
![screen shot 2017-09-04 at 15 36 07](https://user-images.githubusercontent.com/6572596/30029138-3fbc4ca0-9188-11e7-9ba5-fc4fc62f093a.png)

@reviewbybees @jglick 