### PR TITLE
[JENKINS-48736] - add diagnostics for “invalid” -reportFile parameter values.

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -54,7 +54,7 @@ public class CliOptions {
     private File workDirectory;
 
     @Parameter(names = "-reportFile", required = true,
-            description = "Output report xml file path")
+            description = "Output report xml file path. This path must contain a directory, e.g. 'out/pct-report.xml'")
     private File reportFile;
 
     @Parameter(names = "-includePlugins",

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -62,6 +62,14 @@ public class PluginCompatTesterCli {
         if(!"NOREPORT".equals(options.getReportFile().getName())){
             reportFile = options.getReportFile();
         }
+        if (reportFile != null) {
+            // Check the format requirement
+            File parentFile = reportFile.getParentFile();
+            if (parentFile == null) {
+                throw new IllegalArgumentException("The -reportFile value '" + reportFile + "' does not have a directory specification. " +
+                        "A path should be something like 'out/pct-report.xml'");
+            }
+        }
 
         String updateCenterUrl = options.getUpdateCenterUrl();
         String parentCoordinates = options.getParentCoord();

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
@@ -27,6 +27,7 @@ package org.jenkins.tools.test.model;
 
 import com.thoughtworks.xstream.XStream;
 
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.util.*;
 
@@ -83,20 +84,25 @@ public class PluginCompatReport {
         tempReportPath.renameTo(reportPath);
     }
 
-    public static String getXslFilename(File reportPath){
+    public static String getXslFilename(@Nonnull File reportPath){
         return getBaseFilename(reportPath)+".xsl";
     }
 
-    public static File getXslFilepath(File reportPath){
+    public static File getXslFilepath(@Nonnull File reportPath){
         return new File(getBaseFilepath(reportPath)+".xsl");
     }
 
-    public static File getHtmlFilepath(File reportPath){
+    public static File getHtmlFilepath(@Nonnull File reportPath){
         return new File(getBaseFilepath(reportPath)+".html");
     }
 
-    public static String getBaseFilepath(File reportPath){
-        return reportPath.getParentFile().getAbsolutePath()+"/"+getBaseFilename(reportPath);
+    public static String getBaseFilepath(@Nonnull File reportPath){
+        File parentFile = reportPath.getParentFile();
+        if (parentFile == null) {
+            throw new IllegalArgumentException("The report path " + reportPath + " does not have a directory specification. " +
+                    "A correct path should be something like 'out/pct-report.xml'");
+        }
+        return parentFile.getAbsolutePath()+"/"+getBaseFilename(reportPath);
     }
 
     public static String getBaseFilename(File reportPath){


### PR DESCRIPTION
@dwnusbaum caught it in #54: https://github.com/jenkinsci/plugin-compat-tester/pull/54#issuecomment-354349883

This patch does not change the behavior, but it documents it at least.

https://issues.jenkins-ci.org/browse/JENKINS-48736

@reviewbybees 