### PR TITLE
[JENKINS-47634] Metadata fix refinement

### DIFF
--- a/plugins-compat-tester-cli/pom.xml
+++ b/plugins-compat-tester-cli/pom.xml
@@ -17,15 +17,6 @@
 	  <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.3.2</version>
-            <configuration>
-              <source>1.7</source>
-              <target>1.7</target>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <version>2.3</version>
             <executions>

--- a/plugins-compat-tester-gae-client/pom.xml
+++ b/plugins-compat-tester-gae-client/pom.xml
@@ -28,17 +28,6 @@
        </plugin>
      </plugins>
    </pluginManagement>
-	 <plugins>
-    <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.3.2</version>
-    <configuration>
-      <source>1.5</source>
-      <target>1.5</target>
-    </configuration>
-    </plugin>
-	 </plugins>
   </build>
   
   <dependencies>

--- a/plugins-compat-tester-gae/pom.xml
+++ b/plugins-compat-tester-gae/pom.xml
@@ -28,17 +28,6 @@
        </plugin>
      </plugins>
    </pluginManagement>
-	 <plugins>
-    <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.3.2</version>
-    <configuration>
-      <source>1.5</source>
-      <target>1.5</target>
-    </configuration>
-    </plugin>
-	 </plugins>
   </build>
   
   <dependencies>

--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -27,17 +27,6 @@
        </plugin>
      </plugins>
    </pluginManagement>
-	 <plugins>
-    <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.3.2</version>
-    <configuration>
-      <source>1.8</source>
-      <target>1.8</target>
-    </configuration>
-    </plugin>
-	 </plugins>
   </build>
 
   <dependencies>

--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -28,17 +28,6 @@
        </plugin>
      </plugins>
    </pluginManagement>
-	 <plugins>
-    <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.3.2</version>
-    <configuration>
-      <source>1.7</source>
-      <target>1.7</target>
-    </configuration>
-    </plugin>
-	 </plugins>
   </build>
   
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
#49 was merged prematurely—https://github.com/jenkinsci/jenkins/pull/3110 was still under review.

Manual testing scheme: amend upstream core patch with temporary

```diff
diff --git a/war/pom.xml b/war/pom.xml
index 3db732a6a7..0912df3d2c 100644
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -255,6 +255,12 @@ THE SOFTWARE.
                   <outputDirectory>${project.build.directory}/${project.build.finalName}</outputDirectory>
                   <destFileName>winstone.jar</destFileName>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                  <artifactId>workflow-step-api</artifactId>
+                  <version>2.13</version>
+                  <type>hpi</type>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/plugins</outputDirectory>
               <stripVersion>true</stripVersion>
```

then

```bash
mvn -f ../jenkins -pl core,war -DskipTests install
mvn -am -pl plugins-compat-tester-cli -DskipTests install
mvn -f plugins-compat-tester-cli org.codehaus.mojo:exec-maven-plugin:1.2.1:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkins.tools.test.PluginCompatTesterCli -includePlugins workflow-step-api -workDirectory /tmp/plugin-compat-tester -reportFile /tmp/plugin-compat-tester.xml -skipTestCache true -mvn …/bin/mvn'
mvn -f plugins-compat-tester-cli org.codehaus.mojo:exec-maven-plugin:1.2.1:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkins.tools.test.PluginCompatTesterCli -includePlugins workflow-step-api -workDirectory /tmp/plugin-compat-tester -reportFile /tmp/plugin-compat-tester.xml -skipTestCache true -mvn …/bin/mvn -war …/jenkins/war/target/jenkins.war'
mvn -f plugins-compat-tester-cli org.codehaus.mojo:exec-maven-plugin:1.2.1:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkins.tools.test.PluginCompatTesterCli -includePlugins workflow-step-api -workDirectory /tmp/plugin-compat-tester -reportFile /tmp/plugin-compat-tester.xml -skipTestCache true -mvn …/bin/mvn -war …/.m2/repository/com/cloudbees/jenkins/main/jenkins-enterprise-war/2.73.2.1/jenkins-enterprise-war-2.73.2.1.war'
```

The first run picks up core `2.86` and `workflow-step-api 2.13` from the update center. Without `-war`, there is no source of metadata, so it uses the built-in list, and adds `command-launcher 1.1` as a dependency (the current version on the UC).

The second run picks up `2.87-SNAPSHOT` and `2.13`. Successfully scans for metadata, and adds the detached `command-launcher 1.0`.

The third run picks up `2.73.2-cb-1` and `2.11`. Looks for metadata but does not find it, so uses built-in list, and does not add `command-launcher`.

@reviewbybees