### PR TITLE
[JENKINS-55147] - Automate analysis of JVM crashes in PCT Docker images

### DIFF
--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -143,10 +143,10 @@ echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -testJDKHome "${TEST_JDK_HOME}" \
   -testJavaArgs ${TEST_JAVA_ARGS:-} \
   "$@" \
-  "|| echo $? > /pct/tmp/pct_exit_code" > /pct/tmp/pct_command
+  "|| echo \$? > /pct/tmp/pct_exit_code" > /pct/tmp/pct_command
 chmod +x /pct/tmp/pct_command
 cat /pct/tmp/pct_command
-exec /pct/tmp/pct_command
+sh -ex /pct/tmp/pct_command || "Execution failed with code $?"
 
 if [ -f "/pct/tmp/pct_exit_code" ]; then
   pctExitCode=$(cat "/pct/tmp/pct_exit_code")

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -126,11 +126,12 @@ mkdir -p "${PCT_OUTPUT_DIR}"
 TEST_JDK_HOME=${TEST_JAVA_ARGS:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-opendjdk-amd64"}
 if [[ "${JDK_VERSION}" = "11" ]] ; then
   echo "JDK_VERSION detected is 11. Adding JAXB and modules to the command lines."
-  TEST_JAVA_ARGS="${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar"
+  TEST_JAVA_ARGS="'${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar'"
 fi
 
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710
-exec java ${JAVA_OPTS} ${extra_java_opts[@]} \
+pctExitCode=0
+echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -jar /pct/pct-cli.jar \
   -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
   -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
@@ -140,5 +141,25 @@ exec java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -mvn "/usr/bin/mvn" \
   -m2SettingsFile "${MVN_SETTINGS_FILE}" \
   -testJDKHome "${TEST_JDK_HOME}" \
-  -testJavaArgs "${TEST_JAVA_ARGS:-}" \
-  "$@"
+  -testJavaArgs ${TEST_JAVA_ARGS:-} \
+  "$@" \
+  "|| echo $? > /pct/tmp/pct_exit_code" > /pct/tmp/pct_command
+chmod +x /pct/tmp/pct_command
+cat /pct/tmp/pct_command
+exec /pct/tmp/pct_command
+
+if [ -f "/pct/tmp/pct_exit_code" ]; then
+  pctExitCode=$(cat "/pct/tmp/pct_exit_code")
+fi
+
+if [[ "${pctExitCode}" != "0" ]] ; then
+  echo "ERROR: PCT failed with code ${pctExitCode}. Will check for Maven Surefire dumps if it crashed"
+  dumpFiles=$(find /pct/tmp/work/${ARTIFACT_ID}/target/surefire-reports/*.dump* || echo "")
+  if [ -n "${dumpFiles}" ] ; then
+    echo "${dumpFiles}" | while read file; do
+      echo "Found Maven Surefire dump file: ${file}"
+      cat "${file}"
+    done
+  fi
+  exit "${pctExitCode}"
+fi


### PR DESCRIPTION
During testing of plugins with Java 11, we have discovered several case when Maven Surefire just crashes with Java 11 (e.g. JENKINS-55146 or JENKINS-55097).

In the current state the errors just get suppressed, and you need to run manually in Docker containers to reproduce them.

It would be great if there is a way to get crashdumps in the build log when it happens. Ideally we need to do it as a part of the PCT execution engine, but having something for Docker is a good start

Output example:

```
+ [[ 1 != \0 ]]
+ echo 'ERROR: PCT failed with code 1. Will check for Maven Surefire dumps if it crashed'
ERROR: PCT failed with code 1. Will check for Maven Surefire dumps if it crashed
++ find /pct/tmp/work/script-security/target/surefire-reports/2018-12-13T00-30-45_764-jvmRun1.dumpstream
+ dumpFiles=/pct/tmp/work/script-security/target/surefire-reports/2018-12-13T00-30-45_764-jvmRun1.dumpstream
+ '[' -n /pct/tmp/work/script-security/target/surefire-reports/2018-12-13T00-30-45_764-jvmRun1.dumpstream ']'
+ echo /pct/tmp/work/script-security/target/surefire-reports/2018-12-13T00-30-45_764-jvmRun1.dumpstream
+ read file
+ echo 'Found Maven Surefire dump file: /pct/tmp/work/script-security/target/surefire-reports/2018-12-13T00-30-45_764-jvmRun1.dumpstream'
+ cat /pct/tmp/work/script-security/target/surefire-reports/2018-12-13T00-30-45_764-jvmRun1.dumpstream
Found Maven Surefire dump file: /pct/tmp/work/script-security/target/surefire-reports/2018-12-13T00-30-45_764-jvmRun1.dumpstream
# Created on 2018-12-13T00:30:46.986
Corrupted stdin stream in forked JVM 1. Stream 'Error occurred during initialization of boot layer'.
java.lang.IllegalArgumentException: Stream stdin corrupted. Expected comma after third character in command 'Error occurred during initialization of boot layer'.
	at org.apache.maven.plugin.surefire.booterclient.output.ForkClient$OperationalData.<init>(ForkClient.java:469)
	at org.apache.maven.plugin.surefire.booterclient.output.ForkClient.processLine(ForkClient.java:191)
	at org.apache.maven.plugin.surefire.booterclient.output.ForkClient.consumeLine(ForkClient.java:158)
	at org.apache.maven.plugin.surefire.booterclient.output.ThreadedStreamConsumer$Pumper.run(ThreadedStreamConsumer.java:87)
	at java.lang.Thread.run(Thread.java:748)


# Created on 2018-12-13T00:30:46.991
Corrupted stdin stream in forked JVM 1. Stream 'java.lang.module.FindException: Module java.activation not found, required by java.xml.bind'.

+ read file
+ exit 1
```

https://issues.jenkins-ci.org/browse/JENKINS-55147

@jenkinsci/java11-support 
