### PR TITLE
[JENKINS-50540] Make sure to copy hidden files (like .git) on custom sources

### DIFF
--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 if [ $# -eq 1 ]; then
-  # if `docker run` only has one argument, we assume that the user is running an alternate command 
+  # if `docker run` only has one argument, we assume that the user is running an alternate command
   # like `bash` to inspect the image. All options passed to the executable shoud have at least 2 arguments.
   echo "Only one argument is specified, running a custom command"
   exec "$@"
@@ -96,7 +96,7 @@ TMP_CHECKOUT_DIR="${PCT_TMP}/localCheckoutDir/undefined"
 if [ -e "/pct/plugin-src/pom.xml" ] ; then
   echo "Located custom plugin sources on the volume"
   mkdir "${TMP_CHECKOUT_DIR}"
-  cp -R /pct/plugin-src/* "${TMP_CHECKOUT_DIR}/"
+  cp -r /pct/plugin-src/. "${TMP_CHECKOUT_DIR}"
   # Due to whatever reason PCT blows up if you have work in the repo
   cd "${TMP_CHECKOUT_DIR}" && mvn clean && rm -rf work
 else


### PR DESCRIPTION
The existing code was copying the plugin sources (when using custom ones) but not the hidden files (like .git folder)

git-plugin has some tests assuming they are executed in a git repo, so the end result was 121 failing tests due to the lack of a git repo when the PCT was executed using the docker image as no git repo was being found.

@reviewbybees specially @oleg-nenashev