### PR TITLE
[JENKINS-54462] - Add support of Test JDK Home and Test JDK Parameters to PCT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ tmp:
 
 tmp/jenkins-war-$(JENKINS_VERSION).war: tmp
 	mvn dependency:copy -Dartifact=org.jenkins-ci.main:jenkins-war:$(JENKINS_VERSION):war -DoutputDirectory=tmp
-	touch tmp/jenkins-$(JENKINS_VERSION).war
+	touch tmp/jenkins-war-$(JENKINS_VERSION).war
 
 tmp/jaxb-api-$(JAXB_API_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=javax.xml.bind:jaxb-api:$(JAXB_API_VERSION) -DoutputDirectory=tmp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 TEST_JDK_HOME?=$(JAVA_HOME)
 PLUGIN_NAME?=mailer
 
+JENKINS_VERSION=2.150
+JAXB_API_VERSION=2.3.0
+JAXB_VERSION=2.3.0.1
+JAF_VERSION=1.2.0
+
 .PHONY: all
 all: clean package docker
 
@@ -20,36 +25,47 @@ docker:
 tmp:
 	mkdir tmp
 
-tmp/jenkins.war: tmp
-	curl -fsSL http://mirrors.jenkins.io/war/latest/jenkins.war -o tmp/jenkins.war
+tmp/jenkins-war-$(JENKINS_VERSION).war: tmp
+	mvn dependency:copy -Dartifact=org.jenkins-ci.main:jenkins-war:$(JENKINS_VERSION):war -DoutputDirectory=tmp
+	touch tmp/jenkins-$(JENKINS_VERSION).war
 
-tmp/javax.activation.jar: tmp
-	curl -fsSL http://central.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar -o tmp/jaxb-api.jar
-	curl -fsSL http://central.maven.org/maven2/com/sun/xml/bind/jaxb-core/2.3.0.1/jaxb-core-2.3.0.1.jar -o tmp/jaxb-core.jar
-	curl -fsSL http://central.maven.org/maven2/com/sun/xml/bind/jaxb-impl/2.3.0.1/jaxb-impl-2.3.0.1.jar -o tmp/jaxb-impl.jar
-	curl -fsSL https://github.com/javaee/activation/releases/download/JAF-1_2_0/javax.activation.jar -o tmp/javax.activation.jar
+tmp/jaxb-api-$(JAXB_API_VERSION).jar: tmp
+	mvn dependency:copy -Dartifact=javax.xml.bind:jaxb-api:$(JAXB_API_VERSION) -DoutputDirectory=tmp
+	touch tmp/jaxb-api-$(JAXB_API_VERSION).jar
+
+tmp/jaxb-core-$(JAXB_VERSION).jar: tmp
+	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-core:$(JAXB_VERSION) -DoutputDirectory=tmp
+	touch tmp/jaxb-api-$(JAXB_API_VERSION).jar
+
+tmp/jaxb-impl-$(JAXB_VERSION).jar: tmp
+	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-impl:$(JAXB_VERSION) -DoutputDirectory=tmp
+	touch tmp/jaxb-impl-$(JAXB_API_VERSION).jar
+
+tmp/javax.activation-$(JAX_VERSION).jar: tmp
+	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAF_VERSION) -DoutputDirectory=tmp
+	touch tmp/javax.activation-$(JAX_VERSION).jar
 
 .PHONY: print-java-home
 print-java-home:
 	echo "Using JAVA_HOME for tests $(TEST_JDK_HOME)"
 
-.PHONY: demo-jdk8 print-java-home
-demo-jdk8:
+.PHONY: demo-jdk8
+demo-jdk8: tmp/jenkins-war-$(JENKINS_VERSION).war print-java-home
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli-0.0.3-SNAPSHOT.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
-	     -mvn $(shell which mvn) -war tmp/jenkins.war \
+	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
 	     -includePlugins $(PLUGIN_NAME)
 
 .PHONY: demo-jdk11
