### PR TITLE
[JENKINS-55146] javax actication library incorrectly fetched

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM maven:3.6.0-jdk-8 as builder
 # Warmup to avoid downloading the world each time
 RUN git clone https://github.com/jenkinsci/plugin-compat-tester &&\
     cd plugin-compat-tester && \
-    mvn clean package -DskipTests dependency:go-offline && \
+    mvn clean package -Dmaven.test.skip=true dependency:go-offline && \
     mvn clean
 
 COPY plugins-compat-tester/ /pct/src/plugins-compat-tester/
@@ -37,7 +37,7 @@ COPY *.xml /pct/src/
 COPY LICENSE.txt /pct/src/LICENSE.txt
 
 WORKDIR /pct/src/
-RUN mvn clean install -DskipTests
+RUN mvn clean package -Dmaven.test.skip=true
 
 FROM maven:3.6.0-jdk-8
 LABEL Maintainer="Oleg Nenashev <o.v.nenashev@gmail.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,11 +63,11 @@ RUN mkdir -p /pct/jdk11-libs && \
     curl -LSs https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/${JAXB_API_VERSION}/jaxb-api-${JAXB_API_VERSION}.jar -o /pct/jdk11-libs/jaxb-api.jar && \
     curl -LSs https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-core/${JAXB_VERSION}/jaxb-core-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-core.jar && \
     curl -LSs https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-impl/${JAXB_VERSION}/jaxb-impl-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-impl.jar && \
-    curl -LSs https://repo1.maven.org/maven2/com/sun/activation/${JAF_VERSION}/javax.activation-${JAF_VERSION}.jar -o /pct/jdk11-libs/javax.activation.jar && \
+    curl -LSs https://repo1.maven.org/maven2/com/sun/activation/javax.activation/${JAF_VERSION}/javax.activation-${JAF_VERSION}.jar -o /pct/jdk11-libs/javax.activation.jar && \
     echo "99f802e0cb3e953ba3d6e698795c4aeb98d37c48  /pct/jdk11-libs/jaxb-api.jar\n\
 23574ca124d0a694721ce3ef13cd720095f18fdd  /pct/jdk11-libs/jaxb-core.jar\n\
 2e979dabb3e5e74a0686115075956391a14dece8  /pct/jdk11-libs/jaxb-impl.jar\n\
-84e709cb8271e5e7ff7da61528d52d36298aa733  /pct/jdk11-libs/javax.activation.jar" | sha1sum -c
+bf744c1e2776ed1de3c55c8dac1057ec331ef744  /pct/jdk11-libs/javax.activation.jar" | sha1sum -c
 
 COPY src/main/docker/*.groovy /pct/scripts/
 COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar /pct/pct-cli.jar

--- a/Makefile
+++ b/Makefile
@@ -21,28 +21,33 @@ plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar:
 package: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar
 
 .PHONY: docker
-docker:
+docker: Dockerfile 
 	docker build -t jenkins/pct .
 
 tmp:
 	mkdir tmp
 
+.PRECIOUS: tmp/jenkins-war-$(JENKINS_VERSION).war
 tmp/jenkins-war-$(JENKINS_VERSION).war: tmp
 	mvn dependency:copy -Dartifact=org.jenkins-ci.main:jenkins-war:$(JENKINS_VERSION):war -DoutputDirectory=tmp
 	touch tmp/jenkins-war-$(JENKINS_VERSION).war
 
+.PRECIOUS: tmp/jaxb-api-$(JAXB_API_VERSION).jar
 tmp/jaxb-api-$(JAXB_API_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=javax.xml.bind:jaxb-api:$(JAXB_API_VERSION) -DoutputDirectory=tmp
 	touch tmp/jaxb-api-$(JAXB_API_VERSION).jar
 
+.PRECIOUS: tmp/jaxb-core-$(JAXB_VERSION).jar
 tmp/jaxb-core-$(JAXB_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-core:$(JAXB_VERSION) -DoutputDirectory=tmp
 	touch tmp/jaxb-core-$(JAXB_VERSION).jar
 
+.PRECIOUS: tmp/jaxb-impl-$(JAXB_VERSION).jar
 tmp/jaxb-impl-$(JAXB_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-impl:$(JAXB_VERSION) -DoutputDirectory=tmp
 	touch tmp/jaxb-impl-$(JAXB_VERSION).jar
 
+.PRECIOUS: tmp/javax.activation-$(JAF_VERSION).jar
 tmp/javax.activation-$(JAF_VERSION).jar: tmp
 	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAF_VERSION) -DoutputDirectory=tmp
 	touch tmp/javax.activation-$(JAF_VERSION).jar

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ demo-jdk8: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/je
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -failOnError \
-	     -workDirectory $(CURDIR)/work -skipTestCache true \
-	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
+	     -workDirectory $(CURDIR)/work \
+	     -skipTestCache true \
+	     -mvn $(shell which mvn) \
+	     -war $(CURDIR)/tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
 	     -includePlugins $(PLUGIN_NAME)
 
@@ -73,8 +75,10 @@ demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/j
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -failOnError \
-	     -workDirectory $(CURDIR)/work -skipTestCache true \
-	     -mvn $(shell which mvn) -war tmp/jenkins-war-$(JENKINS_VERSION).war \
+	     -workDirectory $(CURDIR)/work \
+	     -skipTestCache true \
+	     -mvn $(shell which mvn) \
+	     -war $(CURDIR)/tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
 	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api-$(JAXB_API_VERSION).jar:$(CURDIR)/tmp/javax.activation-$(JAF_VERSION).jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl-$(JAXB_VERSION).jar:$(CURDIR)/tmp/jaxb-core-$(JAXB_VERSION).jar" \
 	     -includePlugins $(PLUGIN_NAME)


### PR DESCRIPTION
[JENKINS-55146](https://issues.jenkins-ci.org/browse/JENKINS-55146)

The library `javax.activation` wasn't downloaded correctly. 
Because of this, the PCT docker image failed with a Java module error.

I could try with mailer plugin and confirm I don't have the problem anymore.
Testing with `ssh-slaves` (as in the ticket) shows that the plugin has issues with Java 11, failing with `java.lang.NoClassDefFoundError: hudson/tools/JDKInstaller$FileSystem`

@jenkinsci/java11-support 