### PR TITLE
Do not mutate the list of hooks that apply to all plugins

### DIFF
--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -64,7 +64,15 @@ public class PluginCompatTesterHooks {
      */
     private Map<String, Object> runHooks(String stage, Map<String, Object> elements) throws RuntimeException {
         String pluginName = (String)elements.get("pluginName");
-        Queue<PluginCompatTesterHook> beforeHooks = hooksByType.get(stage).get("all") != null ? hooksByType.get(stage).get("all") : new LinkedList<PluginCompatTesterHook>();
+        // List of hooks to execute for the given plugin
+        Queue<PluginCompatTesterHook> beforeHooks = new LinkedList<PluginCompatTesterHook>();
+
+        // Add any hooks that apply for all plugins
+        if(hooksByType.get(stage).get("all") != null) {
+            beforeHooks.addAll(hooksByType.get(stage).get("all"));
+        }
+
+        // Add hooks that applied to this concrete plugin
         if(hooksByType.get(stage).get(pluginName) != null) {
             beforeHooks.addAll(hooksByType.get(stage).get(pluginName));
         }


### PR DESCRIPTION
With the previous code any hook executed for a given plugin would be executed always for the rest of the plugins as long as there is one hook that applies to all plugins.

For example if for some reason SkipUiPlugin is executed for any plugin it would be executed for all next plugins

So, basically this has not been found before because until now there were no hooks applied to all plugins

@reviewbybees @fcojfernandez @varyvol @oleg-nenashev 