-demo-jdk11: tmp/javax.activation.jar tmp/jenkins.war print-java-home
-	# TODO Cleanup once the JAXB bundling issue is resolved.
+demo-jdk11: tmp/javax.activation-$(JAX_VERSION).jar tmp/jaxb-api-$(JAXB_API_VERSION).jar tmp/jenkins-war-$(JENKINS_VERSION).war tmp/jaxb-impl-$(JAXB_VERSION).jar tmp/jaxb-core-$(JAXB_VERSION).jar print-java-home
+	# TODO Cleanup when/if the JAXB bundling issue is resolved.
 	# https://issues.jenkins-ci.org/browse/JENKINS-52186
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli-0.0.3-SNAPSHOT.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
-	     -mvn $(shell which mvn) -war tmp/jenkins.war \
+	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
-	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api.jar:$(CURDIR)/tmp/javax.activation.jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl.jar:$(CURDIR)/tmp/jaxb-core.jar" \
+	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api-$(JAXB_API_VERSION).jar:$(CURDIR)/tmp/javax.activation-${JAF_VERSION}.jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl-$(JAXB_VERSION).jar:$(CURDIR)/tmp/jaxb-core-$(JAXB_VERSION).jar" \
 	     -includePlugins $(PLUGIN_NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 #Makefile
+JAVA11_HOME?=/Users/nenashev/Documents/tools/jdk-11/jdk-11.jdk/Contents/Home
+PLUGIN_NAME?=mailer
 
 .PHONY: all
 all: clean package docker
@@ -14,3 +16,27 @@ package:
 .PHONY: docker
 docker:
 	docker build -t jenkins/pct .
+
+tmp:
+	mkdir tmp
+
+tmp/jenkins.war: tmp
+	curl -fsSL http://mirrors.jenkins.io/war/latest/jenkins.war -o tmp/jenkins.war
+
+tmp/javax.activation.jar: tmp
+	curl -fsSL http://central.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar -o tmp/jaxb-api.jar
+	curl -fsSL http://central.maven.org/maven2/com/sun/xml/bind/jaxb-core/2.3.0.1/jaxb-core-2.3.0.1.jar -o tmp/jaxb-core.jar
+	curl -fsSL http://central.maven.org/maven2/com/sun/xml/bind/jaxb-impl/2.3.0.1/jaxb-impl-2.3.0.1.jar -o tmp/jaxb-impl.jar
+	curl -fsSL https://github.com/javaee/activation/releases/download/JAF-1_2_0/javax.activation.jar -o tmp/javax.activation.jar
+
+.PHONY: test-java11
+test-java11: tmp/javax.activation.jar tmp/jenkins.war
+	# TODO Cleanup once the JAXB bundling issue is resolved.
+	# https://issues.jenkins-ci.org/browse/JENKINS-52186
+	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli-0.0.3-SNAPSHOT.jar \
+	     -reportFile $(CURDIR)/out/pct-report.xml \
+	     -workDirectory $(CURDIR)/work -skipTestCache true \
+	     -mvn $(shell which mvn) -war tmp/jenkins.war \
+	     -testJDKHome $(JAVA11_HOME) \
+	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api.jar:$(CURDIR)/tmp/javax.activation.jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl.jar:$(CURDIR)/tmp/jaxb-core.jar" \
+	     -includePlugins $(PLUGIN_NAME) -localCheckoutDir /Users/nenashev/Documents/jenkins/test/jep-200/manual/jacoco-plugin

--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ You can run the CLI with the `-help` argument to get a full list of supported op
 
 :exclamation: For the moment testing more than one plugin at once requires plugins to be released, so for testing SNAPSHOTS you need to execute the last step for every plugin you want to test*
 
+### Running PCT with custom Java versions
+
+Plugin compat tester supports running Test Suites with a Java version different 
+from the one being used to run PCT and build the plugins.
+For example, such mode can be used to run tests with JDK11 while
+the plugin build flow is not adapted to it.
+
+Two options can be passed to PCT CLI for such purpose:
+
+* `testJDKHome` - A path to JDK HOME to be used for running tests in plugins
+* `testJavaArgs` - Java test arguments to be used for test runs.
+                   For JDK 11 this option may be used to pass modules and the classpath
+
+You can run the example by running the following command:
+
+    make demo-jdk11 -e TEST_JDK_HOME=${YOUR_JDK11_HOME}
+
+Full list of options for JDK11 can be found [here](./Makefile).
+
 ## Developer Info
 
 ### Debugging PCT in Docker

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -52,7 +52,7 @@ public class CliOptions {
 
     @CheckForNull
     @Parameter(names = "-testJDKHome",
-            description = "A Java HOME to be used for running tests in plugins.")
+            description = "A path to JDK HOME to be used for running tests in plugins.")
     private File testJDKHome = null;
 
     @CheckForNull

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -50,6 +50,16 @@ public class CliOptions {
             description = "A WAR file to scan for plugins rather than looking in the update center.")
     private File war = null;
 
+    @CheckForNull
+    @Parameter(names = "-testJDKHome",
+            description = "A Java HOME to be used for running tests in plugins.")
+    private File testJDKHome = null;
+
+    @CheckForNull
+    @Parameter(names = "-testJavaArgs",
+            description = "Java test arguments to be used for test runs.")
+    private String testJavaArgs = null;
+
     @Parameter(names = "-workDirectory", required = true,
             description = "Work directory where plugin sources will be checked out")
     private File workDirectory;
@@ -193,5 +203,15 @@ public class CliOptions {
 
     public boolean isPrintHelp() {
         return printHelp;
+    }
+
+    @CheckForNull
+    public File getTestJDKHome() {
+        return testJDKHome;
+    }
+
+    @CheckForNull
+    public String getTestJavaArgs() {
+        return testJavaArgs;
     }
 }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -128,6 +128,12 @@ public class PluginCompatTesterCli {
         if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());
         }
