### PR TITLE
[JENKINS-55199] - Add explicit resolution of self-dependencies to PCT

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -785,6 +785,7 @@ public class PluginCompatTester {
                 pom.addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, convertFromTestDep);
             }
 
+	    // TODO(oleg_nenashev): This is a hack, logic above should be refactored somehow (JENKINS-55279)
             // Remove the self-dependency if any
             pom.removeDependency(pluginGroupIds.get(thisPlugin), thisPlugin);
         }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -784,6 +784,9 @@ public class PluginCompatTester {
                 System.out.println("Adding/replacing plugin dependencies for compatibility: " + toAdd + " " + toReplace + "\nFor test: " + toAddTest + " " + toReplaceTest);
                 pom.addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, convertFromTestDep);
             }
+
+            // Remove the self-dependency if any
+            pom.removeDependency(pluginGroupIds.get(thisPlugin), thisPlugin);
         }
     }
 


### PR DESCRIPTION
Ports #100 to the master branch. It should prevent `junit` and `structs` plugins from having self-dependencies in their Effective POMs. I doubt this it a good approach (there is already some split dependency logic), so please do not merge until @raul-arabaolaza reviews it

@jenkinsci/java11-support 
