### PR TITLE
[JENKINS-48724] - PCT should allow running PCT for a plugin with custom WAR.

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -70,14 +70,16 @@ public class PluginCompatTesterCli {
             if (updateCenterUrl != null || parentCoordinates != null) {
                 throw new IllegalStateException("Cannot specify -war together with either -updateCenterUrl or -parentCoordinates");
             }
-        } else {
-            if (updateCenterUrl == null) {
-                updateCenterUrl = PluginCompatTesterConfig.DEFAULT_UPDATE_CENTER_URL;
-            }
-            if (parentCoordinates == null) {
-                parentCoordinates = PluginCompatTesterConfig.DEFAULT_PARENT_GAV;
-            }
         }
+
+        // We may need this data even in the -war mode
+        if (updateCenterUrl == null) {
+            updateCenterUrl = PluginCompatTesterConfig.DEFAULT_UPDATE_CENTER_URL;
+        }
+        if (parentCoordinates == null) {
+            parentCoordinates = PluginCompatTesterConfig.DEFAULT_PARENT_GAV;
+        }
+
         PluginCompatTesterConfig config = new PluginCompatTesterConfig(updateCenterUrl, parentCoordinates,
                 options.getWorkDirectory(), reportFile, options.getM2SettingsFile());
         config.setWar(war);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -173,8 +173,33 @@ public class PluginCompatTester {
             dataImporter = new DataImporter(config.getGaeBaseUrl(), config.getGaeSecurityToken());
         }
 
+        // Determine the plugin data
         HashMap<String,String> pluginGroupIds = new HashMap<String, String>();  // Used to track real plugin groupIds from WARs
         UpdateSite.Data data = config.getWar() == null ? extractUpdateCenterData() : scanWAR(config.getWar(), pluginGroupIds);
+        final Map<String, Plugin> pluginsToCheck;
+        final List<String> pluginsToInclude = config.getIncludePlugins();
+        if (data.plugins.isEmpty() && pluginsToInclude != null && !pluginsToInclude.isEmpty()) {
+            // Update Center returns empty info OR the "-war" option is specified for WAR without bundled plugins
+            // TODO: Ideally we should do this tweak in any case, so that we can test custom plugins with Jenkins cores before unbundling
+            // But it will require us to always poll the update center...
+            System.out.println("WAR file does not contain plugin info, will try to extract it from UC for included plugins");
+            pluginsToCheck = new HashMap<>(pluginsToInclude.size());
+            UpdateSite.Data ucData = extractUpdateCenterData();
+            for (String plugin : pluginsToInclude) {
+                UpdateSite.Plugin pluginData = ucData.plugins.get(plugin);
+                if (pluginData != null) {
+                    System.out.println("Adding " + plugin + " to the test scope");
+                    pluginsToCheck.put(plugin, pluginData);
+                }
+            }
+        } else {
+            pluginsToCheck = data.plugins;
+        }
+
+        if (pluginsToCheck.isEmpty()) {
+            throw new IOException("List of plugins to check is empty, it is not possible to run PCT");
+        }
+
         PluginCompatReport report = PluginCompatReport.fromXml(config.reportFile);
 
         SortedSet<MavenCoordinates> testedCores = config.getWar() == null ? generateCoreCoordinatesToTest(data, report) : coreVersionFromWAR(data);
@@ -207,7 +232,7 @@ public class PluginCompatTester {
 		SCMManagerFactory.getInstance().start();
         for(MavenCoordinates coreCoordinates : testedCores){
             System.out.println("Starting plugin tests on core coordinates : "+coreCoordinates.toString());
-            for (Plugin plugin : data.plugins.values()) {
+            for (Plugin plugin : pluginsToCheck.values()) {
                 if(config.getIncludePlugins()==null || config.getIncludePlugins().contains(plugin.name.toLowerCase())){
                     PluginInfos pluginInfos = new PluginInfos(plugin.name, plugin.version, plugin.url);
 
@@ -252,7 +277,7 @@ public class PluginCompatTester {
                     List<String> warningMessages = new ArrayList<String>();
                     if (errorMessage == null) {
                     try {
-                        TestExecutionResult result = testPluginAgainst(actualCoreCoordinates, plugin, mconfig, pomData, data.plugins, pluginGroupIds, pcth);
+                        TestExecutionResult result = testPluginAgainst(actualCoreCoordinates, plugin, mconfig, pomData, pluginsToCheck, pluginGroupIds, pcth);
                         // If no PomExecutionException, everything went well...
                         status = TestStatus.SUCCESS;
                         warningMessages.addAll(result.pomWarningMessages);
@@ -530,6 +555,8 @@ public class PluginCompatTester {
                     }
                     top.put("core", new JSONObject().accumulate("name", "core").accumulate("version", m.group(1)).accumulate("url", ""));
                 }
+
+                //TODO: should it also scan detached plugins info?
                 m = Pattern.compile("WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi").matcher(name);
                 if (m.matches()) {
                     JSONObject plugin = new JSONObject().accumulate("url", "");


### PR DESCRIPTION
I just want to put my custom patch of https://issues.jenkins-ci.org/browse/JENKINS-48724 here. It appears that my use-case has been never supposed to work, so it is a feature, not a bug. Feedback about its feasibility will be appreciated.

The current PoC fails with " Could not find artifact org.jenkins-ci.main:jenkins-core:jar:2.99-SNAPSHOT", the core artifacts needs to be installed in order to run with this patch. It's going to cause some fun in Docker (#53), but we can always add this prerequisite to the docs. 

@raul-arabaolaza @reviewbybees 