### PR TITLE
[JENKINS-50626] - Properly propagate the “-mavenOptions” parameter in PCT CLI

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -28,6 +28,7 @@ package org.jenkins.tools.test;
 import com.beust.jcommander.Parameter;
 import org.jenkins.tools.test.model.TestStatus;
 
+import javax.annotation.CheckForNull;
 import java.io.File;
 import java.util.List;
 
@@ -154,6 +155,7 @@ public class CliOptions {
         return excludePlugins;
     }
 
+    @CheckForNull
     public String getMavenPropertiesFile() {
         return mavenPropertiesFile;
     }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -94,7 +94,12 @@ public class CliOptions {
                     "as part of the cache")
     private String cacheThresholdStatus = TestStatus.COMPILATION_ERROR.toString();
 
-    @Parameter(names="-mavenPropertiesFile", description = "Allow loading some maven properties from *.prop file. These options will be used a la -D")
+    @Parameter(names="-mavenProperties", description = "Define extra properties to be passed to the build. These options will be used a la -D")
+    private String mavenProperties;
+
+    @Parameter(names="-mavenPropertiesFile", description = "Allow loading some maven properties from *.prop file. " +
+            "Format: 'KEY1=VALUE1:KEY2=VALUE2'" +
+            "These options will be used a la -D")
     private String mavenPropertiesFile;
 
     @Parameter(names="-gaeSecurityToken", description = "Allows to pass GAE Security token needed to write data")
@@ -153,6 +158,11 @@ public class CliOptions {
 
     public String getExcludePlugins() {
         return excludePlugins;
+    }
+
+    @CheckForNull
+    public String getMavenProperties() {
+        return mavenProperties;
     }
 
     @CheckForNull

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -94,7 +94,7 @@ public class CliOptions {
                     "as part of the cache")
     private String cacheThresholdStatus = TestStatus.COMPILATION_ERROR.toString();
 
-    @Parameter(names="-mavenProperties", description = "allow to load some maven properties which will be used a la -D")
+    @Parameter(names="-mavenPropertiesFile", description = "Allow loading some maven properties from *.prop file. These options will be used a la -D")
     private String mavenPropertiesFile;
 
     @Parameter(names="-gaeSecurityToken", description = "Allows to pass GAE Security token needed to write data")

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -126,6 +126,10 @@ public class PluginCompatTesterCli {
         if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());
         }
+        if(options.getMavenPropertiesFile() != null) {
+            config.setMavenPropertiesFiles(options.getMavenPropertiesFile());
+        }
+
 
         PluginCompatTester tester = new PluginCompatTester(config);
         tester.testPlugins();

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -35,6 +35,8 @@ import org.jenkins.tools.test.model.TestStatus;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Plugin compatibility tester frontend for the CLI
@@ -126,6 +128,20 @@ public class PluginCompatTesterCli {
         if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());
         }
