### PR TITLE
[JENKINS-48208] BO Hook prevents splits to be properly applied

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
@@ -3,15 +3,12 @@ package org.jenkins.tools.test.hook;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.jenkins.tools.test.PluginCompatTester;
 import org.jenkins.tools.test.exception.PomExecutionException;
 import org.jenkins.tools.test.maven.ExternalMavenRunner;
 import org.jenkins.tools.test.maven.InternalMavenRunner;
 import org.jenkins.tools.test.maven.MavenRunner;
 import org.jenkins.tools.test.model.MavenCoordinates;
-import org.jenkins.tools.test.model.MavenPom;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
-import org.jenkins.tools.test.model.hook.PluginCompatTesterHook;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 
 import java.io.File;
@@ -62,14 +59,6 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
                 compile(mavenConfig, pluginDir);
                 moreInfo.put(OVERRIDE_DEFAULT_COMPILE, true);
             }
-            // Apply splits before generating effective pom as the effective pom already modifes the core version resulting in potential problems or splits not properly added
-            /*PluginCompatTester tester = new PluginCompatTester(config);
-            MavenPom pom = new MavenPom(pluginDir);
-            // As we are going to modify the core set in the pom we store the original for further processing by the PCT
-            moreInfo.put(PluginCompatTesterHook.ORIGINAL_CORE, getCoreVersion());
-
-            // Now we can generate effective pom
-            generateEffectivePom(mavenConfig, pluginDir, core);*/
 
             System.out.println("Executed BO and DP compile hook");
             return moreInfo;
@@ -107,12 +96,6 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
             }
         }
         return mconfig;
-    }
-
-    private void generateEffectivePom(MavenRunner.Config mavenConfig, File path, MavenCoordinates core) throws PomExecutionException {
-        System.out.println("Generating effective pom in " + path);
-        File effectivePomLogfile = new File(path + "/effectivePomTransformationLog.log");
-        runner.run(mavenConfig, path, effectivePomLogfile, "help:effective-pom", "-Doutput=pom.xml", "-Djenkins.version=" + core.version);
     }
 
     private void compile(MavenRunner.Config mavenConfig, File path) throws PomExecutionException, IOException {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
@@ -25,7 +25,7 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
     protected MavenRunner.Config mavenConfig;
     
     public BOAndDPCompileHook() {
-        System.out.println("Loaded Blue Ocean and Declarative Pipelines compile hook");
+        System.out.println("Loaded Blue Ocean and Declarative Pipeline compile hook");
     }
 
     @Override
@@ -43,7 +43,7 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
 
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         try {
-            System.out.println("Executing Blue Ocean and Declarative Pipelines compile hook");
+            System.out.println("Executing Blue Ocean and Declarative Pipeline compile hook");
             PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
             MavenCoordinates core = (MavenCoordinates) moreInfo.get("core");
 
@@ -60,7 +60,7 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
                 moreInfo.put(OVERRIDE_DEFAULT_COMPILE, true);
             }
 
-            System.out.println("Executed BO and DP compile hook");
+            System.out.println("Executed Blue Ocean and Declarative Pipeline compile hook");
             return moreInfo;
             // Exceptions get swallowed, so we print to console here and rethrow again
         } catch (Exception e) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
@@ -3,12 +3,15 @@ package org.jenkins.tools.test.hook;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jenkins.tools.test.PluginCompatTester;
 import org.jenkins.tools.test.exception.PomExecutionException;
 import org.jenkins.tools.test.maven.ExternalMavenRunner;
 import org.jenkins.tools.test.maven.InternalMavenRunner;
 import org.jenkins.tools.test.maven.MavenRunner;
 import org.jenkins.tools.test.model.MavenCoordinates;
+import org.jenkins.tools.test.model.MavenPom;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHook;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 
 import java.io.File;
@@ -25,7 +28,7 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
     protected MavenRunner.Config mavenConfig;
     
     public BOAndDPCompileHook() {
-        System.out.println("Loaded TransformPomToEffectiveOne");
+        System.out.println("Loaded BO and DP compile hook");
     }
 
     @Override
@@ -59,9 +62,14 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
                 compile(mavenConfig, pluginDir);
                 moreInfo.put(OVERRIDE_DEFAULT_COMPILE, true);
             }
