### PR TITLE
[JENKINS-48723] - Use standard Jenkins Parent POM and cleanup/update dependencies

### DIFF
--- a/plugins-compat-tester-cli/pom.xml
+++ b/plugins-compat-tester-cli/pom.xml
@@ -7,11 +7,10 @@
       <version>0.0.3-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.jenkins-ci.tests</groupId>
   <artifactId>plugins-compat-tester-cli</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <name>Plugins compatibility tester CLI</name>
-  <description>Hudson/Jenkins Plugin compatibility tester against latest released version</description>
+  <description>Jenkins Plugin Compatibility Tester (PCT) against latest released version</description>
   
   <build>
 	  <plugins>
@@ -79,6 +78,11 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-access</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/plugins-compat-tester-gae-client/pom.xml
+++ b/plugins-compat-tester-gae-client/pom.xml
@@ -7,28 +7,11 @@
       <version>0.0.3-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.jenkins-ci.tests</groupId>
   <artifactId>plugins-compat-tester-gae-client</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Plugins compatibility tester for Google App Engine client side API</name>
-  <description>Hudson/Jenkins Plugin compatibility tester against latest released version - GAE app</description>
-  
-  <properties>
-      <powermock.version>1.4.8</powermock.version>
-  </properties>
-  
-  <build>
-   <pluginManagement>
-     <plugins>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-surefire-plugin</artifactId>
-         <version>2.8.1</version>
-       </plugin>
-     </plugins>
-   </pluginManagement>
-  </build>
+  <description>Jenkins Plugin Compatibility Tester (PCT) against latest released version - GAE app client</description>
   
   <dependencies>
     <!-- Google App Engine API -->
@@ -40,30 +23,26 @@
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.1.2</version>
+        <version>4.5.3</version>
     </dependency>
     <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>10.0.1</version>
     </dependency>
 
   	<dependency>
 	    <groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-	  	<version>4.8.2</version>
+		  <artifactId>junit</artifactId>
 	  	<scope>test</scope>
   	</dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
   </dependencies>

--- a/plugins-compat-tester-gae/pom.xml
+++ b/plugins-compat-tester-gae/pom.xml
@@ -7,28 +7,11 @@
       <version>0.0.3-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.jenkins-ci.tests</groupId>
   <artifactId>plugins-compat-tester-gae</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>Plugins compatibility tester for Google App Engine</name>
-  <description>Hudson/Jenkins Plugin compatibility tester against latest released version - GAE app</description>
-  
-  <properties>
-      <powermock.version>1.4.8</powermock.version>
-  </properties>
-  
-  <build>
-   <pluginManagement>
-     <plugins>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-surefire-plugin</artifactId>
-         <version>2.8.1</version>
-       </plugin>
-     </plugins>
-   </pluginManagement>
-  </build>
+  <description>Jenkins Plugin Compatibility Tester (PCT) against latest released version - GAE app</description>
   
   <dependencies>
     <!-- Google App Engine API -->
@@ -39,8 +22,7 @@
     </dependency>
     <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.5</version>
+        <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
     <dependency>
@@ -51,20 +33,17 @@
 
   	<dependency>
 	    <groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-	  	<version>4.8.2</version>
+		  <artifactId>junit</artifactId>
 	  	<scope>test</scope>
   	</dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
   </dependencies>

--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -7,61 +7,30 @@
       <version>0.0.3-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.jenkins-ci.tests</groupId>
   <artifactId>plugins-compat-tester-model</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <name>Plugins compatibility tester model layer</name>
-  <description>Hudson/Jenkins Plugin compatibility model layer</description>
-
-  <properties>
-    <powermock.version>1.4.8</powermock.version>
-  </properties>
-
-  <build>
-   <pluginManagement>
-     <plugins>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-surefire-plugin</artifactId>
-         <version>2.8.1</version>
-       </plugin>
-     </plugins>
-   </pluginManagement>
-  </build>
+  <description>Jenkins Plugin Compatibility Tester (PCT) model layer</description>
 
   <dependencies>
       <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
+        <groupId>org.jvnet.hudson</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.3.1</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.4</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>1.4</version>
       </dependency>
 
   	<dependency>
 	    <groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-	  	<version>4.8.2</version>
+		  <artifactId>junit</artifactId>
 	  	<scope>test</scope>
   	</dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
 

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
@@ -26,6 +26,8 @@
 package org.jenkins.tools.test.model;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.Xpp3DomDriver;
+import hudson.util.XStream2;
 
 import java.io.*;
 import java.util.*;
@@ -155,8 +157,8 @@ public class PluginCompatReport {
         return report;
     }
 
