### PR TITLE
[JENKINS-48936] PCT does not honor .eslintrc in blueocean runs

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -513,6 +513,7 @@ public class PluginCompatTester {
             forExecutionHooks.put("pom", pom);
             forExecutionHooks.put("coreCoordinates", coreCoordinates);
             forExecutionHooks.put("config", config);
+            forExecutionHooks.put("pluginDir", pluginCheckoutDir);
             pcth.runBeforeExecution(forExecutionHooks);
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, ((List<String>)forExecutionHooks.get("args")).toArray(new String[args.size()]));
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -22,13 +22,6 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
 
     protected boolean firstRun = true;
 
-    /**
-     * All the plugins that are part of this repository.
-     */
-    public List<String> transformedPlugins() {
-        return getBundledPlugins();
-    }
-
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         PluginCompatTesterConfig config = (PluginCompatTesterConfig)moreInfo.get("config");
         UpdateSite.Plugin currentPlugin = (UpdateSite.Plugin)moreInfo.get("plugin");
@@ -71,11 +64,6 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
 
         return moreInfo;
     }
-
-    /**
-     * Returns the list of plugins that belong to the multi module project that this hook is intended for
-     */
-    protected abstract List<String> getBundledPlugins();
 
     /**
      * Returns the folder where the multimodule project parent will be checked out

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
@@ -57,7 +57,9 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
                     pluginSourcesDir = pluginSourcesDir.getParent();
                 }
                 // Copy the file if it exists
-                Files.walk(pluginSourcesDir, 1).filter(file -> isEslintFile(file)).forEach(eslintrc -> copy(eslintrc, pluginDir));
+                Files.walk(pluginSourcesDir, 1)
+                    .filter(file -> isEslintFile(file))
+                    .forEach(eslintrc -> copy(eslintrc, pluginDir));
             }
 
             // We need to compile before generating effective pom overriding jenkins.version

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
@@ -45,9 +45,6 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
             mavenConfig = getMavenConfig(config);
 
             File pluginDir = (File) moreInfo.get("pluginDir");
-            if (pluginDir.exists())
-
-
             Path pluginSourcesDir = config.getLocalCheckoutDir().toPath();
 
             if (pluginSourcesDir != null) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BOAndDPCompileHook.java
@@ -45,13 +45,15 @@ public class BOAndDPCompileHook extends PluginCompatTesterHookBeforeCompile {
             mavenConfig = getMavenConfig(config);
 
             File pluginDir = (File) moreInfo.get("pluginDir");
+            if (pluginDir.exists())
+
 
             Path pluginSourcesDir = config.getLocalCheckoutDir().toPath();
 
             if (pluginSourcesDir != null) {
                 boolean isMultipleLocalPlugins = config.getIncludePlugins() != null && config.getIncludePlugins().size() > 1;
                 // We are running for local changes, let's copy the .eslintrc file if we can
-                //If we are using localCheckoutDir with multiple plufins the .eslintrc must be located at the top level
+                // If we are using localCheckoutDir with multiple plugins the .eslintrc must be located at the top level
                 // If not it must be located on the parent of the localCheckoutDir
                 if (!isMultipleLocalPlugins) {
                     pluginSourcesDir = pluginSourcesDir.getParent();

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -2,6 +2,7 @@ package org.jenkins.tools.test.hook;
 
 import org.jenkins.tools.test.SCMManagerFactory;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.PomData;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
 
 import org.apache.maven.scm.ScmFileSet;
@@ -12,6 +13,10 @@ import org.apache.maven.scm.repository.ScmRepository;
 import hudson.model.UpdateSite.Plugin;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -22,16 +27,6 @@ import java.util.Map;
  * 
  */
 public class BlueOceanHook extends AbstractMultiParentHook {
-
-    public static final List<String> BO_PLUGINS = Arrays.asList("blueocean", "blueocean-commons",
-            "blueocean-config", "blueocean-dashboard", "blueocean-events", "blueocean-git-pipeline", "blueocean-github-pipeline",
-            "blueocean-i18n", "blueocean-jwt", "blueocean-personalization", "blueocean-pipeline-api-impl", "blueocean-rest",
-            "blueocean-rest-impl", "blueocean-web", "blueocean-pipeline-scm-api", "blueocean-pipeline-editor", "blueocean-jira");
-
-    @Override
-    protected List<String> getBundledPlugins() {
-        return BO_PLUGINS;
-    }
 
     @Override
     protected String getParentFolder() {
@@ -47,4 +42,15 @@ public class BlueOceanHook extends AbstractMultiParentHook {
     protected String getParentProjectName() {
         return "blueocean-parent";
     }
+
+    @Override
+    public boolean check(Map<String, Object> info) throws Exception {
+        return isBOPlugin(info);
+    }
+
+    public static boolean isBOPlugin(Map<String, Object> moreInfo) {
+        PomData data = (PomData) moreInfo.get("pomData");
+        return data.parent.artifactId.equalsIgnoreCase("blueocean-parent");
+    }
+
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -1,17 +1,8 @@
 package org.jenkins.tools.test.hook;
 
 
-import hudson.model.UpdateSite;
-import org.apache.maven.scm.ScmFileSet;
-import org.apache.maven.scm.ScmTag;
-import org.apache.maven.scm.command.checkout.CheckOutScmResult;
-import org.apache.maven.scm.manager.ScmManager;
-import org.apache.maven.scm.repository.ScmRepository;
-import org.jenkins.tools.test.SCMManagerFactory;
-import org.jenkins.tools.test.model.PluginCompatTesterConfig;
-import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.jenkins.tools.test.model.PomData;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -21,13 +12,6 @@ import java.util.Map;
  * stored in a central repository.
  */
 public class DeclarativePipelineHook extends AbstractMultiParentHook {
-
-    public static final List<String> DP_PLUGINS = Arrays.asList("pipeline-model-api", "pipeline-model-definition", "pipeline-model-extensions", "pipeline-model-json-shaded", "pipeline-stage-tags-metadata");
-
-    @Override
-    protected List<String> getBundledPlugins() {
-        return DP_PLUGINS;
-    }
 
     @Override
     protected String getParentFolder() {
@@ -42,5 +26,15 @@ public class DeclarativePipelineHook extends AbstractMultiParentHook {
     @Override
     protected String getParentProjectName() {
         return "pipeline-model-definition";
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) throws Exception {
+        return isDPPlugin(info);
+    }
+
+    public static boolean isDPPlugin(Map<String, Object> moreInfo) {
+        PomData data = (PomData) moreInfo.get("pomData");
+        return data.parent.artifactId.equalsIgnoreCase("pipeline-model-parent");
     }
 }


### PR DESCRIPTION
[JENKINS-48936](https://issues.jenkins-ci.org/browse/JENKINS-48936)

The PCT wasn't copying the `.eslintrc` file when running local versions of BO plugins, making modules like `blueocean-core-js` to fail in the build phase due to linter errors.

Also I have make the hook able to deal with newly added BO modules without the need of a hardcoded list that needed to be updated for every new BO module

@reviewbybees @vivek @fcojfernandez 