### PR TITLE
[JENKINS-55169] - Add support of running PCT against incrementalified plugins

### DIFF
--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
@@ -25,9 +25,12 @@
  */
 package org.jenkins.tools.test.model;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.jenkins.tools.test.model.comparators.VersionComparator;
+
+import javax.annotation.Nonnull;
 
 /**
  * Class representing Maven GAV
@@ -39,10 +42,24 @@ public class MavenCoordinates implements Comparable<MavenCoordinates> {
     public final String version;
     // No classifier/type for the moment...
 
-    public MavenCoordinates(String groupId, String artifactId, String version){
-        this.groupId = groupId;
-        this.artifactId = artifactId;
-        this.version = version;
+    /**
+     * Constructor.
+     * @throws IllegalArgumentException one of the parameters is invalid.
+     */
+    public MavenCoordinates(@Nonnull String groupId, @Nonnull String artifactId, @Nonnull String version){
+        this.groupId = verifyInput( groupId, artifactId, version,"groupId", groupId);
+        this.artifactId = verifyInput( groupId, artifactId, version,"artifactId", artifactId);
+        this.version = verifyInput( groupId, artifactId, version,"version", version);
+    }
+
+    private static String verifyInput(String groupId, String artifactId, String version,
+                                      String fieldName, String value) throws IllegalArgumentException {
+        if (value == null || StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid parameter passed for %s:%s:%s: Field %s; %s",
+                            groupId, artifactId, version, fieldName, value));
+        }
+        return value.trim();
     }
 
     public boolean equals(Object o){

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PomData.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PomData.java
@@ -25,6 +25,8 @@
  */
 package org.jenkins.tools.test.model;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,12 +36,18 @@ import java.util.List;
  */
 public class PomData {
     public final String artifactId;
+
+    @Nonnull
+    private final String packaging;
+
+    @CheckForNull
     public final MavenCoordinates parent;
     private String connectionUrl;
     private List<String> warningMessages = new ArrayList<String>();
 
-    public PomData(String artifactId, String connectionUrl, MavenCoordinates parent){
+    public PomData(String artifactId, @CheckForNull String packaging, String connectionUrl, @CheckForNull MavenCoordinates parent){
         this.artifactId = artifactId;
+        this.packaging = packaging != null ? packaging : "jar";
         this.setConnectionUrl(connectionUrl);
         this.parent = parent;
     }
@@ -54,5 +62,18 @@ public class PomData {
 
     public List<String> getWarningMessages() {
         return warningMessages;
+    }
+
+    @Nonnull
+    public String getPackaging() {
+        return packaging;
+    }
+
+    public boolean isPluginPOM() {
+        if (parent != null) {
+            return parent.matches("org.jenkins-ci.plugins", "plugin");
+        } else { // Interpolate by packaging
+            return "hpi".equalsIgnoreCase(packaging);
+        }
     }
 }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/comparators/VersionComparator.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/comparators/VersionComparator.java
@@ -56,6 +56,11 @@ public class VersionComparator implements Comparator<String> {
                 chunk2 = splitO2Version[i];
             }
 
+            if (chunk1.getClass() != chunk2.getClass()) {
+                throw new IllegalArgumentException("Comparing different types in chunk " + i +
+                        ". Version 1 = " + o1 + ", version 2 = " + o2);
+            }
+
             if(!splitO1Version[i].equals(splitO2Version[i])){
                 return chunk1.compareTo(chunk2);
             }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -94,6 +94,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -108,6 +110,7 @@ import org.jenkins.tools.test.maven.MavenRunner;
  */
 public class PluginCompatTester {
 
+    private static final Logger LOGGER = Logger.getLogger(PluginCompatTester.class.getName());
     private static final String DEFAULT_SOURCE_ID = "default";
 
     /** First version with new parent POM. */
@@ -261,6 +264,8 @@ public class PluginCompatTester {
                         }
                     } catch (Throwable t) {
                         status = TestStatus.INTERNAL_ERROR;
+                        LOGGER.log(Level.SEVERE, String.format("Internal error while executing a test for core %s and plugin %s %s. Please submit a bug to plugin-compat-tester",
+                                coreCoordinates.version, plugin.getDisplayName(), plugin.version), t);
                         errorMessage = t.getMessage();
                         pomData = null;
                     }
@@ -292,6 +297,8 @@ public class PluginCompatTester {
                         throw e;
                     } catch (Throwable t){
                         status = TestStatus.INTERNAL_ERROR;
+                        LOGGER.log(Level.SEVERE, String.format("Internal error while executing a test for core %s and plugin %s %s. Please submit a bug to plugin-compat-tester",
+                                coreCoordinates.version, plugin.getDisplayName(), plugin.version), t);
                         errorMessage = t.getMessage();
                     }
                     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -253,14 +253,18 @@ public class PluginCompatTester {
                     PomData pomData;
                     try {
                         pomData = remote.retrievePomData();
-                        System.out.println("detected parent POM " + pomData.parent.toGAV());
-                        if ((pomData.parent.groupId.equals(PluginCompatTesterConfig.DEFAULT_PARENT_GROUP)
-                                && pomData.parent.artifactId.equals(PluginCompatTesterConfig.DEFAULT_PARENT_ARTIFACT)
-                                || pomData.parent.groupId.equals("org.jvnet.hudson.plugins"))
-                                && coreCoordinates.version.matches("1[.][0-9]+[.][0-9]+")
-                                && new VersionNumber(coreCoordinates.version).compareTo(new VersionNumber("1.485")) < 0) { // TODO unless 1.480.3+
-                            System.out.println("Cannot test against " + coreCoordinates.version + " due to lack of deployed POM for " + coreCoordinates.toGAV());
-                            actualCoreCoordinates = new MavenCoordinates(coreCoordinates.groupId, coreCoordinates.artifactId, coreCoordinates.version.replaceFirst("[.][0-9]+$", ""));
+                        MavenCoordinates parentPom = pomData.parent;
+                        if (parentPom != null) {
+                            // Parent POM is used here only to detect old versions of core
+                            LOGGER.log(Level.INFO,"Detected parent POM: {0}", parentPom.toGAV());
+                            if ((parentPom.groupId.equals(PluginCompatTesterConfig.DEFAULT_PARENT_GROUP)
+                                    && parentPom.artifactId.equals(PluginCompatTesterConfig.DEFAULT_PARENT_ARTIFACT)
+                                    || parentPom.groupId.equals("org.jvnet.hudson.plugins"))
+                                    && coreCoordinates.version.matches("1[.][0-9]+[.][0-9]+")
+                                    && new VersionNumber(coreCoordinates.version).compareTo(new VersionNumber("1.485")) < 0) { // TODO unless 1.480.3+
+                                LOGGER.log(Level.WARNING, "Cannot test against " + coreCoordinates.version + " due to lack of deployed POM for " + coreCoordinates.toGAV());
+                                actualCoreCoordinates = new MavenCoordinates(coreCoordinates.groupId, coreCoordinates.artifactId, coreCoordinates.version.replaceFirst("[.][0-9]+$", ""));
+                            }
                         }
                     } catch (Throwable t) {
                         status = TestStatus.INTERNAL_ERROR;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -20,6 +20,8 @@ import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Workaround for the blueocean plugins since they are
@@ -27,6 +29,8 @@ import java.util.Map;
  * 
  */
 public class BlueOceanHook extends AbstractMultiParentHook {
+
+    private static final Logger LOGGER = Logger.getLogger(BlueOceanHook.class.getName());
 
     @Override
     protected String getParentFolder() {
@@ -50,7 +54,17 @@ public class BlueOceanHook extends AbstractMultiParentHook {
 
     public static boolean isBOPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
-        return data.parent.artifactId.equalsIgnoreCase("blueocean-parent");
+        return isBOPlugin(data);
+    }
+
+    public static boolean isBOPlugin(PomData data) {
+        if (data.parent != null) {
+            return data.parent.artifactId.equalsIgnoreCase("blueocean-parent");
+        } else {
+            LOGGER.log(Level.WARNING, "Artifact {0} has no parent POM, likely it was incrementalified (JEP-305). " +
+                    "Will guess the plugin by artifact ID. FTR JENKINS-55169", data.artifactId);
+            return data.artifactId.contains("blueocean");
+        }
     }
 
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -6,12 +6,16 @@ import org.jenkins.tools.test.model.PomData;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Workaround for the declarative pipeline plugins since they are
  * stored in a central repository.
  */
 public class DeclarativePipelineHook extends AbstractMultiParentHook {
+
+    private static final Logger LOGGER = Logger.getLogger(DeclarativePipelineHook.class.getName());
 
     @Override
     protected String getParentFolder() {
@@ -35,6 +39,16 @@ public class DeclarativePipelineHook extends AbstractMultiParentHook {
 
     public static boolean isDPPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
-        return data.parent.artifactId.equalsIgnoreCase("pipeline-model-parent");
+        return isDPPlugin(data);
+    }
+
+    public static boolean isDPPlugin(PomData data) {
+        if (data.parent != null) {
+            return data.parent.artifactId.equalsIgnoreCase("blueocean-parent");
+        } else {
+            LOGGER.log(Level.WARNING, "Artifact {0} has no parent POM, likely it was incrementalified (JEP-305). " +
+                    "Will guess the plugin by artifact ID. FTR JENKINS-55169", data.artifactId);
+            return data.artifactId.contains("pipeline-model");
+        }
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
@@ -34,6 +34,18 @@ public class StructsHook extends AbstractMultiParentHook {
 
     public static boolean isStructsPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
-        return data.parent.artifactId.equalsIgnoreCase("structs-parent");
+        return isStructsPlugin(data);
+    }
+
+    public static boolean isStructsPlugin(PomData data) {
+        if (data.parent != null) {
+            // Non-incrementals
+            return data.parent.artifactId.equalsIgnoreCase("structs-parent");
+        } else if (!"structs".equalsIgnoreCase(data.artifactId)) {
+            return false;
+        } else {
+            throw new IllegalStateException("Structs Plugin may have been incrementalified, and PCT does not supports the discovery now. " +
+                    "See JENKINS-55169 and linked tickets");
+        }
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -47,7 +47,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         } else {
             //TODO(oleg_nenashev): all these assumptions are unreliable at best (JENKINS-55169)
             LOGGER.log(Level.WARNING, "Parent POM is missing for {0}. " +
-                    "Likely it is Incrementals Plugin, hence assuming it's not a CloudBees one and that the version is above 3.4 (JENKINS-55169)");
+                    "Likely it is Incrementals Plugin, hence assuming it's not a CloudBees one and that the version is above 3.4 (JENKINS-55169)", pomData.artifactId);
             isCB = false;
             parentV2 = true;
             parentUnder233 = false;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -7,8 +7,11 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
 
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TransformPom extends PluginCompatTesterHookBeforeExecution {
+    private static final Logger LOGGER = Logger.getLogger(TransformPom.class.getName());
     private static final String CORE_NEW_PARENT_POM = "1.646";
     private static final String CORE_WITHOUT_WAR_FOR_TEST = "2.64";
     private static final String PLUGINS_PARENT_POM_FOR_CORE_WITHOUT_WAR_TEST = "2.33";
@@ -28,16 +31,28 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         PomData pomData = (PomData)info.get("pomData");
         MavenCoordinates parent = pomData.parent;
         MavenCoordinates coreCoordinates = (MavenCoordinates)info.get("coreCoordinates");
-        boolean isDeclarativePipeline = parent.matches("org.jenkinsci.plugins", "pipeline-model-parent");
-        boolean isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
-                // TODO ought to analyze the chain of parent POMs, which would lead to com.cloudbees.jenkins.plugins:jenkins-plugins in this case:
-                parent.matches("com.cloudbees.operations-center.common", "operations-center-parent") ||
-                parent.matches("com.cloudbees.operations-center.client", "operations-center-parent-client");
-        boolean isBO = parent.matches("io.jenkins.blueocean", "blueocean-parent");
-        boolean isStructs = parent.matches("org.jenkins-ci.plugins", "structs-parent");
-        boolean pluginPOM = parent.matches("org.jenkins-ci.plugins", "plugin");
-        boolean parentV2 = parent.compareVersionTo("2.0") >= 0;
-        boolean parentUnder233 = parentV2 && parent.compareVersionTo(PLUGINS_PARENT_POM_FOR_CORE_WITHOUT_WAR_TEST) < 0;
+
+        final boolean isCB, parentV2, parentUnder233;
+        boolean isStructs = StructsHook.isStructsPlugin(pomData);
+        boolean isBO = BlueOceanHook.isBOPlugin(pomData);
+        boolean isDeclarativePipeline = DeclarativePipelineHook.isDPPlugin(pomData);
+        boolean pluginPOM = pomData.isPluginPOM();
+        if (parent != null) {
+            isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
+                    // TODO ought to analyze the chain of parent POMs, which would lead to com.cloudbees.jenkins.plugins:jenkins-plugins in this case:
+                    parent.matches("com.cloudbees.operations-center.common", "operations-center-parent") ||
+                    parent.matches("com.cloudbees.operations-center.client", "operations-center-parent-client");
+            parentV2 = parent.compareVersionTo("2.0") >= 0;
+            parentUnder233 = parentV2 && parent.compareVersionTo(PLUGINS_PARENT_POM_FOR_CORE_WITHOUT_WAR_TEST) < 0;
+        } else {
+            //TODO(oleg_nenashev): all these assumptions are unreliable at best (JENKINS-55169)
+            LOGGER.log(Level.WARNING, "Parent POM is missing for {0}. " +
+                    "Likely it is Incrementals Plugin, hence assuming it's not a CloudBees one and that the version is above 3.4 (JENKINS-55169)");
+            isCB = false;
+            parentV2 = true;
+            parentUnder233 = false;
+        }
+
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
         boolean coreRequiresPluginOver233 = coreCoordinates.compareVersionTo(CORE_WITHOUT_WAR_FOR_TEST) >= 0;
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -111,6 +111,7 @@ public class PluginRemoting {
 	public PomData retrievePomData() throws PluginSourcesUnavailableException {
 		String scmConnection = null;
         String artifactId = null;
+        String packaging;
 		String pomContent = this.retrievePomContent();
         @CheckForNull MavenCoordinates parent = null;
 		
@@ -123,9 +124,11 @@ public class PluginRemoting {
             XPath xpath = xpathFactory.newXPath();
 			XPathExpression scmConnectionXPath = xpath.compile("/project/scm/connection/text()");
             XPathExpression artifactIdXPath = xpath.compile("/project/artifactId/text()");
+            XPathExpression packagingXPath = xpath.compile("/project/packaging/text()");
 
 			scmConnection = (String)scmConnectionXPath.evaluate(doc, XPathConstants.STRING);
             artifactId = (String)artifactIdXPath.evaluate(doc, XPathConstants.STRING);
+            packaging = StringUtils.trimToNull((String)packagingXPath.evaluate(doc, XPathConstants.STRING));
 
             String parentNode = xpath.evaluate("/project/parent", doc);
             if (StringUtils.isNotBlank(parentNode)) {
@@ -137,7 +140,7 @@ public class PluginRemoting {
             } else {
                 LOGGER.log(Level.WARNING, "No parent POM reference for artifact {0}, " +
                                 "likely a plugin with Incrementals support is used (Jenkins JEP-305). " +
-                                "Will try to ignore it. " +
+                                "Will try to ignore it (FTR https://issues.jenkins-ci.org/browse/JENKINS-55169). " +
                                 "hpiRemoteUrl={1}, pomFile={2}",
                         new Object[] {artifactId, hpiRemoteUrl, pomFile});
             }
@@ -149,7 +152,7 @@ public class PluginRemoting {
 			throw new PluginSourcesUnavailableException("Problem while retrieving plugin's scm connection", e);
 		}
 		
-		PomData pomData = new PomData(artifactId, scmConnection, parent);
+		PomData pomData = new PomData(artifactId, packaging, scmConnection, parent);
         computeScmConnection(pomData);
         return pomData;
 	}

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
@@ -42,7 +42,7 @@ import org.junit.Ignore;
 public class ScmConnectionSpecialCasesTest {
 
     private static void runComputeScmConnectionAgainst(String scmUrlToTest, String artifactId, String expectedComputedScmUrl) {
-        PomData pom = new PomData(artifactId, scmUrlToTest, new MavenCoordinates("", "", ""));
+        PomData pom = new PomData(artifactId, "hpi", scmUrlToTest, new MavenCoordinates("", "", ""));
         PluginRemoting.computeScmConnection(pom);
         assertThat(pom.getConnectionUrl(), is(equalTo(expectedComputedScmUrl)));
     }

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
@@ -42,7 +42,8 @@ import org.junit.Ignore;
 public class ScmConnectionSpecialCasesTest {
 
     private static void runComputeScmConnectionAgainst(String scmUrlToTest, String artifactId, String expectedComputedScmUrl) {
-        PomData pom = new PomData(artifactId, "hpi", scmUrlToTest, new MavenCoordinates("", "", ""));
+        PomData pom = new PomData(artifactId, "hpi", scmUrlToTest,
+                new MavenCoordinates("org.jenkins-ci.main", "jenkins-cli", "2.150.1"));
         PluginRemoting.computeScmConnection(pom);
         assertThat(pom.getConnectionUrl(), is(equalTo(expectedComputedScmUrl)));
     }


### PR DESCRIPTION
I started from a silent classcast issue and ended up with the fact that PCT does not handle Incrementalified plugins properly. https://issues.jenkins-ci.org/browse/JENKINS-55169

What has changed here:

- [x] A LOT of diagnostics improvements to actually propagate and diagnose the error
- [x] Add diagnostics for Parent POM, extend APIs
- [x] Add support of missing Parent POM in pom.xml. All hooks and logic now use various guessing mechanisms. What could possibly go wrong?

@jenkinsci/java11-support @raul-arabaolaza 