+        if(options.getTestJDKHome() != null) {
+            config.setTestJDKHome(options.getTestJDKHome());
+        }
+        if (options.getTestJavaArgs() != null && !options.getTestJavaArgs().isEmpty()) {
+            config.setTestJavaArgs(options.getTestJavaArgs());
+        }
 
         // Handle properties
         if (options.getMavenProperties() != null) {

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -273,6 +273,36 @@ public class PluginCompatTesterConfig {
                 throw new IOException("Extra Maven Properties File " + mavenPropertiesFile + " does not exist or not a File" );
             }
         }
+
+        // Read other explicit CLI arguments
+
+        // Override JDK if passed explicitly
+        if (testJDKHome != null) {
+            if (!testJDKHome.exists() || !testJDKHome.isDirectory()) {
+                throw new IOException("Wrong Test JDK Home passed as a parameter: " + testJDKHome);
+            }
+
+            if (res.containsKey("jvm")) {
+                System.out.println("WARNING: Maven properties already contain the 'jvm' argument. " +
+                        "Overriding the previous Test JDK home value '" + res.get("jvm") +
+                        "' by the explicit argument: " + testJDKHome);
+            } else {
+                System.out.println("Using custom Test JDK home: " + testJDKHome);
+            }
+            res.put("jvm", new File(testJDKHome, "bin/java").getAbsolutePath());
+        }
+
+        // Merge test Java args if needed
+        if (StringUtils.isNotBlank(testJavaArgs)) {
+            if (res.containsKey("argLine")) {
+                System.out.println("WARNING: Maven properties already contain the 'argLine' argument. " +
+                        "Merging value from properties and from the command line");
+                res.put("argLine", res.get("argLine") + " " + testJavaArgs);
+            } else {
+                res.put("argLine", testJavaArgs);
+            }
+        }
+
         return res;
     }
 

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -27,6 +27,7 @@ package org.jenkins.tools.test.model;
 
 import org.apache.commons.lang.StringUtils;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FileInputStream;
@@ -75,6 +76,15 @@ public class PluginCompatTesterConfig {
     private String parentVersion = null;
 
     private File war = null;
+
+    /**
+     * A Java HOME to be used for running tests in plugins.
+     */
+    @CheckForNull
+    private File testJDKHome = null;
+
+    @CheckForNull
+    private String testJavaArgs = null;
 
     private File externalMaven = null;
 
@@ -196,6 +206,16 @@ public class PluginCompatTesterConfig {
         return parentGroupId;
     }
 
+    @CheckForNull
+    public File getTestJDKHome() {
+        return testJDKHome;
+    }
+
+    @CheckForNull
+    public String getTestJavaArgs() {
+        return testJavaArgs;
+    }
+
     public String getParentArtifactId() {
         return parentArtifactId;
     }
@@ -303,6 +323,18 @@ public class PluginCompatTesterConfig {
     public void setHookPrefixes(List<String> hookPrefixes) {
         // Want to also process the default
         this.hookPrefixes.addAll(hookPrefixes);
+    }
+
+    /**
+     * Sets JDK Home for tests
+     * @param testJDKHome JDK home to be used. {@code null} for using defaul system one.
+     */
+    public void setTestJDKHome(@CheckForNull File testJDKHome) {
+        this.testJDKHome = testJDKHome;
+    }
+
+    public void setTestJavaArgs(@CheckForNull String testJavaArgs) {
+        this.testJavaArgs = testJavaArgs;
     }
 
     public File getLocalCheckoutDir() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -212,20 +212,6 @@ public class PluginCompatTester {
         mconfig.userProperties.put( "failIfNoTests", "false" );
         mconfig.userProperties.putAll(this.config.retrieveMavenProperties());
 
-        // Override JDK if passed explicitly
-        if (config.getTestJDKHome() != null) {
-            //TODO: move up
-            File jdkHome = config.getTestJDKHome();
-            if (!jdkHome.exists() || !jdkHome.isDirectory()) {
-                throw new IOException("Wrong Test JDK Home: " + jdkHome);
-            } else {
-                System.out.println("Using custom Test JDK, home=" + jdkHome);
-            }
-            mconfig.userProperties.put("jvm", new File(jdkHome, "bin/java").getAbsolutePath());
-        }
-        if (StringUtils.isNotBlank(config.getTestJavaArgs())) {
-            mconfig.userProperties.put("argLine", config.getTestJavaArgs());
-        }
 
 		SCMManagerFactory.getInstance().start();
         for(MavenCoordinates coreCoordinates : testedCores){

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.41</version>
+    <version>1.46</version>
   </parent>
 
   <groupId>org.jenkins-ci.tests</groupId>


### PR DESCRIPTION
This PR adds support of passing custom JDK home and JDK arguments to Maven Surefire Plugin in tests.

- [x] - Initial implementation
- [x] - Update documentation
- [x] - Cleanup makefile
- [x] - investigate potential argument collisions like `argLine`

https://issues.jenkins-ci.org/browse/JENKINS-54462

@jenkinsci/java11-support 
