### PR TITLE
[INFRA-1534] Using a volume for maven settings file caused a lot of problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,6 @@ VOLUME /pct/plugin-src
 VOLUME /pct/jenkins.war
 VOLUME /pct/out
 VOLUME /pct/tmp
-VOLUME /pct/m2-settings.xml
+VOLUME /pct/m2-settings
 VOLUME /root/.m2
 ENTRYPOINT ["run-pct"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,6 @@ VOLUME /pct/plugin-src
 VOLUME /pct/jenkins.war
 VOLUME /pct/out
 VOLUME /pct/tmp
-VOLUME /pct/m2-settings
+VOLUME /pct/m2-settings.xml
 VOLUME /root/.m2
 ENTRYPOINT ["run-pct"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The image will be able to determine this ID automatically if `CHECKOUT_SRC` or `
 * `CHECKOUT_SRC` - Custom Git clone source (e.g. `https://github.com/oleg-nenashev/job-restrictions-plugin.git`). `https://github.com/jenkinsci/${ARTIFACT_ID}-plugin.git` by default
 * `JAVA_OPTS` - Java options to be passed to the PCT CLI
 * `DEBUG` - Boolean flag, which enables the Remote Debug mode (port == 5000)
-* `M2_SETTINGS_FILE` -  If set indicates the path of the custom maven settinmgs file to use (see volumes below)
+* `M2_SETTINGS_FILE` -  If set indicates the path of the custom maven settings file to use (see volumes below)
 
 Volumes:
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ The image will be able to determine this ID automatically if `CHECKOUT_SRC` or `
 * `CHECKOUT_SRC` - Custom Git clone source (e.g. `https://github.com/oleg-nenashev/job-restrictions-plugin.git`). `https://github.com/jenkinsci/${ARTIFACT_ID}-plugin.git` by default
 * `JAVA_OPTS` - Java options to be passed to the PCT CLI
 * `DEBUG` - Boolean flag, which enables the Remote Debug mode (port == 5000)
-* `M2_SETTINGS_FILE` -  If set indicates the name of the custom maven settinmgs file to use (see volumes below), defaults to settings.xml
+* `M2_SETTINGS_FILE` -  If set indicates the path of the custom maven settinmgs file to use (see volumes below)
 
 Volumes:
 
 * `/pct/plugin-src` - Plugin sources to be used for the PCT run. Sources will be checked out if not specified
 * `/pct/jenkins.war` - Jenkins WAR file to be used for the PCT run
-* `/pct/m2-settings - Custom Maven Settings parent folder, if specified the PCT will use the maven settings file indicated by `M2_SETTINGS_FILE` environment variable
+* `/pct/m2-settings.xml - Custom Maven Settings if `M2_SETTINGS_FILE` environment variable exists `run-pct` will ignore this location and use the one specified in the varaible`
 * `/pct/out` - Output directory for PCT. All reports will be stored there
 * `/pct/tmp` - Temporary directory. Can be exposed to analyze run failures
 * `/root/.m2` - Maven repository. It can be used to pass settings.xml or to cache artifacts

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ The image will be able to determine this ID automatically if `CHECKOUT_SRC` or `
 * `CHECKOUT_SRC` - Custom Git clone source (e.g. `https://github.com/oleg-nenashev/job-restrictions-plugin.git`). `https://github.com/jenkinsci/${ARTIFACT_ID}-plugin.git` by default
 * `JAVA_OPTS` - Java options to be passed to the PCT CLI
 * `DEBUG` - Boolean flag, which enables the Remote Debug mode (port == 5000)
+* `M2_SETTINGS_FILE` -  If set indicates the name of the custom maven settinmgs file to use (see volumes below), defaults to settings.xml
 
 Volumes:
 
 * `/pct/plugin-src` - Plugin sources to be used for the PCT run. Sources will be checked out if not specified
 * `/pct/jenkins.war` - Jenkins WAR file to be used for the PCT run
-* `/pct/m2-settings.xml` - Custom Maven Settings file (optional)
+* `/pct/m2-settings - Custom Maven Settings parent folder, if specified the PCT will use the maven settings file indicated by `M2_SETTINGS_FILE` environment variable
 * `/pct/out` - Output directory for PCT. All reports will be stored there
 * `/pct/tmp` - Temporary directory. Can be exposed to analyze run failures
 * `/root/.m2` - Maven repository. It can be used to pass settings.xml or to cache artifacts

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Volumes:
 
 * `/pct/plugin-src` - Plugin sources to be used for the PCT run. Sources will be checked out if not specified
 * `/pct/jenkins.war` - Jenkins WAR file to be used for the PCT run
-* `/pct/m2-settings.xml - Custom Maven Settings if `M2_SETTINGS_FILE` environment variable exists `run-pct` will ignore this location and use the one specified in the varaible`
+* `/pct/m2-settings.xml` - Custom Maven Settings (optional) if `M2_SETTINGS_FILE` environment variable exists `run-pct` will ignore this location and use the one specified in the variable
 * `/pct/out` - Output directory for PCT. All reports will be stored there
 * `/pct/tmp` - Temporary directory. Can be exposed to analyze run failures
 * `/root/.m2` - Maven repository. It can be used to pass settings.xml or to cache artifacts

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -74,7 +74,14 @@ if [[ "$DEBUG" ]] ; then
   )
 fi
 
+CUSTOM_MAVEN_SETTINGS=${M2_SETTINGS_FILE:-settings.xml}
 
+if [ -f "/pct/m2-settings/${CUSTOM_MAVEN_SETTINGS}" ] ; then
+    echo "Using a custom Maven settings file specified by the volume"
+    MVN_SETTINGS_FILE="/pct/m2-settings/${CUSTOM_MAVEN_SETTINGS}"
+else
+    MVN_SETTINGS_FILE="/pct/default-m2-settings.xml"
+fi
 
 ###
 # Checkout sources

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -17,9 +17,11 @@ if [ -n "${ARTIFACT_ID}" ]; then
   echo "Running PCT for plugin ${ARTIFACT_ID}"
 fi
 
-if [ -f "/pct/m2-settings.xml" ] ; then
-    echo "Using a custom Maven settings file specified by the volume"
-    MVN_SETTINGS_FILE="/pct/m2-settings.xml"
+CUSTOM_MAVEN_SETTINGS=${M2_SETTINGS_FILE:-"/pct/m2-settings.xml"}
+
+if [ -f "${CUSTOM_MAVEN_SETTINGS}" ] ; then
+    echo "Using a custom Maven settings file"
+    MVN_SETTINGS_FILE="${CUSTOM_MAVEN_SETTINGS}"
 else
     MVN_SETTINGS_FILE="/pct/default-m2-settings.xml"
 fi
@@ -72,15 +74,6 @@ if [[ "$DEBUG" ]] ; then
     '-Xdebug' \
     '-Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=y' \
   )
-fi
-
-CUSTOM_MAVEN_SETTINGS=${M2_SETTINGS_FILE:-settings.xml}
-
-if [ -f "/pct/m2-settings/${CUSTOM_MAVEN_SETTINGS}" ] ; then
-    echo "Using a custom Maven settings file specified by the volume"
-    MVN_SETTINGS_FILE="/pct/m2-settings/${CUSTOM_MAVEN_SETTINGS}"
-else
-    MVN_SETTINGS_FILE="/pct/default-m2-settings.xml"
 fi
 
 ###


### PR DESCRIPTION
When running in parallel in a pipeline you can not just mount several volumes
with the same name so you need to use `docker.inside` and move the settings file into the folder
But as m2-settings.xml was defined as volume it is created as a folder, hence
run-pct script failed to recognize the custom settings as it was looking for
a regular file