### PR TITLE
[JENKINS-55508] Create hook for pipeline-stage-view plugin

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -85,7 +85,8 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
 
     @Override
     public boolean check(Map<String, Object> info) throws Exception {
-        return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info);
+        return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) ||
+              StructsHook.isStructsPlugin(info) || PipelineStageViewHook.isPipelineStageViewPlugin(info);
     }
 
     private boolean isEslintFile(Path file) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -1,0 +1,53 @@
+package org.jenkins.tools.test.hook;
+
+import hudson.model.UpdateSite;
+import org.jenkins.tools.test.model.PomData;
+
+import java.util.Map;
+
+public class PipelineStageViewHook extends AbstractMultiParentHook {
+
+    @Override
+    protected String getParentFolder() {
+        return "pipeline-stage-view-plugin";
+    }
+
+    @Override
+    protected String getParentUrl() {
+        return "scm:git:git://github.com/jenkinsci/pipeline-stage-view-plugin.git";
+    }
+
+    @Override
+    protected String getParentProjectName() {
+        return "pipeline-stage-view";
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) {
+        return isPipelineStageViewPlugin(info);
+    }
+
+    @Override
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
+        if ("pipeline-rest-api".equalsIgnoreCase(currentPlugin.name)) {
+            return "rest-api";
+        } else if("pipeline-stage-view".equals(currentPlugin.name)) {
+            return "ui";
+        }
+        return super.getPluginFolderName(currentPlugin);
+    }
+
+    static boolean isPipelineStageViewPlugin(Map<String, Object> info) {
+        PomData data = (PomData) info.get("pomData");
+        return isPipelineStageViewPlugin(data);
+    }
+
+    private static boolean isPipelineStageViewPlugin(PomData data) {
+        if (data.parent != null) {
+            return data.parent.artifactId.equalsIgnoreCase("parent-pom")
+                  && data.parent.groupId.equalsIgnoreCase("org.jenkins-ci.plugins.pipeline-stage-view");
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-55508](https://issues.jenkins-ci.org/browse/JENKINS-55508)

Required as the plugin is a multi-module project.

However, this is not enough for this `pipeline-stage-view` plugin as the parent pom groupId is different and PCT "replacement" break the hierarchy.

cc @raul-arabaolaza  