### PR TITLE
Revert "[JENKINS-47393] PCT against 2.86+ needs to know about command-launcher split"

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -674,7 +674,6 @@ public class PluginCompatTester {
                 "matrix-project:1.561.*:1.0",
                 "junit:1.577.*:1.0",
                 "bouncycastle-api:2.16.*:2.16.0",
-                "command-launcher:2.86.*:1.0",
             };
             // Synchronize with ClassicPluginStrategy.BREAK_CYCLES:
             String[] exceptions = {
@@ -682,8 +681,6 @@ public class PluginCompatTester {
                 "script-security/windows-slaves",
                 "script-security/antisamy-markup-formatter",
                 "script-security/matrix-project",
-                "script-security/bouncycastle-api",
-                "script-security/command-launcher",
                 "credentials/matrix-auth",
                 "credentials/windows-slaves"
             };


### PR DESCRIPTION
Reverts jenkinsci/plugin-compat-tester#46

Generating issues with injected tests.

FYI @jglick 