+            // Apply splits before generating effective pom as the effective pom already modifes the core version resulting in potential problems or splits not properly added
+            /*PluginCompatTester tester = new PluginCompatTester(config);
+            MavenPom pom = new MavenPom(pluginDir);
+            // As we are going to modify the core set in the pom we store the original for further processing by the PCT
+            moreInfo.put(PluginCompatTesterHook.ORIGINAL_CORE, getCoreVersion());
 
             // Now we can generate effective pom
-            generateEffectivePom(mavenConfig, pluginDir, core);
+            generateEffectivePom(mavenConfig, pluginDir, core);*/
 
             System.out.println("Executed BO and DP compile hook");
             return moreInfo;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
@@ -25,7 +25,7 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
     protected MavenRunner.Config mavenConfig;
     
     public BOAndDPCompileHook() {
-        System.out.println("Loaded BO and DP compile hook");
+        System.out.println("Loaded Blue Ocean and Declarative Pipelines compile hook");
     }
 
     @Override
@@ -43,7 +43,7 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
 
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         try {
-            System.out.println("Executing BO and DO compile hook");
+            System.out.println("Executing Blue Ocean and Declarative Pipelines compile hook");
             PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
             MavenCoordinates core = (MavenCoordinates) moreInfo.get("core");
 


### PR DESCRIPTION
[JENKINS-48208](https://issues.jenkins-ci.org/browse/JENKINS-48208)

I have launched the BO PCT (master) with this changes and there is only one failing test which is unrelated

```
io.jenkins.blueocean.service.embedded.rest.UserImplPermissionTest.useTestAgainstJenkinsRoot

Error Message

User permission does not match expected:<false> but was:<true>
Stacktrace

java.lang.AssertionError: User permission does not match expected:<false> but was:<true>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at io.jenkins.blueocean.service.embedded.rest.UserImplPermissionTest.checkPermissions(UserImplPermissionTest.java:149)
	at io.jenkins.blueocean.service.embedded.rest.UserImplPermissionTest.useTestAgainstJenkinsRoot(UserImplPermissionTest.java:144)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.internal.runners.TestMethod.invoke(TestMethod.java:68)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$PowerMockJUnit44MethodRunner.runTestMethod(PowerMockJUnit44RunnerDelegateImpl.java:316)
	at org.junit.internal.runners.MethodRoadie$2.run(MethodRoadie.java:89)
	at org.junit.internal.runners.MethodRoadie.runBeforesThenTestThenAfters(MethodRoadie.java:97)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$PowerMockJUnit44MethodRunner.executeTest(PowerMockJUnit44RunnerDelegateImpl.java:300)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.executeTestInSuper(PowerMockJUnit47RunnerDelegateImpl.java:131)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.access$100(PowerMockJUnit47RunnerDelegateImpl.java:59)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner$TestExecutorStatement.evaluate(PowerMockJUnit47RunnerDelegateImpl.java:147)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.evaluateStatement(PowerMockJUnit47RunnerDelegateImpl.java:107)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.executeTest(PowerMockJUnit47RunnerDelegateImpl.java:82)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$PowerMockJUnit44MethodRunner.runBeforesThenTestThenAfters(PowerMockJUnit44RunnerDelegateImpl.java:288)
	at org.junit.internal.runners.MethodRoadie.runTest(MethodRoadie.java:87)
	at org.junit.internal.runners.MethodRoadie.run(MethodRoadie.java:50)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl.invokeTestMethod(PowerMockJUnit44RunnerDelegateImpl.java:208)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl.runMethods(PowerMockJUnit44RunnerDelegateImpl.java:147)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$1.run(PowerMockJUnit44RunnerDelegateImpl.java:121)
	at org.junit.internal.runners.ClassRoadie.runUnprotected(ClassRoadie.java:34)
	at org.junit.internal.runners.ClassRoadie.runProtected(ClassRoadie.java:44)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl.run(PowerMockJUnit44RunnerDelegateImpl.java:123)
	at org.powermock.modules.junit4.common.internal.impl.JUnit4TestSuiteChunkerImpl.run(JUnit4TestSuiteChunkerImpl.java:121)
	at org.powermock.modules.junit4.common.internal.impl.AbstractCommonPowerMockRunner.run(AbstractCommonPowerMockRunner.java:53)
	at org.powermock.modules.junit4.PowerMockRunner.run(PowerMockRunner.java:59)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:367)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:274)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:161)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)

```

@reviewbybees @andresrc @vivek

 