### PR TITLE
[JENKINS-55296] - Support running PCT with Java 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #Makefile
 TEST_JDK_HOME?=$(JAVA_HOME)
 PLUGIN_NAME?=mailer
-LOCAL_SRC?=$(shell pwd)/work/$(PLUGIN_NAME)
+LOCAL_SRC?=$(CURDIR)/work/$(PLUGIN_NAME)
 USE_TEST_JDK_HOME_EXEC?=
 
 # Weekly with the latest Java 11 patches is used by default

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 #Makefile
 TEST_JDK_HOME?=$(JAVA_HOME)
 PLUGIN_NAME?=mailer
+LOCAL_SRC?=$(shell pwd)/work/$(PLUGIN_NAME)
 
 # Weekly with the latest Java 11 patches is used by default
 JENKINS_VERSION=2.155
@@ -65,7 +66,7 @@ demo-jdk8: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/je
 demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/javax.activation-$(JAF_VERSION).jar tmp/jaxb-api-$(JAXB_API_VERSION).jar tmp/jenkins-war-$(JENKINS_VERSION).war tmp/jaxb-impl-$(JAXB_VERSION).jar tmp/jaxb-core-$(JAXB_VERSION).jar print-java-home
 	# TODO Cleanup when/if the JAXB bundling issue is resolved.
 	# https://issues.jenkins-ci.org/browse/JENKINS-52186
-	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
+	$(TEST_JDK_HOME)/bin/java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -failOnError \
 	     -workDirectory $(CURDIR)/work -skipTestCache true \
@@ -82,6 +83,7 @@ demo-jdk11-docker: tmp/jenkins-war-$(JENKINS_VERSION).war
 	     -v $(shell pwd)/tmp/jenkins-war-$(JENKINS_VERSION).war:/pct/jenkins.war:ro \
 	     -e ARTIFACT_ID=$(PLUGIN_NAME) \
 	     -e JDK_VERSION=11 \
+	     -e USE_TEST_JDK_HOME_EXEC=1 \
 	     jenkins/pct
 
 # TODO: take other default directory to avoid collisions?
@@ -90,8 +92,9 @@ demo-jdk11-docker: tmp/jenkins-war-$(JENKINS_VERSION).war
 demo-jdk11-docker-src: tmp/jenkins-war-$(JENKINS_VERSION).war
 	docker run --rm -v maven-repo:/root/.m2 \
 	     -v $(shell pwd)/out:/pct/out \
-	     -v $(shell pwd)/work/$(PLUGIN_NAME):/pct/plugin-src:ro \
+	     -v $(LOCAL_SRC):/pct/plugin-src:ro \
 	     -v $(shell pwd)/tmp/jenkins-war-$(JENKINS_VERSION).war:/pct/jenkins.war:ro \
 	     -e ARTIFACT_ID=$(PLUGIN_NAME) \
 	     -e JDK_VERSION=11 \
+	     -e USE_TEST_JDK_HOME_EXEC=1 \
 	     jenkins/pct

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 TEST_JDK_HOME?=$(JAVA_HOME)
 PLUGIN_NAME?=mailer
 LOCAL_SRC?=$(shell pwd)/work/$(PLUGIN_NAME)
+USE_TEST_JDK_HOME_EXEC?=
 
 # Weekly with the latest Java 11 patches is used by default
 JENKINS_VERSION=2.155
@@ -83,7 +84,7 @@ demo-jdk11-docker: tmp/jenkins-war-$(JENKINS_VERSION).war
 	     -v $(shell pwd)/tmp/jenkins-war-$(JENKINS_VERSION).war:/pct/jenkins.war:ro \
 	     -e ARTIFACT_ID=$(PLUGIN_NAME) \
 	     -e JDK_VERSION=11 \
-	     -e USE_TEST_JDK_HOME_EXEC=1 \
+	     -e USE_TEST_JDK_HOME_EXEC=$(USE_TEST_JDK_HOME_EXEC) \
 	     jenkins/pct
 
 # TODO: take other default directory to avoid collisions?
