### PR TITLE
Update to parent pom:1.50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.46</version>
+    <version>1.50</version>
   </parent>
 
   <groupId>org.jenkins-ci.tests</groupId>


### PR DESCRIPTION
My initial intent was to test the 1.51-SNAPSHOT upcoming from https://github.com/jenkinsci/pom/pull/37, but as we're not yet on current last 1.50 here, I'm filing to check the bump would work fine first.

Loosely related to @jenkinsci/java11-support (given bumping plugins gives IMO a better chance to get upstream maven plugins fixes for Java 11)