### PR TITLE
[JENKINS-55144] - Introduce new "-failOnError" option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ print-java-home:
 demo-jdk8: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/jenkins-war-$(JENKINS_VERSION).war print-java-home
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
+	     -failOnError \
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
 	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
@@ -65,6 +66,7 @@ demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/j
 	# https://issues.jenkins-ci.org/browse/JENKINS-52186
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
+	     -failOnError \
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
 	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli-${PCT_VERSI
   -includePlugins ${PLUGIN_ARTIFACT_ID} \
   -war jenkins.war -localCheckoutDir ${PLUGIN_SRC} \
   -skipTestCache true \
+  -failOnError \
   -mvn ${PATH_TO_MAVEN}
 ```
 

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -127,6 +127,9 @@ public class CliOptions {
     @Parameter(names="-help", description = "Print this help message")
     private boolean printHelp;
 
+    @Parameter(names="-failOnError", description = "Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code")
+    private boolean failOnError;
+
     public String getUpdateCenterUrl() {
         return updateCenterUrl;
     }
@@ -213,5 +216,9 @@ public class CliOptions {
     @CheckForNull
     public String getTestJavaArgs() {
         return testJavaArgs;
+    }
+
+    public boolean isFailOnError() {
+        return failOnError;
     }
 }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -134,6 +134,10 @@ public class PluginCompatTesterCli {
         if (options.getTestJavaArgs() != null && !options.getTestJavaArgs().isEmpty()) {
             config.setTestJavaArgs(options.getTestJavaArgs());
         }
+        if (options.isFailOnError()) {
+            //TODO: also interpolate it for the case when a single plugin passed?
+            config.setFailOnError(true);
+        }
 
         // Handle properties
         if (options.getMavenProperties() != null) {

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -128,6 +128,9 @@ public class PluginCompatTesterConfig {
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
     private File localCheckoutDir;
 
+    // Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code
+    private boolean failOnError;
+
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
                 workDirectory, reportFile, m2SettingsFile);
@@ -373,5 +376,13 @@ public class PluginCompatTesterConfig {
 
     public void setLocalCheckoutDir(String localCheckoutDir) {
         this.localCheckoutDir = new File(localCheckoutDir);
+    }
+
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -27,6 +27,7 @@ package org.jenkins.tools.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import hudson.AbortException;
 import hudson.Functions;
 import hudson.maven.MavenEmbedderException;
 import hudson.model.UpdateSite;
@@ -94,6 +95,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -212,9 +214,9 @@ public class PluginCompatTester {
         mconfig.userProperties.put( "failIfNoTests", "false" );
         mconfig.userProperties.putAll(this.config.retrieveMavenProperties());
 
-
+        boolean failed = false;
 		SCMManagerFactory.getInstance().start();
-        for(MavenCoordinates coreCoordinates : testedCores){
+        ROOT_CYCLE: for(MavenCoordinates coreCoordinates : testedCores){
             System.out.println("Starting plugin tests on core coordinates : "+coreCoordinates.toString());
             for (Plugin plugin : pluginsToCheck.values()) {
                 if(config.getIncludePlugins()==null || config.getIncludePlugins().contains(plugin.name.toLowerCase())){
@@ -317,6 +319,13 @@ public class PluginCompatTester {
                         }
                         report.save(config.reportFile);
                     }
+
+                    if (status != TestStatus.SUCCESS) {
+                        failed = true;
+                        if (config.isFailOnError()) {
+                            break ROOT_CYCLE;
+                        }
+                    }
                 } else {
                     System.out.println("Plugin "+plugin.name+" not in included plugins => test skipped !");
                 }
@@ -328,6 +337,10 @@ public class PluginCompatTester {
             generateHtmlReportFile();
         } else {
             System.out.println("No HTML report is generated, because it has been disabled or no tests have been executed");
+        }
+
+        if (failed && config.isFailOnError()) {
+		    throw new AbortException("Execution was aborted due to the failure in a plugin test (-failOnerror is set)");
         }
 
         return report;

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -135,6 +135,7 @@ exec java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
   -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
   -skipTestCache true \
+  -failOnError \
   -localCheckoutDir "${PCT_TMP}/localCheckoutDir/${ARTIFACT_ID}" \
   -includePlugins "${ARTIFACT_ID}" \
   -mvn "/usr/bin/mvn" \


### PR DESCRIPTION
Currently PCT and PCT Docker Image always return zero error code, even if a test run fails. It would be great to somehow propagate issues there.

This PR:

- [x] Introduces a new `-failOnError` CLI option
- [x] Adds the option by default to demos
- [x] Enables it by default in PCT Docker image, so it returns error code by default. PCT Docker image always runs with a single core and a single plugin, so it should be OK

Sample output:

```
/// ... Whatever Maven Failure
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
succeeded artifactIds: [maven-hpi-plugin, maven-hpi-plugin]
Exception in thread "main" hudson.AbortException: Execution was aborted due to the failure in a plugin test (-failOnerror is set)
	at org.jenkins.tools.test.PluginCompatTester.testPlugins(PluginCompatTester.java:343)
	at org.jenkins.tools.test.PluginCompatTesterCli.main(PluginCompatTesterCli.java:161)
```

https://issues.jenkins-ci.org/browse/JENKINS-55144
