### PR TITLE
[JENKINS-50909] - Add support of running PCT for WAR and Plugin snapshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,11 @@ LABEL Description="Base image for running Jenkins Plugin Compat Tester (PCT) aga
 ENV JENKINS_WAR_PATH=/pct/jenkins.war
 ENV PCT_OUTPUT_DIR=/pct/out
 ENV PCT_TMP=/pct/tmp
+ENV INSTALL_BUNDLED_SNAPSHOTS=true
 
 RUN apt-get -y update && apt-get install -y groovy && rm -rf /var/lib/apt/lists/*
 
-COPY src/main/docker/readJenkinsVersion.groovy /pct/readJenkinsVersion.groovy
+COPY src/main/docker/*.groovy /pct/scripts/
 COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tester-cli-*.jar /pct/pct-cli.jar
 COPY src/main/docker/run-pct.sh /usr/local/bin/run-pct
 COPY src/main/docker/pct-default-settings.xml /pct/default-m2-settings.xml

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The image will be able to determine this ID automatically if `CHECKOUT_SRC` or `
 * `JAVA_OPTS` - Java options to be passed to the PCT CLI
 * `DEBUG` - Boolean flag, which enables the Remote Debug mode (port == 5000)
 * `M2_SETTINGS_FILE` -  If set indicates the path of the custom maven settings file to use (see volumes below)
+* `INSTALL_BUNDLED_SNAPSHOTS` - Install JAR and plugin snapshots to local repository.
+        `true` by default. WAR snapshots will be always installed.
 
 Volumes:
 

--- a/src/main/docker/installWARSnapshots.groovy
+++ b/src/main/docker/installWARSnapshots.groovy
@@ -1,0 +1,87 @@
+#!/usr/bin/env groovy
+import java.util.zip.*
+import java.util.jar.*
+
+class PluginData {
+    String groupId
+    String artifactId
+    String version
+}
+
+static void installPluginSnapshots(File directory, File explodeDir, File mavenSettings = null, String javaOpts="") throws IOException {
+    def plugins = directory.listFiles()
+    if (plugins == null) {
+        return;
+    }
+
+    explodeDir.mkdirs()
+    for (File plugin : plugins) {
+        if (plugin.getAbsolutePath().endsWith(".hpi")) {
+            File pluginExplodeDir = new File(explodeDir, plugin.name)
+            installLocally(plugin, pluginExplodeDir, mavenSettings, javaOpts)
+        }
+    }
+}
+
+static void installLocally(File plugin, File tmpDir, File mavenSettings = null, String javaOpts="") {
+    def pluginData = readPluginManifest(plugin)
+    if (!pluginData.version.contains("SNAPSHOT")) {
+        return
+    }
+    println "Installing SNAPSHOT for ${pluginData.artifactId}:${pluginData.version}"
+    execOrFail("unzip -q ${plugin.absolutePath} -d ${tmpDir.absolutePath}");
+
+    String mvnSettingsArg = mavenSettings != null ? "-s ${mavenSettings.absolutePath}" : "";
+    execOrFail("mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file " +
+        "--batch-mode ${javaOpts} ${mvnSettingsArg} " +
+        "-Dfile=${plugin.absolutePath}")
+    execOrFail("mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file " +
+        "--batch-mode -Dpackaging=jar ${javaOpts} ${mvnSettingsArg} " +
+        "-Dfile=${tmpDir.absolutePath}/WEB-INF/lib/${pluginData.artifactId}.jar")
+    execOrFail("mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file " +
+        "--batch-mode -Dpackaging=pom ${javaOpts} ${mvnSettingsArg} " +
+        "-Dfile=${tmpDir.absolutePath}/META-INF/maven/${pluginData.groupId}/${pluginData.artifactId}/pom.xml " +
+        "-DpomFile=${tmpDir.absolutePath}/META-INF/maven/${pluginData.groupId}/${pluginData.artifactId}/pom.xml " +
+        "-Dversion=${pluginData.version} -DartifactId=pom -DgroupId=${pluginData.groupId}")
+}
+
+static void execOrFail(String command) {
+    def proc = command.execute()
+    proc.consumeProcessOutput(System.out, System.err)
+    proc.waitForOrKill(5000)
+    if (proc.exitValue() != 0) {
+       throw new IOException("Task failed with exit code ${proc.exitValue()}")
+    }
+}
+
+static PluginData readPluginManifest(File sourceHPI) throws IOException {
+    def zipFile = new ZipFile(sourceHPI)
+    InputStream is
+    try {
+        def entries = zipFile.entries()
+        while (entries.hasMoreElements()) {
+            ZipEntry zipEntry = (ZipEntry) entries.nextElement()
+            if (zipEntry.getName().equals("META-INF/MANIFEST.MF")) {
+                is = zipFile.getInputStream(zipEntry)
+                def manifest = new Manifest(is)
+                def mainAttribs = manifest.getMainAttributes()
+                PluginData res = new PluginData();
+                res.version = mainAttribs.getValue("Plugin-Version").split("\\s+")[0]
+                res.groupId = mainAttribs.getValue("Group-Id")
+                res.artifactId = mainAttribs.getValue("Short-Name")
+                return res;
+            }
+        }
+    } finally {
+        if (is != null) {
+            is.close()
+        }
+        zipFile.close()
+    }
+
+    throw new IllegalStateException("Manifest not found in ${sourceHPI}")
+}
+
+println installPluginSnapshots(new File(this.args[0]), new File((String)this.args[1]),
+    this.args.length > 2 ? new File(this.args[2]) : null,
+    this.args.length > 3 ? this.args[3] : "")

--- a/src/main/docker/readJenkinsVersion.groovy
+++ b/src/main/docker/readJenkinsVersion.groovy
@@ -1,7 +1,7 @@
 import java.util.zip.*
 import java.util.jar.*
 
-static String readManifest(String sourceJARFile) throws IOException {
+static String readManifest(String sourceJARFile, String attributeName) throws IOException {
     def zipFile = new ZipFile(sourceJARFile)
     InputStream is
     try {
@@ -14,7 +14,7 @@ static String readManifest(String sourceJARFile) throws IOException {
                 def mainAttribs = manifest.getMainAttributes()
                 def version = mainAttribs.getValue("Jenkins-Version")
                 if(version != null) {
-                    return version
+                    return version.split("\\s+")[0]
                 }
             }
         }
@@ -28,4 +28,4 @@ static String readManifest(String sourceJARFile) throws IOException {
     throw new IllegalStateException("Manifest not found in" + sourceJARFile);
 }
 
-println readManifest(this.args[0])
+println readManifest(this.args[0], this.args.length > 1 ? this.args[1] : "Jenkins-Version")


### PR DESCRIPTION
In this PR I have fixed handling of local snapshots for WAR and bundled plugins within the Docker image. Components like Libs or Modules are not modified, but IIUC PCT will not work with them correctly anyway.

- [x] WAR file now installs proper artifacts, even when "Implementation-Version" and "Jenkins-Version" differ
- [x] Versions with `(private foo)` are handled correctly
- [x] If a flag set, `run-pct` will also deploy snapshots for bundled plugins

https://issues.jenkins-ci.org/browse/JENKINS-50909

@reviewbybees @raul-arabaolaza 
