### PR TITLE
[JENKINS-54675] Add reporting of the used JDK version to the report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ plugins-compat-tester-cli/dependency-reduced-pom.xml
 *.ipr
 *.iml
 
+### Eclipse
+.factorypath
+.classpath
+.settings/
+.project
+
 ### Jenkins
 work/
 ^jenkins/

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ You can find it [here](https://hub.docker.com/r/jenkins/pct/).
 This command will clone of a repository and run PCT against the latest Jenkins Core:
 
 ```shell
-docker run --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -e ARTIFACT_ID=ssh-slaves -e VERSION=ssh-slaves-1.24 jenkins/pct
+docker run -ti --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -e ARTIFACT_ID=ssh-slaves -e VERSION=ssh-slaves-1.24 jenkins/pct
 ```
 
 This command will run PCT for the latest plugin version against the specified Jenkins WAR.
 PCT supports running against SNAPSHOT builds, but PCT will have to install local Maven artifacts in such case.
 
 ```shell
-docker run --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -v my/jenkins.war:/pct/jenkins.war:ro -e ARTIFACT_ID=ssh-slaves jenkins/pct
+docker run -ti --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -v my/jenkins.war:/pct/jenkins.war:ro -e ARTIFACT_ID=ssh-slaves jenkins/pct
 ```
 
 This command will run PCT against custom versions of Jenkins and the plugin specified by volumes.
 
 ```shell
-docker run --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -v my/jenkins.war:/pct/jenkins.war:ro -v my/plugin:/pct/plugin-src:ro jenkins/pct
+docker run -ti --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -v my/jenkins.war:/pct/jenkins.war:ro -v my/plugin:/pct/plugin-src:ro jenkins/pct
 ```
 
 The command below will run PCT for a branch in a custom repository.

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
@@ -40,6 +40,7 @@ import java.util.*;
 public class PluginCompatReport {
     private Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests;
     private SortedSet<MavenCoordinates> testedCoreCoordinates;
+    private String testJdkVersion;
 
     public PluginCompatReport(){
         this.pluginCompatTests = new TreeMap<PluginInfos, List<PluginCompatResult>>();
@@ -183,6 +184,15 @@ public class PluginCompatReport {
 
     public SortedSet<MavenCoordinates> getTestedCoreCoordinates() {
         return new TreeSet(testedCoreCoordinates);
+    }
+
+
+    public void setTestJdkVersion(String testJdkVersion) {
+        this.testJdkVersion = testJdkVersion;
+    }
+
+    public String getTestJdkVersion() {
+        return testJdkVersion;
     }
 
     public Map<PluginInfos, List<PluginCompatResult>> getPluginCompatTests(){

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -206,6 +206,7 @@ public class PluginCompatTester {
         // TODO REMOVE
         mconfig.userProperties.put( "failIfNoTests", "false" );
         mconfig.userProperties.putAll(this.config.retrieveMavenProperties());
+        report.setTestJdkVersion(mconfig.userProperties.get("javaVersion"));
 
         boolean failed = false;
 		SCMManagerFactory.getInstance().start();

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -26,6 +26,7 @@ public class ExternalMavenRunner implements MavenRunner {
     public void run(Config config, File baseDirectory, File buildLogFile, String... goals) throws PomExecutionException {
         List<String> cmd = new ArrayList<String>();
         cmd.add(mvn.getAbsolutePath());
+        cmd.add("--show-version");
         cmd.add("--batch-mode");
         if (config.userSettingsFile != null) {
             cmd.add("--settings=" + config.userSettingsFile);

--- a/plugins-compat-tester/src/main/resources/resultToReport.xsl
+++ b/plugins-compat-tester/src/main/resources/resultToReport.xsl
@@ -78,7 +78,7 @@
             <tr>
                 <xsl:for-each select="$testedJenkinsCoordinates" >
                     <th class="version">
-                        <xsl:value-of select="version" />
+                        <xsl:value-of select="version" />  / <xsl:value-of select="/report/testJdkVersion" />
                     </th>
                 </xsl:for-each>
                 <xsl:for-each select="$testedHudsonCoordinates" >


### PR DESCRIPTION
Manually tested. 

This is a bit narrow because I didn't want to raise https://github.com/jenkinsci/plugin-compat-tester/blob/2d26e2bd434402aa645084249a0cce601e82751d/plugins-compat-tester/src/main/resources/resultToReport.xsl#L51, I guess we mainly want the data, and not care too much about it's rendering. See what it looks like below:

![image](https://user-images.githubusercontent.com/223853/50344400-18d73380-052b-11e9-9e7f-77236f921913.png)

