### PR TITLE
[JENKINS-55097/JENKINS-54674] - Fixes towards running Java 11 PCT in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.idea
+target
+**/target
+out
+reports
+work
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get -y update && apt-get install -y groovy && rm -rf /var/lib/apt/lists/
 RUN curl -L --show-error https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz --output openjdk.tar.gz && \
     echo "7a6bb980b9c91c478421f865087ad2d69086a0583aeeb9e69204785e8e97dcfd  openjdk.tar.gz" | sha256sum -c && \
     tar xvzf openjdk.tar.gz && \
-    mv jdk-11.0.1/ /usr/lib/jvm/java-11-opendjdk-amd64 && \
+    mv jdk-11.0.1/ /usr/lib/jvm/java-11-openjdk-amd64 && \
     rm openjdk.tar.gz
 
 COPY src/main/docker/*.groovy /pct/scripts/

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -123,7 +123,7 @@ mkdir -p "${PCT_OUTPUT_DIR}"
 ###
 # Determine if we test the plugin against another JDK
 ###
-TEST_JDK_HOME=${TEST_JAVA_ARGS:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-opendjdk-amd64"}
+TEST_JDK_HOME=${TEST_JAVA_ARGS:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-openjdk-amd64"}
 if [[ "${JDK_VERSION}" = "11" ]] ; then
   echo "JDK_VERSION detected is 11. Adding JAXB and modules to the command lines."
   TEST_JAVA_ARGS="${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true"

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -126,7 +126,9 @@ mkdir -p "${PCT_OUTPUT_DIR}"
 TEST_JDK_HOME=${TEST_JAVA_ARGS:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-opendjdk-amd64"}
 if [[ "${JDK_VERSION}" = "11" ]] ; then
   echo "JDK_VERSION detected is 11. Adding JAXB and modules to the command lines."
-  TEST_JAVA_ARGS="${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar"
+  TEST_JAVA_ARGS="${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true"
+else
+  TEST_JAVA_ARGS="${TEST_JAVA_ARGS:-} -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true"
 fi
 
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710


### PR DESCRIPTION
- [x] - Workaround the SUREFIRE-1588 issue in the PCT Docker Images (JENKINS-55097)
- [x] - Fix regression for Java 8 in Docker packaging caused by [JENKINS-54674](https://issues.jenkins-ci.org/browse/JENKINS-54674)
- [x] - Speedup the build of Docker images in the local dev environment

## Context for JENKINS-55097

https://issues.jenkins-ci.org/browse/JENKINS-55097

Current Docker images do not pass the `-Djdk.net.URLClassPath.disableClassPathURLCheck=true`, which was used as a workaround for Plugin POM by @jglick in https://github.com/jenkinsci/plugin-pom/pull/131 . So for Java 8 the recent PCT Docker image can only build tests with Plugin POM 3.28+ 

For Java 11 it was even worse, because the JVM override was not passing `-Xmx768M -Djava.awt.headless=true`, so the heavy tests would just fail there.

Ideally we need to offer a way in PCT to gracefully merge `-argLine` from Plugin POM and from CLI options, but here I just put the current values from Plugin POM to apply a hotfix.

CC @jenkinsci/java11-support @alecharp @raul-arabaolaza 
