### PR TITLE
Fix split calculations

### DIFF
--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -43,6 +43,11 @@
   
   <dependencies>
     <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+      <version>1.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.tests</groupId>
       <artifactId>plugins-compat-tester-model</artifactId>
       <version>0.0.3-SNAPSHOT</version>


### PR DESCRIPTION
Restores #46 after #47 backed it out, by fixing the underlying bug noted in [JENKINS-47634](https://issues.jenkins-ci.org/browse/JENKINS-47634). Next step would be to load the metadata from core going forward.

Tested manually using:

```bash
mvn -DskipTests -am -pl plugins-compat-tester-cli clean install && mvn -f plugins-compat-tester-cli exec:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkins.tools.test.PluginCompatTesterCli -includePlugins workflow-step-api -workDirectory /tmp/plugin-compat-tester -reportFile /tmp/plugin-compat-tester.xml -skipTestCache true -mvn …/bin/mvn' && mvn -f plugins-compat-tester-cli exec:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkins.tools.test.PluginCompatTesterCli -includePlugins workflow-step-api -war …/jenkins-enterprise-war-2.73.2.1.war -workDirectory /tmp/plugin-compat-tester -reportFile /tmp/plugin-compat-tester.xml -skipTestCache true -mvn …/bin/mvn'
```

@reviewbybees