### PR TITLE
Removing no needed SCM URL transformations

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -192,12 +192,6 @@ public class PluginRemoting {
         }
 
         oldUrl = transformedConnectionUrl;
-        transformedConnectionUrl = transformedConnectionUrl.replaceAll("((ssh)|(http(s)?))://github\\.com", "git://github.com");
-        if(!oldUrl.equals(transformedConnectionUrl)){
-            pomData.getWarningMessages().add("project.scm.connectionUrl should be accessed in read-only mode (with git:// protocol)");
-        }
-
-        oldUrl = transformedConnectionUrl;
         transformedConnectionUrl = transformedConnectionUrl.replaceAll("://github\\.com/hudson/", "://github.com/jenkinsci/");
         if(!oldUrl.equals(transformedConnectionUrl)){
             pomData.getWarningMessages().add("project.scm.connectionUrl should not reference hudson project anymore (no plugin repository there))");
@@ -211,12 +205,6 @@ public class PluginRemoting {
         }
         if(!oldUrl.equals(transformedConnectionUrl)){
             pomData.getWarningMessages().add("project.scm.connectionUrl should be ending with '-plugin.git'");
-        }
-
-        oldUrl = transformedConnectionUrl;
-        transformedConnectionUrl = transformedConnectionUrl.replace("git.cloudbees.com", "github.com");
-        if (!oldUrl.equals(transformedConnectionUrl)) {
-            pomData.getWarningMessages().add("project.scm.connectionUrl was using git.cloudbees.com; moved to GitHub");
         }
 
         pomData.setConnectionUrl(transformedConnectionUrl);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
@@ -109,30 +109,6 @@ public class ScmConnectionSpecialCasesTest {
     }
 
     @Test
-    public void shouldGithubBeAccessedWithGitProtocol() throws Throwable{
-        runComputeScmConnectionAgainst(
-                "scm:git:ssh://github.com/jenkinsci/artifactory-plugin.git", // ssh protocol requiring ssh host key
-                "",
-                "scm:git:git://github.com/jenkinsci/artifactory-plugin.git"
-        );
-        runComputeScmConnectionAgainst(
-                "scm:git:http://github.com/jenkinsci/artifactory-plugin.git", // ssh protocol requiring ssh host key
-                "",
-                "scm:git:git://github.com/jenkinsci/artifactory-plugin.git"
-        );
-        runComputeScmConnectionAgainst(
-                "scm:git:https://github.com/jenkinsci/cifs-plugin.git", // ssh protocol requiring ssh host key
-                "",
-                "scm:git:git://github.com/jenkinsci/cifs-plugin.git"
-        );
-        runComputeScmConnectionAgainst(
-                "scm:git:git://git@github.com:jenkinsci/dockerhub-notification-plugin.git", // ssh url with git protocol
-                "",
-                "scm:git:git://github.com/jenkinsci/dockerhub-notification-plugin.git"
-        );
-    }
-
-    @Test
     public void shouldGitHudsonRepoBeMigratedToJenkinsCI() throws Throwable{
         runComputeScmConnectionAgainst(
                 "scm:git:git://github.com/hudson/hudson-clearcase-plugin.git", // hudson repository
@@ -147,7 +123,7 @@ public class ScmConnectionSpecialCasesTest {
         runComputeScmConnectionAgainst(
                 "\n   scm:git:https://github.com/jenkinsci/cifs-plugin.git  \n   ", // ssh protocol requiring ssh host key
                 "",
-                "scm:git:git://github.com/jenkinsci/cifs-plugin.git"
+                "scm:git:https://github.com/jenkinsci/cifs-plugin.git"
         );
     }
 


### PR DESCRIPTION
PCT is transforming these URLs `scm:git:https://github.com/` to `scm:git:git://github.com/` and this is wrong. And `git clone git://github.com/` will fail.

@reviewbybees, especially @andresrc, @varyvol 