### PR TITLE
[JENKINS-54862] Add option to override dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Because of this, you might have to provide on the same parameter the new version
 Plugin Compat Tester supports overriding the plugin dependency version. 
 For example, we might want to validate that a newer version of a plugin is not breaking the latest version of the plugin we want to test.
 
-To do that, the option `overridePlugins` can be passed to PCT CLI.
+To do that, the option `overridenPlugins` can be passed to PCT CLI.
 The format of the value **must** be `PLUGIN_NAME=PLUGIN_VERSION`.
 
 So, running
@@ -125,7 +125,7 @@ So, running
 ```
 java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
   [...]
-  -overridePlugins display-url-api=2.3.0
+  -overridenPlugins display-url-api=2.3.0
   -includePlugins mailer
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ the version to use. The version needs to be bundled in the docker image. By spec
 
 ### Running PCT with different version of dependencies
 
+IMPORTANT: At this moment, the replacement of a dependency will not update the transitive dependencies.
+Because of this, you might have to provide on the same parameter the new versions of the transitive dependencies.
+
 Plugin Compat Tester supports overriding the plugin dependency version. 
 For example, we might want to validate that a newer version of a plugin is not breaking the latest version of the plugin we want to test.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ When using the docker image, it is possible to use `JDK_VERSION` variable to sel
 the version to use. The version needs to be bundled in the docker image. By specifying 
 `11`, the modules and jaxb libraries are also added to the command line. 
 
+### Running PCT with different version of dependencies
+
+Plugin Compat Tester supports overriding the plugin dependency version. 
+For example, we might want to validate that a newer version of a plugin is not breaking the latest version of the plugin we want to test.
+
+To do that, the option `overridePlugins` can be passed to PCT CLI.
+The format of the value **must** be `PLUGIN_NAME=PLUGIN_VERSION`.
+
+So, running
+
+```
+java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
+  [...]
+  -overridePlugins display-url-api=2.3.0
+  -includePlugins mailer
+```
+
+will run the PCT on the `mailer` plugin, but replacing the `display-url-api` dependency of Mailer (which is `1.0`) with the version `2.3.0`.
+
 ## Developer Info
 
 ### Debugging PCT in Docker

--- a/plugins-compat-tester-cli/pom.xml
+++ b/plugins-compat-tester-cli/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.17</version>
+        <version>1.71</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -30,7 +30,7 @@ import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import hudson.util.VersionNumber;
-import org.jenkins.tools.test.model.Plugin;
+import org.jenkins.tools.test.model.PCTPlugin;
 import org.jenkins.tools.test.model.TestStatus;
 
 import javax.annotation.CheckForNull;
@@ -134,7 +134,7 @@ public class CliOptions {
 
     @Parameter(names = "-overridePlugins", description = "List of plugins to use to test a plugin in place of the normal dependencies." +
           "Format: 'PLUGIN_NAME=PLUGIN_VERSION", converter = PluginConverter.class, validateWith = PluginValidator.class)
-    private List<Plugin> overridePlugins;
+    private List<PCTPlugin> overridenPlugins;
 
     public String getUpdateCenterUrl() {
         return updateCenterUrl;
@@ -225,15 +225,15 @@ public class CliOptions {
     }
 
     @CheckForNull
-    public List<Plugin> getOverridePlugins() {
-        return overridePlugins;
+    public List<PCTPlugin> getOverridenPlugins() {
+        return overridenPlugins;
     }
 
-    public static class PluginConverter implements IStringConverter<Plugin> {
+    public static class PluginConverter implements IStringConverter<PCTPlugin> {
         @Override
-        public Plugin convert(String s) {
+        public PCTPlugin convert(String s) {
             String[] details = s.split("=");
-            return new Plugin(details[0], new VersionNumber(details[1]));
+            return new PCTPlugin(details[0], new VersionNumber(details[1]));
         }
     }
 

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -25,7 +25,10 @@
  */
 package org.jenkins.tools.test;
 
+import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
+import hudson.util.VersionNumber;
+import org.jenkins.tools.test.model.Plugin;
 import org.jenkins.tools.test.model.TestStatus;
 
 import javax.annotation.CheckForNull;
@@ -127,6 +130,9 @@ public class CliOptions {
     @Parameter(names="-help", description = "Print this help message")
     private boolean printHelp;
 
+    @Parameter(names = "-overridePlugins", description = "List of plugins to use to test a plugin in place of the normal dependencies", converter = PluginConverter.class)
+    private List<Plugin> overridePlugins;
+
     public String getUpdateCenterUrl() {
         return updateCenterUrl;
     }
@@ -213,5 +219,18 @@ public class CliOptions {
     @CheckForNull
     public String getTestJavaArgs() {
         return testJavaArgs;
+    }
+
+    public List<Plugin> getOverridePlugins() {
+        return overridePlugins;
+    }
+
+    public static class PluginConverter implements IStringConverter<Plugin> {
+        @Override
+        public Plugin convert(String s) {
+            String[] details = s.split("=");
+            assert details.length == 2;
+            return new Plugin(details[0], new VersionNumber(details[1]));
+        }
     }
 }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -25,8 +25,10 @@
  */
 package org.jenkins.tools.test;
 
+import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import hudson.util.VersionNumber;
 import org.jenkins.tools.test.model.Plugin;
 import org.jenkins.tools.test.model.TestStatus;
@@ -130,7 +132,8 @@ public class CliOptions {
     @Parameter(names="-help", description = "Print this help message")
     private boolean printHelp;
 
-    @Parameter(names = "-overridePlugins", description = "List of plugins to use to test a plugin in place of the normal dependencies", converter = PluginConverter.class)
+    @Parameter(names = "-overridePlugins", description = "List of plugins to use to test a plugin in place of the normal dependencies." +
+          "Format: 'PLUGIN_NAME=PLUGIN_VERSION", converter = PluginConverter.class, validateWith = PluginValidator.class)
     private List<Plugin> overridePlugins;
 
     public String getUpdateCenterUrl() {
@@ -229,8 +232,17 @@ public class CliOptions {
         @Override
         public Plugin convert(String s) {
             String[] details = s.split("=");
-            assert details.length == 2;
             return new Plugin(details[0], new VersionNumber(details[1]));
+        }
+    }
+
+    public static class PluginValidator implements IParameterValidator {
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            final String[] split = value.split("=");
+            if (split.length != 2) {
+                throw new ParameterException(name + " must be formatted as NAME=VERSION");
+            }
         }
     }
 }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -239,9 +239,11 @@ public class CliOptions {
     public static class PluginValidator implements IParameterValidator {
         @Override
         public void validate(String name, String value) throws ParameterException {
-            final String[] split = value.split("=");
-            if (split.length != 2) {
-                throw new ParameterException(name + " must be formatted as NAME=VERSION");
+            for (String s : value.split(",")) {
+                final String[] split = s.split("=");
+                if (split.length != 2) {
+                    throw new ParameterException(name + " must be formatted as NAME=VERSION");
+                }
             }
         }
     }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -224,6 +224,7 @@ public class CliOptions {
         return testJavaArgs;
     }
 
+    @CheckForNull
     public List<Plugin> getOverridePlugins() {
         return overridePlugins;
     }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -132,7 +132,7 @@ public class CliOptions {
     @Parameter(names="-help", description = "Print this help message")
     private boolean printHelp;
 
-    @Parameter(names = "-overridePlugins", description = "List of plugins to use to test a plugin in place of the normal dependencies." +
+    @Parameter(names = "-overridenPlugins", description = "List of plugins to use to test a plugin in place of the normal dependencies." +
           "Format: 'PLUGIN_NAME=PLUGIN_VERSION", converter = PluginConverter.class, validateWith = PluginValidator.class)
     private List<PCTPlugin> overridenPlugins;
 

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -135,8 +135,8 @@ public class PluginCompatTesterCli {
             config.setTestJavaArgs(options.getTestJavaArgs());
         }
 
-        if(options.getOverridePlugins() != null && !options.getOverridePlugins().isEmpty()) {
-            config.setOverridePlugins(options.getOverridePlugins());
+        if(options.getOverridenPlugins() != null && !options.getOverridenPlugins().isEmpty()) {
+            config.setOverridenPlugins(options.getOverridenPlugins());
         }
 
         // Handle properties

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -135,6 +135,10 @@ public class PluginCompatTesterCli {
             config.setTestJavaArgs(options.getTestJavaArgs());
         }
 
+        if(options.getOverridePlugins() != null && !options.getOverridePlugins().isEmpty()) {
+            config.setOverridePlugins(options.getOverridePlugins());
+        }
+
         // Handle properties
         if (options.getMavenProperties() != null) {
             String[] split = options.getMavenProperties().split("\\s*:\\s*");

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PCTPlugin.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PCTPlugin.java
@@ -2,11 +2,11 @@ package org.jenkins.tools.test.model;
 
 import hudson.util.VersionNumber;
 
-public class Plugin {
+public class PCTPlugin {
     private String name;
     private VersionNumber version;
 
-    public Plugin(String name, VersionNumber version) {
+    public PCTPlugin(String name, VersionNumber version) {
         this.name = name;
         this.version = version;
     }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/Plugin.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/Plugin.java
@@ -1,0 +1,21 @@
+package org.jenkins.tools.test.model;
+
+import hudson.util.VersionNumber;
+
+public class Plugin {
+    private String name;
+    private VersionNumber version;
+
+    public Plugin(String name, VersionNumber version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public VersionNumber getVersion() {
+        return version;
+    }
+}

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -381,6 +381,7 @@ public class PluginCompatTesterConfig {
         this.overridePlugins = overridePlugins;
     }
 
+    @CheckForNull
     public List<Plugin> getOverridePlugins() {
         return overridePlugins;
     }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -128,7 +128,7 @@ public class PluginCompatTesterConfig {
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
     private File localCheckoutDir;
 
-    private List<Plugin> overridePlugins;
+    private List<PCTPlugin> overridenPlugins;
 
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
@@ -377,12 +377,12 @@ public class PluginCompatTesterConfig {
         this.localCheckoutDir = new File(localCheckoutDir);
     }
 
-    public void setOverridePlugins(List<Plugin> overridePlugins) {
-        this.overridePlugins = overridePlugins;
+    public void setOverridenPlugins(List<PCTPlugin> overridePlugins) {
+        this.overridenPlugins = overridenPlugins;
     }
 
     @CheckForNull
-    public List<Plugin> getOverridePlugins() {
-        return overridePlugins;
+    public List<PCTPlugin> getOverridenPlugins() {
+        return overridenPlugins;
     }
 }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -128,6 +128,8 @@ public class PluginCompatTesterConfig {
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
     private File localCheckoutDir;
 
+    private List<Plugin> overridePlugins;
+
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
                 workDirectory, reportFile, m2SettingsFile);
@@ -373,5 +375,13 @@ public class PluginCompatTesterConfig {
 
     public void setLocalCheckoutDir(String localCheckoutDir) {
         this.localCheckoutDir = new File(localCheckoutDir);
+    }
+
+    public void setOverridePlugins(List<Plugin> overridePlugins) {
+        this.overridePlugins = overridePlugins;
+    }
+
+    public List<Plugin> getOverridePlugins() {
+        return overridePlugins;
     }
 }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -128,7 +128,7 @@ public class PluginCompatTesterConfig {
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
     private File localCheckoutDir;
 
-    private List<PCTPlugin> overridenPlugins;
+    private List<PCTPlugin> overridenPlugins = new ArrayList<>();
 
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
@@ -381,7 +381,6 @@ public class PluginCompatTesterConfig {
         this.overridenPlugins = overridenPlugins;
     }
 
-    @CheckForNull
     public List<PCTPlugin> getOverridenPlugins() {
         return overridenPlugins;
     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -742,10 +742,12 @@ public class PluginCompatTester {
             Map<String,VersionNumber> toReplace = new HashMap<String,VersionNumber>();
             Map<String,VersionNumber> toAddTest = new HashMap<String,VersionNumber>();
             Map<String,VersionNumber> toReplaceTest = new HashMap<String,VersionNumber>();
-            overridePlugins.forEach(plugin -> {
-                toReplace.put(plugin.getName(), plugin.getVersion());
-                toReplaceTest.put(plugin.getName(), plugin.getVersion());
-            });
+            if (overridePlugins != null) {
+                overridePlugins.forEach(plugin -> {
+                    toReplace.put(plugin.getName(), plugin.getVersion());
+                    toReplaceTest.put(plugin.getName(), plugin.getVersion());
+                });
+            }
 
             for (String split : splits) {
                 String[] pieces = split.split(" ");


### PR DESCRIPTION
By passing `-overridePlugins` option (multiple times), we can change the dependencies
of the plugin we are validating.

@jenkinsci/java11-support 