@@ -96,5 +97,5 @@ demo-jdk11-docker-src: tmp/jenkins-war-$(JENKINS_VERSION).war
 	     -v $(shell pwd)/tmp/jenkins-war-$(JENKINS_VERSION).war:/pct/jenkins.war:ro \
 	     -e ARTIFACT_ID=$(PLUGIN_NAME) \
 	     -e JDK_VERSION=11 \
-	     -e USE_TEST_JDK_HOME_EXEC=1 \
+	     -e USE_TEST_JDK_HOME_EXEC=$(USE_TEST_JDK_HOME_EXEC) \
 	     jenkins/pct

--- a/README.md
+++ b/README.md
@@ -106,9 +106,15 @@ You can run the example by running the following command:
 
 Full list of options for JDK11 can be found [here](./Makefile).
 
+#### Running PCT with custom Java versions in Docker
+
 When using the docker image, it is possible to use `JDK_VERSION` variable to select 
-the version to use. The version needs to be bundled in the docker image. By specifying 
+the version to use to. The version needs to be bundled in the docker image. By specifying 
 `11`, the modules and jaxb libraries are also added to the command line. 
+
+`USE_TEST_JDK_HOME_EXEC` can be used to use the Java executable from `TEST_JDK_HOME` for the PCT run.
+Such mode requires recent versions of [plugin POM](https://github.com/jenkinsci/plugin-pom) to be defined in the plugin
+(JDK11 build support, version 3.32 or above is recommended).
 
 ### Running PCT with different version of dependencies
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Full list of options for JDK11 can be found [here](./Makefile).
 #### Running PCT with custom Java versions in Docker
 
 When using the docker image, it is possible to use `JDK_VERSION` variable to select 
-the version to use to. The version needs to be bundled in the docker image. By specifying 
+the version to use. The version needs to be bundled in the docker image. By specifying 
 `11`, the modules and jaxb libraries are also added to the command line. 
 
 `USE_TEST_JDK_HOME_EXEC` can be used to use the Java executable from `TEST_JDK_HOME` for the PCT run.

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -139,6 +139,9 @@ public class CliOptions {
     @Parameter(names = "-failOnError", description = "Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code")
     private boolean failOnError;
 
+    @Parameter(names = "-setJenkinsVersionOnPrecompile", description = "Sets Jenkins version on precompile steps. It may be needed if the plugin cannot compile on the target Java version by default")
+    private boolean setJenkinsVersionOnPrecompile;
+
     public String getUpdateCenterUrl() {
         return updateCenterUrl;
     }
@@ -234,6 +237,10 @@ public class CliOptions {
 
     public boolean isFailOnError() {
         return failOnError;
+    }
+
+    public boolean isSetJenkinsVersionOnPrecompile() {
+        return setJenkinsVersionOnPrecompile;
     }
 
     public static class PluginConverter implements IStringConverter<PCTPlugin> {

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -139,6 +139,10 @@ public class PluginCompatTesterCli {
             config.setFailOnError(true);
         }
 
+        if (options.isSetJenkinsVersionOnPrecompile()) {
+            config.setSetJenkinsVersionOnPrecompile(true);
+        }
+
         if(options.getOverridenPlugins() != null && !options.getOverridenPlugins().isEmpty()) {
             config.setOverridenPlugins(options.getOverridenPlugins());
         }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -133,6 +133,8 @@ public class PluginCompatTesterConfig {
     // Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code
     private boolean failOnError;
 
+    private boolean setJenkinsVersionOnPrecompile;
+
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
                 workDirectory, reportFile, m2SettingsFile);
@@ -394,5 +396,13 @@ public class PluginCompatTesterConfig {
 
     public void setFailOnError(boolean failOnError) {
         this.failOnError = failOnError;
+    }
+
+    public boolean isSetJenkinsVersionOnPrecompile() {
+        return setJenkinsVersionOnPrecompile;
+    }
+
+    public void setSetJenkinsVersionOnPrecompile(boolean setJenkinsVersionOnPrecompile) {
+        this.setJenkinsVersionOnPrecompile = setJenkinsVersionOnPrecompile;
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -74,6 +74,7 @@ import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -475,7 +476,13 @@ public class PluginCompatTester {
             // and ensures that we are testing a plugin binary as close as possible to what was actually released.
             // We also skip potential javadoc execution to avoid general test failure.
             if (!ranCompile) {
-                runner.run(mconfig, pluginCheckoutDir, buildLogFile, "clean", "process-test-classes", "-Dmaven.javadoc.skip");
+                List<String> goals;
+                goals = new ArrayList<>(Arrays.asList("clean", "process-test-classes", "-Dmaven.javadoc.skip"));
+                if (config.isSetJenkinsVersionOnPrecompile()) {
+                    goals.add("-Djenkins.version="+coreCoordinates.version);
+                    goals.add("-Denforcer.skip");
+                }
+                runner.run(mconfig, pluginCheckoutDir, buildLogFile, goals.toArray(new String[0]));
             }
             ranCompile = true;
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -11,6 +11,7 @@ import org.jenkins.tools.test.model.MavenCoordinates;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 
+import javax.annotation.CheckForNull;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -40,7 +41,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
             MavenCoordinates core = (MavenCoordinates) moreInfo.get("core");
 
             runner = config.getExternalMaven() == null ? new InternalMavenRunner() : new ExternalMavenRunner(config.getExternalMaven());
-            mavenConfig = getMavenConfig(config);
+            mavenConfig = getMavenConfig(config, core);
 
             File pluginDir = (File) moreInfo.get("pluginDir");
             System.out.println("Plugin dir is " + pluginDir);
@@ -100,12 +101,16 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
         }
     }
 
-    private MavenRunner.Config getMavenConfig(PluginCompatTesterConfig config) throws IOException {
+    private MavenRunner.Config getMavenConfig(PluginCompatTesterConfig config, @CheckForNull MavenCoordinates coreCoordinates) throws IOException {
         MavenRunner.Config mconfig = new MavenRunner.Config();
         mconfig.userSettingsFile = config.getM2SettingsFile();
         // TODO REMOVE
         mconfig.userProperties.put("failIfNoTests", "false");
         mconfig.userProperties.putAll(config.retrieveMavenProperties());
+        if (coreCoordinates != null && config.isSetJenkinsVersionOnPrecompile()) {
+            mconfig.userProperties.put("jenkins.version", coreCoordinates.version);
+            mconfig.userProperties.put("enforcer.skip", null);
+        }
 
         return mconfig;
     }

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -131,9 +131,18 @@ else
   TEST_JAVA_ARGS="'${TEST_JAVA_ARGS:-} -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true'"
 fi
 
+EXTRA_PCT_OPTIONS=""
+JAVA_EXECUTABLE="java"
+if [[ "${USE_TEST_JDK_HOME_EXEC}" ]] ; then
+  JAVA_EXECUTABLE=${TEST_JDK_HOME}/bin/java
+  export JAVA_HOME=${TEST_JDK_HOME}
+  #TODO: move to the external call?
+  EXTRA_PCT_OPTIONS="-setJenkinsVersionOnPrecompile"
+fi
+
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710
 pctExitCode=0
-echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
+echo ${JAVA_EXECUTABLE} ${JAVA_OPTS} ${extra_java_opts[@]} \
   -jar /pct/pct-cli.jar \
   -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
   -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
@@ -145,6 +154,7 @@ echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -m2SettingsFile "${MVN_SETTINGS_FILE}" \
   -testJDKHome "${TEST_JDK_HOME}" \
   -testJavaArgs ${TEST_JAVA_ARGS:-} \
+  ${EXTRA_PCT_OPTIONS} \
   "$@" \
   "|| echo \$? > /pct/tmp/pct_exit_code" > /pct/tmp/pct_command
 chmod +x /pct/tmp/pct_command


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-55296

It was my theory about a potential solution for [JENKINS-55146](https://issues.jenkins-ci.org/browse/JENKINS-55146), but unfortunately it does not work

- [x] - Introduce new `-setJenkinsVersionOnPrecompile ` option. It is needed, because pre-compilation fails on JDK11 and Jenkins 2.137- due to metainf-services indexing in the core
- [x] - Update Docker to support the `USE_TEST_JDK_HOME_EXEC` option which sets proper `JAVA_HOME`and runs the entire PCT with Java 11
- [x] - Makefile magic to make it possible