+
+        // Handle properties
+        if (options.getMavenProperties() != null) {
+            String[] split = options.getMavenProperties().split("\\s*:\\s*");
+            Map<String, String> mavenProps = new HashMap<>(split.length);
+            for (String expr : split) {
+                String[] split2 = expr.split("=");
+                String key = split2[0];
+                String value = split2.length >= 2 ? split2[1] : null;
+                mavenProps.put(key, value);
+            }
+            config.setMavenProperties(mavenProps);
+        }
+        //TODO: Read property file here as well? No sense to do it letter unless PCT Hooks modify file
         if(options.getMavenPropertiesFile() != null) {
             config.setMavenPropertiesFiles(options.getMavenPropertiesFile());
         }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -27,11 +27,13 @@ package org.jenkins.tools.test.model;
 
 import org.apache.commons.lang.StringUtils;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +104,7 @@ public class PluginCompatTesterConfig {
     // Only if reportFile is not null
     private boolean generateHtmlReport = true;
 
+    private Map<String, String> mavenProperties = Collections.emptyMap();
     private String mavenPropertiesFile;
 
     // GoogleAppEngine property allowing to provide a security token to be able to write data
@@ -205,6 +208,19 @@ public class PluginCompatTesterConfig {
         this.excludePlugins = excludePlugins;
     }
 
+    public void setMavenProperties(@Nonnull Map<String, String> mavenProperties) {
+        this.mavenProperties = new HashMap<>(mavenProperties);
+    }
+
+    /**
+     * Gets a list of Maven properties defined in the config.
+     * It is not a full list of properties, {@link #retrieveMavenProperties()} should be used to construct it
+     */
+    @Nonnull
+    public Map<String, String> getMavenProperties() {
+        return Collections.unmodifiableMap(mavenProperties);
+    }
+
     public String getMavenPropertiesFile() {
         return mavenPropertiesFile;
     }
@@ -220,7 +236,7 @@ public class PluginCompatTesterConfig {
      * @since TODO
      */
     public Map<String, String> retrieveMavenProperties() throws IOException {
-        Map<String, String> res = new HashMap<>();
+        Map<String, String> res = new HashMap<>(mavenProperties);
 
         // Read properties from File
         if ( StringUtils.isNotBlank( mavenPropertiesFile )) {

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -25,10 +25,17 @@
  */
 package org.jenkins.tools.test.model;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * POJO used to configure PluginCompatTester execution
@@ -204,6 +211,33 @@ public class PluginCompatTesterConfig {
 
     public void setMavenPropertiesFiles( String mavenPropertiesFile ) {
         this.mavenPropertiesFile = mavenPropertiesFile;
+    }
+
+    /**
+     * Retrieves Maven Properties from available sources like {@link #mavenPropertiesFile}.
+     * @return Map of properties
+     * @throws IOException Property read failure
+     * @since TODO
+     */
+    public Map<String, String> retrieveMavenProperties() throws IOException {
+        Map<String, String> res = new HashMap<>();
+
+        // Read properties from File
+        if ( StringUtils.isNotBlank( mavenPropertiesFile )) {
+            File file = new File (mavenPropertiesFile);
+            if (file.exists() && file.isFile()) {
+                try(FileInputStream fileInputStream = new FileInputStream(file)) {
+                    Properties properties = new Properties(  );
+                    properties.load( fileInputStream  );
+                    for (Map.Entry<Object,Object> entry : properties.entrySet()) {
+                        res.put((String) entry.getKey(), (String) entry.getValue());
+                    }
+                }
+            } else {
+                throw new IOException("Extra Maven Properties File " + mavenPropertiesFile + " does not exist or not a File" );
+            }
+        }
+        return res;
     }
 
     public TestStatus getCacheThresholStatus() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -211,21 +211,7 @@ public class PluginCompatTester {
         // TODO REMOVE
         mconfig.userProperties.put( "failIfNoTests", "false" );
         mconfig.userProperties.put( "argLine", "-XX:MaxPermSize=128m" );
-        String mavenPropertiesFilePath = this.config.getMavenPropertiesFile();
-        if ( StringUtils.isNotBlank( mavenPropertiesFilePath )) {
-            File file = new File (mavenPropertiesFilePath);
-            if (file.exists() && file.isFile()) {
-                try(FileInputStream fileInputStream = new FileInputStream(file)) {
-                    Properties properties = new Properties(  );
-                    properties.load( fileInputStream  );
-                    for (Map.Entry<Object,Object> entry : properties.entrySet()) {
-                        mconfig.userProperties.put((String) entry.getKey(), (String) entry.getValue());
-                    }
-                }
-            } else {
-                throw new IOException("Extra Maven Properties File " + mavenPropertiesFilePath + " does not exist" );
-            }
-        }
+        mconfig.userProperties.putAll(this.config.retrieveMavenProperties());
 
 		SCMManagerFactory.getInstance().start();
         for(MavenCoordinates coreCoordinates : testedCores){

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -214,20 +214,16 @@ public class PluginCompatTester {
         String mavenPropertiesFilePath = this.config.getMavenPropertiesFile();
         if ( StringUtils.isNotBlank( mavenPropertiesFilePath )) {
             File file = new File (mavenPropertiesFilePath);
-            if (file.exists()) {
-                FileInputStream fileInputStream = null;
-                try {
-                    fileInputStream = new FileInputStream( file );
+            if (file.exists() && file.isFile()) {
+                try(FileInputStream fileInputStream = new FileInputStream(file)) {
                     Properties properties = new Properties(  );
                     properties.load( fileInputStream  );
                     for (Map.Entry<Object,Object> entry : properties.entrySet()) {
                         mconfig.userProperties.put((String) entry.getKey(), (String) entry.getValue());
                     }
-                } finally {
-                    IOUtils.closeQuietly( fileInputStream );
                 }
             } else {
-                System.out.println("File " + mavenPropertiesFilePath + " not exists" );
+                throw new IOException("Extra Maven Properties File " + mavenPropertiesFilePath + " does not exist" );
             }
         }
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -106,25 +106,8 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
         // TODO REMOVE
         mconfig.userProperties.put("failIfNoTests", "false");
         mconfig.userProperties.put("argLine", "-XX:MaxPermSize=128m");
-        String mavenPropertiesFilePath = config.getMavenPropertiesFile();
-        if (StringUtils.isNotBlank(mavenPropertiesFilePath)) {
-            File file = new File(mavenPropertiesFilePath);
-            if (file.exists()) {
-                FileInputStream fileInputStream = null;
-                try {
-                    fileInputStream = new FileInputStream(file);
-                    Properties properties = new Properties();
-                    properties.load(fileInputStream);
-                    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-                        mconfig.userProperties.put((String) entry.getKey(), (String) entry.getValue());
-                    }
-                } finally {
-                    IOUtils.closeQuietly(fileInputStream);
-                }
-            } else {
-                System.out.println("File " + mavenPropertiesFilePath + " not exists");
-            }
-        }
+        mconfig.userProperties.putAll(config.retrieveMavenProperties());
+
         return mconfig;
     }
 


### PR DESCRIPTION
I was experimenting with running PCT for custom WARs, but it appears that I cannot pass any custom Maven Properties with "-mavenProperties" file, because... this parameter is just ignored in the PCT CLI codebase.

After the patch the properties are being propagated correctly.

https://issues.jenkins-ci.org/browse/JENKINS-50626

@reviewbybees 
