### PR TITLE
[FIXED JENKINS-48742] - Enable gathering of groupId info from Update Sites

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -516,7 +516,7 @@ public class PluginCompatTester {
     /**
      * Extracts Update Site data from the update center.
      * @param groupIDs Target storage for Group IDs. The existing values won't be overridden
-     * @return Update sire Data
+     * @return Update site Data
      */
     private UpdateSite.Data extractUpdateCenterData(Map<String, String> groupIDs){
 		URL url = null;


### PR DESCRIPTION
Before this change PCT was collecting the info only from WAR files. In Jenkins 2.0 there is no information since the plugins are detached. Runs against plugins like Git or Mailer for the stock Jenkins core were just failing (workflow-api uses a non-default groupID).

After this change PCT will extract the data from Update Site, but it WILL NOT override the data extracted from the WAR file. So it will not cause regressions in WARs with bundled plugins. Confirmed it locally.

https://issues.jenkins-ci.org/browse/JENKINS-48742

@reviewbybees @raul-arabaolaza 
