### PR TITLE
Pass Maven Settings and JAVA_OPTS to every Maven Invocation with Docker PCT package

### DIFF
--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -57,10 +57,10 @@ if [ -f "${JENKINS_WAR_PATH}" ]; then
     unzip -q -c "jenkins.war" "WEB-INF/lib/jenkins-core-${JENKINS_VERSION}.jar" > "war-exploded/jenkins-core.jar"
     unzip -q -c "jenkins.war" "WEB-INF/lib/cli-${JENKINS_VERSION}.jar" > "war-exploded/jenkins-cli.jar"
     unzip -q -c "jenkins.war" "META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml" > "war-exploded/jenkins-pom.xml"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -m2SettingsFile "${MVN_SETTINGS_FILE}" -Dfile="jenkins.war"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -m2SettingsFile "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-core.jar"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -m2SettingsFile "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-cli.jar"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file -Dpackaging=pom ${JAVA_OPTS} -m2SettingsFile "${MVN_SETTINGS_FILE}"  -Dfile="war-exploded/jenkins-pom.xml" -DpomFile="war-exploded/jenkins-pom.xml" -Dversion="${JENKINS_VERSION}" -DartifactId="pom" -DgroupId="org.jenkins-ci.main"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="jenkins.war"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-core.jar"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-cli.jar"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file -Dpackaging=pom ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}"  -Dfile="war-exploded/jenkins-pom.xml" -DpomFile="war-exploded/jenkins-pom.xml" -Dversion="${JENKINS_VERSION}" -DartifactId="pom" -DgroupId="org.jenkins-ci.main"
   fi
 else
   WAR_PATH_OPT=""
@@ -100,7 +100,7 @@ fi
 ###
 cd "${TMP_CHECKOUT_DIR}"
 if [ -z "${ARTIFACT_ID}" ] ; then
-  ARTIFACT_ID=$(mvn org.apache.maven.plugins:maven-help-plugin:2.2:evaluate ${JAVA_OPTS} -m2SettingsFile "${MVN_SETTINGS_FILE}" -Dexpression=project.artifactId | grep -Ev '(^\[|Download.*)')
+  ARTIFACT_ID=$(mvn org.apache.maven.plugins:maven-help-plugin:2.2:evaluate ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dexpression=project.artifactId | grep -Ev '(^\[|Download.*)')
   echo "ARTIFACT_ID is not specified, using ${ARTIFACT_ID} defined in the POM file"
   mvn clean
 fi

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -57,10 +57,10 @@ if [ -f "${JENKINS_WAR_PATH}" ]; then
     unzip -q -c "jenkins.war" "WEB-INF/lib/jenkins-core-${JENKINS_VERSION}.jar" > "war-exploded/jenkins-core.jar"
     unzip -q -c "jenkins.war" "WEB-INF/lib/cli-${JENKINS_VERSION}.jar" > "war-exploded/jenkins-cli.jar"
     unzip -q -c "jenkins.war" "META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml" > "war-exploded/jenkins-pom.xml"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="jenkins.war"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-core.jar"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-cli.jar"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file -Dpackaging=pom ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}"  -Dfile="war-exploded/jenkins-pom.xml" -DpomFile="war-exploded/jenkins-pom.xml" -Dversion="${JENKINS_VERSION}" -DartifactId="pom" -DgroupId="org.jenkins-ci.main"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="jenkins.war"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-core.jar"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dfile="war-exploded/jenkins-cli.jar"
+    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode -Dpackaging=pom ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}"  -Dfile="war-exploded/jenkins-pom.xml" -DpomFile="war-exploded/jenkins-pom.xml" -Dversion="${JENKINS_VERSION}" -DartifactId="pom" -DgroupId="org.jenkins-ci.main"
   fi
 else
   WAR_PATH_OPT=""
@@ -100,7 +100,7 @@ fi
 ###
 cd "${TMP_CHECKOUT_DIR}"
 if [ -z "${ARTIFACT_ID}" ] ; then
-  ARTIFACT_ID=$(mvn org.apache.maven.plugins:maven-help-plugin:2.2:evaluate ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" -Dexpression=project.artifactId | grep -Ev '(^\[|Download.*)')
+  ARTIFACT_ID=$(mvn org.apache.maven.plugins:maven-help-plugin:2.2:evaluate ${JAVA_OPTS} --batch-mode -s "${MVN_SETTINGS_FILE}" -Dexpression=project.artifactId | grep -Ev '(^\[|Download.*)')
   echo "ARTIFACT_ID is not specified, using ${ARTIFACT_ID} defined in the POM file"
   mvn clean
 fi


### PR DESCRIPTION
Just noticed that Maven Settings file and JAVA_OPTS are not passed to all calls within `run-pct` script. It causes issues on ci.jenkins.io, because Azure mirror settings are not passed

@reviewbybees @raul-arabaolaza 
