### PR TITLE
[JENKINS-54674] Add Java 11 into PCT docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,12 @@ ENV INSTALL_BUNDLED_SNAPSHOTS=true
 
 RUN apt-get -y update && apt-get install -y groovy && rm -rf /var/lib/apt/lists/*
 
+RUN curl -L --show-error https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz --output openjdk.tar.gz && \
+    echo "7a6bb980b9c91c478421f865087ad2d69086a0583aeeb9e69204785e8e97dcfd  openjdk.tar.gz" | sha256sum -c && \
+    tar xvzf openjdk.tar.gz && \
+    mv jdk-11.0.1/ /usr/lib/jvm/java-11-opendjdk-amd64 && \
+    rm openjdk.tar.gz
+
 COPY src/main/docker/*.groovy /pct/scripts/
 COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tester-cli-*.jar /pct/pct-cli.jar
 COPY src/main/docker/run-pct.sh /usr/local/bin/run-pct

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,15 @@ COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tes
 COPY src/main/docker/run-pct.sh /usr/local/bin/run-pct
 COPY src/main/docker/pct-default-settings.xml /pct/default-m2-settings.xml
 
+ARG JAXB_API_VERSION="2.3.0"
+ARG JAXB_VERSION="2.3.0.1"
+ARG JAF_VERSION="1.2.0"
+RUN mkdir -p /pct/jdk11-libs && \
+    curl -L http://repo.jenkins-ci.org/public/javax/xml/bind/jaxb-api/${JAXB_API_VERSION}/jaxb-api-${JAXB_API_VERSION}.jar -o /pct/jdk11-libs/jaxb-api.jar && \
+    curl -L http://repo.jenkins-ci.org/public/com/sun/xml/bind/jaxb-core/${JAXB_VERSION}/jaxb-core-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-core.jar && \
+    curl -L http://repo.jenkins-ci.org/public/com/sun/xml/bind/jaxb-impl/${JAXB_VERSION}/jaxb-impl-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-impl.jar && \
+    curl -L http://repo.jenkins-ci.org/public/com/sun/activation/${JAF_VERSION}/javax.activation-${JAF_VERSION}.jar -o /pct/jdk11-libs/javax.activation.jar
+
 EXPOSE 5005
 
 VOLUME /pct/plugin-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /pct/src/
 RUN mvn clean install -DskipTests
 
 FROM maven:3.6.0-jdk-8
-MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
+LABEL Maintainer="Oleg Nenashev <o.v.nenashev@gmail.com>"
 LABEL Description="Base image for running Jenkins Plugin Compat Tester (PCT) against custom plugins and Jenkins cores" Vendor="Jenkins project"
 ENV JENKINS_WAR_PATH=/pct/jenkins.war
 ENV PCT_OUTPUT_DIR=/pct/out

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,16 @@ COPY src/main/docker/pct-default-settings.xml /pct/default-m2-settings.xml
 ARG JAXB_API_VERSION="2.3.0"
 ARG JAXB_VERSION="2.3.0.1"
 ARG JAF_VERSION="1.2.0"
+# Checksum for JavaBean Activation Framework lib is not matching the Maven Central one. 
 RUN mkdir -p /pct/jdk11-libs && \
-    curl -L http://repo.jenkins-ci.org/public/javax/xml/bind/jaxb-api/${JAXB_API_VERSION}/jaxb-api-${JAXB_API_VERSION}.jar -o /pct/jdk11-libs/jaxb-api.jar && \
-    curl -L http://repo.jenkins-ci.org/public/com/sun/xml/bind/jaxb-core/${JAXB_VERSION}/jaxb-core-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-core.jar && \
-    curl -L http://repo.jenkins-ci.org/public/com/sun/xml/bind/jaxb-impl/${JAXB_VERSION}/jaxb-impl-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-impl.jar && \
-    curl -L http://repo.jenkins-ci.org/public/com/sun/activation/${JAF_VERSION}/javax.activation-${JAF_VERSION}.jar -o /pct/jdk11-libs/javax.activation.jar
+    curl -LSs https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/${JAXB_API_VERSION}/jaxb-api-${JAXB_API_VERSION}.jar -o /pct/jdk11-libs/jaxb-api.jar && \
+    curl -LSs https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-core/${JAXB_VERSION}/jaxb-core-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-core.jar && \
+    curl -LSs https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-impl/${JAXB_VERSION}/jaxb-impl-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-impl.jar && \
+    curl -LSs https://repo1.maven.org/maven2/com/sun/activation/${JAF_VERSION}/javax.activation-${JAF_VERSION}.jar -o /pct/jdk11-libs/javax.activation.jar && \
+    echo "99f802e0cb3e953ba3d6e698795c4aeb98d37c48  /pct/jdk11-libs/jaxb-api.jar\n\
+23574ca124d0a694721ce3ef13cd720095f18fdd  /pct/jdk11-libs/jaxb-core.jar\n\
+2e979dabb3e5e74a0686115075956391a14dece8  /pct/jdk11-libs/jaxb-impl.jar\n\
+84e709cb8271e5e7ff7da61528d52d36298aa733  /pct/jdk11-libs/javax.activation.jar" | sha1sum -c
 
 EXPOSE 5005
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ You can run the example by running the following command:
 
 Full list of options for JDK11 can be found [here](./Makefile).
 
+When using the docker image, it is possible to use `JDK_VERSION` variable to select 
+the version to use. The version needs to be bundled in the docker image. By specifying 
+`11`, the modules and jaxb libraries are also added to the command line. 
+
 ## Developer Info
 
 ### Debugging PCT in Docker

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -121,4 +121,13 @@ mkdir -p "${PCT_TMP}/work"
 mkdir -p "${PCT_OUTPUT_DIR}"
 
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710
-exec java ${JAVA_OPTS} ${extra_java_opts[@]} -jar /pct/pct-cli.jar -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} -skipTestCache true -localCheckoutDir "${PCT_TMP}/localCheckoutDir/${ARTIFACT_ID}" -includePlugins "${ARTIFACT_ID}" -mvn "/usr/bin/mvn" -m2SettingsFile "${MVN_SETTINGS_FILE}" "$@"
+exec java ${JAVA_OPTS} ${extra_java_opts[@]} \
+  -jar /pct/pct-cli.jar \
+  -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
+  -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
+  -skipTestCache true \
+  -localCheckoutDir "${PCT_TMP}/localCheckoutDir/${ARTIFACT_ID}" \
+  -includePlugins "${ARTIFACT_ID}" \
+  -mvn "/usr/bin/mvn" \
+  -m2SettingsFile "${MVN_SETTINGS_FILE}" \
+  "$@"

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -123,9 +123,9 @@ mkdir -p "${PCT_OUTPUT_DIR}"
 ###
 # Determine if we test the plugin against another JDK
 ###
-if [[ "${JDK11}" ]] ; then
-  TEST_JDK_HOME="/usr/lib/jvm/java-11-opendjdk-amd64"
-  TEST_JAVA_ARGS="-p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar"
+TEST_JDK_HOME=${:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-opendjdk-amd64"}
+if [[ "${JDK_VERSION}" = "11" ]] ; then
+  TEST_JAVA_ARGS="${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar"
 fi
 
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710
@@ -138,6 +138,6 @@ exec java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -includePlugins "${ARTIFACT_ID}" \
   -mvn "/usr/bin/mvn" \
   -m2SettingsFile "${MVN_SETTINGS_FILE}" \
-  -testJDKHome "${TEST_JDK_HOME:-$JAVA_HOME}" \
+  -testJDKHome "${TEST_JDK_HOME}" \
   -testJavaArgs "${TEST_JAVA_ARGS:-}" \
   "$@"

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -125,6 +125,7 @@ mkdir -p "${PCT_OUTPUT_DIR}"
 ###
 TEST_JDK_HOME=${:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-opendjdk-amd64"}
 if [[ "${JDK_VERSION}" = "11" ]] ; then
+  echo "JDK_VERSION detected is 11. Adding JAXB and modules to the command lines."
   TEST_JAVA_ARGS="${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar"
 fi
 

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -120,6 +120,14 @@ mv "${TMP_CHECKOUT_DIR}" "${PCT_TMP}/localCheckoutDir/${ARTIFACT_ID}"
 mkdir -p "${PCT_TMP}/work"
 mkdir -p "${PCT_OUTPUT_DIR}"
 
+###
+# Determine if we test the plugin against another JDK
+###
+if [[ "${JDK11}" ]] ; then
+  TEST_JDK_HOME="/usr/lib/jvm/java-11-opendjdk-amd64"
+  TEST_JAVA_ARGS="-p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar"
+fi
+
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710
 exec java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -jar /pct/pct-cli.jar \
@@ -130,4 +138,6 @@ exec java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -includePlugins "${ARTIFACT_ID}" \
   -mvn "/usr/bin/mvn" \
   -m2SettingsFile "${MVN_SETTINGS_FILE}" \
+  -testJDKHome "${TEST_JDK_HOME:-$JAVA_HOME}" \
+  -testJavaArgs "${TEST_JAVA_ARGS:-}" \
   "$@"


### PR DESCRIPTION
- [x] Add openjdk binary to the docker image
- [x] Add JAXB libraries to docker image
- [x] Add activator to use alternate JVM to run PCT tests

@jenkinsci/java11-support @raul-arabaolaza 