### PR TITLE
[WIP] [JENKINS-48843] extend LocalCheckoutDir with multiple local repos

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -107,6 +107,10 @@ public class CliOptions {
     @Parameter(names="-localCheckoutDir", description = "Folder containing a local (possibly modified) clone of a plugin repository")
     private String localCheckoutDir;
 
+    @Parameter(names = "-skipSingleLocalCheckoutDir",
+            description = "Allows to use localCheckoutDir with multiple plugins rather than just an individual repo.")
+    private String skipSingleLocalCheckoutDir = null;
+
     public String getUpdateCenterUrl() {
         return updateCenterUrl;
     }
@@ -174,4 +178,9 @@ public class CliOptions {
     public String getLocalCheckoutDir() {
         return localCheckoutDir;
     }
+
+    public String getSkipSingleLocalCheckoutDir() {
+        return skipSingleLocalCheckoutDir;
+    }
+
 }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -121,6 +121,9 @@ public class PluginCompatTesterCli {
         if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());
         }
+        if(options.getSkipSingleLocalCheckoutDir() != null){
+            config.setSkipSingleLocalCheckoutDir(Boolean.valueOf(options.getSkipSingleLocalCheckoutDir()).booleanValue());
+        }
 
         PluginCompatTester tester = new PluginCompatTester(config);
         tester.testPlugins();

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -108,6 +108,9 @@ public class PluginCompatTesterConfig {
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
     private File localCheckoutDir;
 
+    // Skips single plugin checkout folder
+    private boolean skipSingleLocalCheckoutDir = false;
+
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
                 workDirectory, reportFile, m2SettingsFile);
@@ -261,5 +264,13 @@ public class PluginCompatTesterConfig {
 
     public void setLocalCheckoutDir(String localCheckoutDir) {
         this.localCheckoutDir = new File(localCheckoutDir);
+    }
+
+    public boolean isSkipSingleLocalCheckoutDir() {
+        return skipSingleLocalCheckoutDir;
+    }
+
+    public void setSkipSingleLocalCheckoutDir(boolean skipSingleLocalCheckoutDir) {
+        this.skipSingleLocalCheckoutDir = skipSingleLocalCheckoutDir;
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -363,7 +363,7 @@ public class PluginCompatTester {
 
     private static File createBuildLogFile(File reportFile, String pluginName, String pluginVersion, MavenCoordinates coreCoords){
         return new File(reportFile.getParentFile().getAbsolutePath()
-                            +"/"+createBuildLogFilePathFor(pluginName, pluginVersion, coreCoords));
+                            + File.separator + createBuildLogFilePathFor(pluginName, pluginVersion, coreCoords));
     }
 
     private static String createBuildLogFilePathFor(String pluginName, String pluginVersion, MavenCoordinates coreCoords){
@@ -381,7 +381,7 @@ public class PluginCompatTester {
         System.out.println(String.format("#############################################"));
         System.out.println(String.format("%n%n%n%n%n"));
 
-        File pluginCheckoutDir = new File(config.workDirectory.getAbsolutePath()+"/"+plugin.name+"/");
+        File pluginCheckoutDir = new File(config.workDirectory.getAbsolutePath() + File.separator + plugin.name + File.separator);
 
 		try {
             // Run any precheckout hooks

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -414,6 +414,7 @@ public class PluginCompatTester {
                 File localCheckoutPluginDir = new File(config.getLocalCheckoutDir(), plugin.name);
                 if (localCheckoutProvided() && localCheckoutPluginDir.exists()) {
                     if (!onlyOnePluginIncluded()) {
+                        System.out.println("Copy plugin directory from : " + localCheckoutPluginDir.getAbsolutePath());
                         FileUtils.copyDirectoryStructure(localCheckoutPluginDir, pluginCheckoutDir);
                     } else {
                         // TODO this fails when it encounters symlinks (e.g. work/jobs/…/builds/lastUnstableBuild),


### PR DESCRIPTION
[JENKINS-48843](https://issues.jenkins-ci.org/browse/JENKINS-48843)

- Allow overriding default behaviour when using `localCheckoutDir`
- If property set, it will copy the content for that particular plugin folder instead of checking out from SCM. If plugin folder doesn't exist then it will check it out from SCM.

Folder structure is based on `<localCheckoutDir>/artifactId`

For instance:
``` bash
ls -l /folder/localCheckoutDir
blueocean
git
```
  
@reviewbybees @varyvol @recena 