### PR TITLE
[JENKINS-54766] Fix targets pre-requisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,17 @@
-/plugins-compat-tester/target
-/plugins-compat-tester/.settings
-/plugins-compat-tester/.classpath
-/plugins-compat-tester/.project
-/plugins-compat-tester/plugins-compat-tester (1).iml
-/plugins-compat-tester-cli/plugins-compat-tester-cli.iml
-plugins-compat-tester.iml
-target
-/plugins-compat-tester-cli/nbactions*.xml
-/plugins-compat-tester-cli/nb-configuration.xml
-reports
-/plugins-compat-tester-cli/dependency-reduced-pom.xml
+### Maven
+target/
+plugins-compat-tester-cli/dependency-reduced-pom.xml
+
+### IntelliJ IDEA
+.idea/
+*.ipr
 *.iml
+
+### Jenkins
 work/
 ^jenkins/
-.idea
-out
+
+### CLI
+out/
+tmp/
+reports/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV INSTALL_BUNDLED_SNAPSHOTS=true
 RUN apt-get -y update && apt-get install -y groovy && rm -rf /var/lib/apt/lists/*
 
 COPY src/main/docker/*.groovy /pct/scripts/
-COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tester-cli-*.jar /pct/pct-cli.jar
+COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar /pct/pct-cli.jar
 COPY src/main/docker/run-pct.sh /usr/local/bin/run-pct
 COPY src/main/docker/pct-default-settings.xml /pct/default-m2-settings.xml
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PLUGIN_NAME?=mailer
 JENKINS_VERSION=2.150
 JAXB_API_VERSION=2.3.0
 JAXB_VERSION=2.3.0.1
-JAF_VERSION=1.2.0
+JAX_VERSION=1.2.0
 
 .PHONY: all
 all: clean package docker
@@ -36,14 +36,14 @@ tmp/jaxb-api-$(JAXB_API_VERSION).jar: tmp
 
 tmp/jaxb-core-$(JAXB_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-core:$(JAXB_VERSION) -DoutputDirectory=tmp
-	touch tmp/jaxb-api-$(JAXB_API_VERSION).jar
+	touch tmp/jaxb-core-$(JAXB_VERSION).jar
 
 tmp/jaxb-impl-$(JAXB_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-impl:$(JAXB_VERSION) -DoutputDirectory=tmp
 	touch tmp/jaxb-impl-$(JAXB_VERSION).jar
 
 tmp/javax.activation-$(JAX_VERSION).jar: tmp
-	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAF_VERSION) -DoutputDirectory=tmp
+	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAX_VERSION) -DoutputDirectory=tmp
 	touch tmp/javax.activation-$(JAX_VERSION).jar
 
 .PHONY: print-java-home
@@ -68,5 +68,5 @@ demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/j
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
 	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
-	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api-$(JAXB_API_VERSION).jar:$(CURDIR)/tmp/javax.activation-${JAF_VERSION}.jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl-$(JAXB_VERSION).jar:$(CURDIR)/tmp/jaxb-core-$(JAXB_VERSION).jar" \
+	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api-$(JAXB_API_VERSION).jar:$(CURDIR)/tmp/javax.activation-${JAX_VERSION}.jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl-$(JAXB_VERSION).jar:$(CURDIR)/tmp/jaxb-core-$(JAXB_VERSION).jar" \
 	     -includePlugins $(PLUGIN_NAME)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PLUGIN_NAME?=mailer
 JENKINS_VERSION=2.150
 JAXB_API_VERSION=2.3.0
 JAXB_VERSION=2.3.0.1
-JAX_VERSION=1.2.0
+JAF_VERSION=1.2.0
 
 .PHONY: all
 all: clean package docker
@@ -42,9 +42,9 @@ tmp/jaxb-impl-$(JAXB_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-impl:$(JAXB_VERSION) -DoutputDirectory=tmp
 	touch tmp/jaxb-impl-$(JAXB_VERSION).jar
 
-tmp/javax.activation-$(JAX_VERSION).jar: tmp
-	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAX_VERSION) -DoutputDirectory=tmp
-	touch tmp/javax.activation-$(JAX_VERSION).jar
+tmp/javax.activation-$(JAF_VERSION).jar: tmp
+	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAF_VERSION) -DoutputDirectory=tmp
+	touch tmp/javax.activation-$(JAF_VERSION).jar
 
 .PHONY: print-java-home
 print-java-home:
@@ -60,7 +60,7 @@ demo-jdk8: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/je
 	     -includePlugins $(PLUGIN_NAME)
 
 .PHONY: demo-jdk11
-demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/javax.activation-$(JAX_VERSION).jar tmp/jaxb-api-$(JAXB_API_VERSION).jar tmp/jenkins-war-$(JENKINS_VERSION).war tmp/jaxb-impl-$(JAXB_VERSION).jar tmp/jaxb-core-$(JAXB_VERSION).jar print-java-home
+demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/javax.activation-$(JAF_VERSION).jar tmp/jaxb-api-$(JAXB_API_VERSION).jar tmp/jenkins-war-$(JENKINS_VERSION).war tmp/jaxb-impl-$(JAXB_VERSION).jar tmp/jaxb-core-$(JAXB_VERSION).jar print-java-home
 	# TODO Cleanup when/if the JAXB bundling issue is resolved.
 	# https://issues.jenkins-ci.org/browse/JENKINS-52186
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
@@ -68,5 +68,5 @@ demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/j
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
 	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
-	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api-$(JAXB_API_VERSION).jar:$(CURDIR)/tmp/javax.activation-${JAX_VERSION}.jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl-$(JAXB_VERSION).jar:$(CURDIR)/tmp/jaxb-core-$(JAXB_VERSION).jar" \
+	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api-$(JAXB_API_VERSION).jar:$(CURDIR)/tmp/javax.activation-$(JAF_VERSION).jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl-$(JAXB_VERSION).jar:$(CURDIR)/tmp/jaxb-core-$(JAXB_VERSION).jar" \
 	     -includePlugins $(PLUGIN_NAME)

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,10 @@ all: clean package docker
 clean:
 	mvn clean
 
+plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar:
+	mvn verify
 .PHONY: package
-package:
-	mvn package verify
+package: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar
 
 .PHONY: docker
 docker:
@@ -39,7 +40,7 @@ tmp/jaxb-core-$(JAXB_VERSION).jar: tmp
 
 tmp/jaxb-impl-$(JAXB_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-impl:$(JAXB_VERSION) -DoutputDirectory=tmp
-	touch tmp/jaxb-impl-$(JAXB_API_VERSION).jar
+	touch tmp/jaxb-impl-$(JAXB_VERSION).jar
 
 tmp/javax.activation-$(JAX_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAF_VERSION) -DoutputDirectory=tmp
@@ -50,8 +51,8 @@ print-java-home:
 	echo "Using JAVA_HOME for tests $(TEST_JDK_HOME)"
 
 .PHONY: demo-jdk8
-demo-jdk8: tmp/jenkins-war-$(JENKINS_VERSION).war print-java-home
-	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli-0.0.3-SNAPSHOT.jar \
+demo-jdk8: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/jenkins-war-$(JENKINS_VERSION).war print-java-home
+	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
 	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
@@ -59,10 +60,10 @@ demo-jdk8: tmp/jenkins-war-$(JENKINS_VERSION).war print-java-home
 	     -includePlugins $(PLUGIN_NAME)
 
 .PHONY: demo-jdk11
-demo-jdk11: tmp/javax.activation-$(JAX_VERSION).jar tmp/jaxb-api-$(JAXB_API_VERSION).jar tmp/jenkins-war-$(JENKINS_VERSION).war tmp/jaxb-impl-$(JAXB_VERSION).jar tmp/jaxb-core-$(JAXB_VERSION).jar print-java-home
+demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/javax.activation-$(JAX_VERSION).jar tmp/jaxb-api-$(JAXB_API_VERSION).jar tmp/jenkins-war-$(JENKINS_VERSION).war tmp/jaxb-impl-$(JAXB_VERSION).jar tmp/jaxb-core-$(JAXB_VERSION).jar print-java-home
 	# TODO Cleanup when/if the JAXB bundling issue is resolved.
 	# https://issues.jenkins-ci.org/browse/JENKINS-52186
-	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli-0.0.3-SNAPSHOT.jar \
+	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
 	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \

--- a/plugins-compat-tester-cli/pom.xml
+++ b/plugins-compat-tester-cli/pom.xml
@@ -13,6 +13,7 @@
   <description>Jenkins Plugin Compatibility Tester (PCT) against latest released version</description>
   
   <build>
+    <finalName>${project.artifactId}</finalName>
 	  <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Make sure the cli jar is built before trying to use it.
Remove version from cli jar name to ease its usage.

@jenkinsci/java11-support 