### PR TITLE
[JENKINS-47478] Forcing the same jenkins-core version for all modules

### DIFF
--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -82,9 +82,8 @@
       <version>0.9.10</version>
     </dependency>
     <dependency>
-	    <groupId>org.jenkins-ci.main</groupId>
+	  <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
-	  	<version>1.404</version>
   	</dependency>
   </dependencies>
 </project>

--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -82,7 +82,7 @@
       <version>0.9.10</version>
     </dependency>
     <dependency>
-	  <groupId>org.jenkins-ci.main</groupId>
+      <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
   	</dependency>
   </dependencies>

--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -55,7 +55,6 @@
   	<dependency>
 	    <groupId>org.jenkins-ci.main</groupId>
 		<artifactId>jenkins-core</artifactId>
-	  	<version>1.430</version>
   	</dependency>
   	<dependency>
       <groupId>org.apache.maven.scm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-core</artifactId>
+        <version>1.430</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>1.6.1</version>


### PR DESCRIPTION
[JENKINS-47478](https://issues.jenkins-ci.org/browse/JENKINS-47478)

Modules `plugins-compat-tester` and `plungins-compact-tester-model` have defined different version for their jenkins-core dependency.

**Features:**
- Adds a dependency management in parent POM to force same jenkins-core version in all modules.
- Deletes the specification of jenkins-core version in each module.

@reviewbybees 