-    private static XStream createXStream(){
-        XStream xstream = new XStream();
+    private static XStream2 createXStream(){
+        XStream2 xstream = new XStream2(new Xpp3DomDriver());
         xstream.setMode(XStream.NO_REFERENCES);
         xstream.alias("pluginInfos", PluginInfos.class);
         xstream.alias("coord", MavenCoordinates.class);

--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -7,29 +7,15 @@
       <version>0.0.3-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.jenkins-ci.tests</groupId>
   <artifactId>plugins-compat-tester</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <name>Plugins compatibility tester</name>
-  <description>Hudson/Jenkins Plugin compatibility tester against latest released version</description>
+  <description>Jenkins Plugin Compatibility Tester (PCT) against latest released version</description>
   
   <properties>
   	<maven.scm.providers.version>1.5</maven.scm.providers.version>
-    <powermock.version>1.4.8</powermock.version>
   </properties>
-  
-  <build>
-   <pluginManagement>
-     <plugins>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-surefire-plugin</artifactId>
-         <version>2.8.1</version>
-       </plugin>
-     </plugins>
-   </pluginManagement>
-  </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -48,8 +34,44 @@
     </dependency>
   	<dependency>
 	    <groupId>org.jenkins-ci.main</groupId>
-		<artifactId>jenkins-core</artifactId>
+		  <artifactId>jenkins-core</artifactId>
   	</dependency>
+
+    <!-- Upper bounds between core and Maven Embedder -->
+    <!-- TODO: All of that stuff happens due to Maven detaching. Would it be sane to include Maven Plugin 3.0 as a JAR instead? -->
+    <dependency>
+      <groupId>antlr</groupId>
+      <artifactId>antlr</artifactId>
+      <version>2.7.7</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.9.2</version>
+    </dependency>
+
+    <!-- Upper bounds in Embedder -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.24</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-classworlds</artifactId>
+      <version>2.5.2</version>
+    </dependency>
+
   	<dependency>
       <groupId>org.apache.maven.scm</groupId>
       <artifactId>maven-scm-manager-plexus</artifactId>
@@ -64,43 +86,7 @@
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>lib-jenkins-maven-embedder</artifactId>
-      <version>3.9</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>wagon-provider-api</artifactId>
-          <groupId>org.apache.maven.wagon</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
-      <version>3.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>3.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>3.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>3.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-embedder</artifactId>
-      <version>3.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http</artifactId>
-      <version>2.2</version>
+      <version>3.12.1</version>
     </dependency>
 
     <!-- scm providers declaration -->
@@ -177,9 +163,8 @@
     <!-- end providers declaration -->
 
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
+      <groupId>org.jvnet.hudson</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.3.1</version>
     </dependency>
 
     <dependency>
@@ -219,26 +204,23 @@
     
   	<dependency>
 	    <groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-	  	<version>4.8.2</version>
+		  <artifactId>junit</artifactId>
 	  	<scope>test</scope>
   	</dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.5</version>
-    </dependency>
   </dependencies>
 </project>

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -528,7 +528,9 @@ public class PluginCompatTester {
                     if (top.has("core")) {
                         throw new IOException(">1 jenkins-core.jar in " + war);
                     }
-                    top.put("core", new JSONObject().accumulate("name", "core").accumulate("version", m.group(1)).accumulate("url", ""));
+                    // http://foobar is used to workaround the check in https://github.com/jenkinsci/jenkins/commit/f8daafd0327081186c06555f225e84c420261b4c
+                    // We do not really care about the value
+                    top.put("core", new JSONObject().accumulate("name", "core").accumulate("version", m.group(1)).accumulate("url", "https://foobar"));
                 }
                 m = Pattern.compile("WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi").matcher(name);
                 if (m.matches()) {

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -75,6 +75,7 @@ public class PluginCompatTesterTest {
         config.setCacheThresholStatus(TestStatus.TEST_FAILURES);
         config.setTestCacheTimeout(345600000);
         config.setParentVersion("1.410");
+        config.setGenerateHtmlReport(true);
 
         PluginCompatTester tester = new PluginCompatTester(config);
 		tester.testPlugins();

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci</groupId>
+    <artifactId>jenkins</artifactId>
+    <version>1.39</version>
+  </parent>
+
   <groupId>org.jenkins-ci.tests</groupId>
   <artifactId>plugins-compat-tester-aggregator</artifactId>
   <version>0.0.3-SNAPSHOT</version>
   <name>Plugins compatibility tester Aggregator</name>
-  <description>Hudson/Jenkins Plugin compatibility tester against latest released version</description>
+  <description>Jenkins Plugin Compatibility Tester (PCT) against latest released version</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Plugin+Compatibility+Tester</url>
   <packaging>pom</packaging>
 
@@ -17,6 +24,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <logbackVersion>0.9.28</logbackVersion>
+    <java.level>8</java.level>
+
+    <!-- Components -->
+
+    <!-- Test libs -->
+    <powermock.version>1.4.8</powermock.version>
   </properties>
 
   <modules>
@@ -33,13 +46,31 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-core</artifactId>
-        <version>1.430</version>
+        <version>1.625.3</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>15.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jvnet.hudson</groupId>
+        <artifactId>xstream</artifactId>
+        <version>1.4.7-jenkins-1</version>
       </dependency>
 
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.25</version>
       </dependency>
 
       <dependency>
@@ -58,6 +89,24 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-access</artifactId>
         <version>${logbackVersion}</version>
+      </dependency>
+
+      <!-- Test libs -->
+      <!-- TODO: make them a test dependency in Parent POM? -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${powermock.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -93,14 +142,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.0</version>
         <executions>
           <execution>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>validate</phase>
-            <id>ensure-no-plexus-container</id>
+            <id>display-info</id>
             <configuration>
               <rules>
                 <bannedDependencies>
@@ -112,18 +156,9 @@
                   </message>
                 </bannedDependencies>
               </rules>
-              <fail>true</fail>
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
This change does some facelifting job and adjusts dependencies. It also bumps XStream to the Jenkins' XStream fork so that we are aligned with the core versions.

https://issues.jenkins-ci.org/browse/JENKINS-48723

@reviewbybees @raul-arabaolaza 