### PR TITLE
[JENKINS-55962] - Stop requiring JAXB in PCT for Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,20 +55,6 @@ RUN curl -L --show-error https://download.java.net/java/GA/jdk11/13/GPL/openjdk-
     mv jdk-11.0.1/ /usr/lib/jvm/java-11-openjdk-amd64 && \
     rm openjdk.tar.gz
 
-ARG JAXB_API_VERSION="2.3.0"
-ARG JAXB_VERSION="2.3.0.1"
-ARG JAF_VERSION="1.2.0"
-# Checksum for JavaBean Activation Framework lib is not matching the Maven Central one. 
-RUN mkdir -p /pct/jdk11-libs && \
-    curl -LSs https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/${JAXB_API_VERSION}/jaxb-api-${JAXB_API_VERSION}.jar -o /pct/jdk11-libs/jaxb-api.jar && \
-    curl -LSs https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-core/${JAXB_VERSION}/jaxb-core-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-core.jar && \
-    curl -LSs https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-impl/${JAXB_VERSION}/jaxb-impl-${JAXB_VERSION}.jar -o /pct/jdk11-libs/jaxb-impl.jar && \
-    curl -LSs https://repo1.maven.org/maven2/com/sun/activation/javax.activation/${JAF_VERSION}/javax.activation-${JAF_VERSION}.jar -o /pct/jdk11-libs/javax.activation.jar && \
-    echo "99f802e0cb3e953ba3d6e698795c4aeb98d37c48  /pct/jdk11-libs/jaxb-api.jar\n\
-23574ca124d0a694721ce3ef13cd720095f18fdd  /pct/jdk11-libs/jaxb-core.jar\n\
-2e979dabb3e5e74a0686115075956391a14dece8  /pct/jdk11-libs/jaxb-impl.jar\n\
-bf744c1e2776ed1de3c55c8dac1057ec331ef744  /pct/jdk11-libs/javax.activation.jar" | sha1sum -c
-
 COPY src/main/docker/*.groovy /pct/scripts/
 COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar /pct/pct-cli.jar
 COPY src/main/docker/run-pct.sh /usr/local/bin/run-pct

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,9 @@
 TEST_JDK_HOME?=$(JAVA_HOME)
 PLUGIN_NAME?=mailer
 
+# TODO: Switch to 2.164.1 LTS once it is released
 # Weekly with the latest Java 11 patches is used by default
-JENKINS_VERSION=2.155
-JAXB_API_VERSION=2.3.0
-JAXB_VERSION=2.3.0.1
-JAF_VERSION=1.2.0
+JENKINS_VERSION=2.164
 
 .PHONY: all
 all: clean package docker
@@ -32,26 +30,6 @@ tmp/jenkins-war-$(JENKINS_VERSION).war: tmp
 	mvn dependency:copy -Dartifact=org.jenkins-ci.main:jenkins-war:$(JENKINS_VERSION):war -DoutputDirectory=tmp
 	touch tmp/jenkins-war-$(JENKINS_VERSION).war
 
-.PRECIOUS: tmp/jaxb-api-$(JAXB_API_VERSION).jar
-tmp/jaxb-api-$(JAXB_API_VERSION).jar: tmp
-	mvn dependency:copy -Dartifact=javax.xml.bind:jaxb-api:$(JAXB_API_VERSION) -DoutputDirectory=tmp
-	touch tmp/jaxb-api-$(JAXB_API_VERSION).jar
-
-.PRECIOUS: tmp/jaxb-core-$(JAXB_VERSION).jar
-tmp/jaxb-core-$(JAXB_VERSION).jar: tmp
-	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-core:$(JAXB_VERSION) -DoutputDirectory=tmp
-	touch tmp/jaxb-core-$(JAXB_VERSION).jar
-
-.PRECIOUS: tmp/jaxb-impl-$(JAXB_VERSION).jar
-tmp/jaxb-impl-$(JAXB_VERSION).jar: tmp
-	mvn dependency:copy -Dartifact=com.sun.xml.bind:jaxb-impl:$(JAXB_VERSION) -DoutputDirectory=tmp
-	touch tmp/jaxb-impl-$(JAXB_VERSION).jar
-
-.PRECIOUS: tmp/javax.activation-$(JAF_VERSION).jar
-tmp/javax.activation-$(JAF_VERSION).jar: tmp
-	mvn dependency:copy -Dartifact=com.sun.activation:javax.activation:$(JAF_VERSION) -DoutputDirectory=tmp
-	touch tmp/javax.activation-$(JAF_VERSION).jar
-
 .PHONY: print-java-home
 print-java-home:
 	echo "Using JAVA_HOME for tests $(TEST_JDK_HOME)"
@@ -69,7 +47,7 @@ demo-jdk8: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/je
 	     -includePlugins $(PLUGIN_NAME)
 
 .PHONY: demo-jdk11
-demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/javax.activation-$(JAF_VERSION).jar tmp/jaxb-api-$(JAXB_API_VERSION).jar tmp/jenkins-war-$(JENKINS_VERSION).war tmp/jaxb-impl-$(JAXB_VERSION).jar tmp/jaxb-core-$(JAXB_VERSION).jar print-java-home
+demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/jenkins-war-$(JENKINS_VERSION).war print-java-home
 	# TODO Cleanup when/if the JAXB bundling issue is resolved.
 	# https://issues.jenkins-ci.org/browse/JENKINS-52186
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
@@ -80,7 +58,6 @@ demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/j
 	     -mvn $(shell which mvn) \
 	     -war $(CURDIR)/tmp/jenkins-war-$(JENKINS_VERSION).war \
 	     -testJDKHome $(TEST_JDK_HOME) \
-	     -testJavaArgs "-p $(CURDIR)/tmp/jaxb-api-$(JAXB_API_VERSION).jar:$(CURDIR)/tmp/javax.activation-$(JAF_VERSION).jar --add-modules java.xml.bind,java.activation -cp $(CURDIR)/tmp/jaxb-impl-$(JAXB_VERSION).jar:$(CURDIR)/tmp/jaxb-core-$(JAXB_VERSION).jar" \
 	     -includePlugins $(PLUGIN_NAME)
 
 # We do not automatically rebuild Docker here

--- a/README.md
+++ b/README.md
@@ -91,24 +91,25 @@ You can run the CLI with the `-help` argument to get a full list of supported op
 
 Plugin compat tester supports running Test Suites with a Java version different 
 from the one being used to run PCT and build the plugins.
-For example, such mode can be used to run tests with JDK11 while
-the plugin build flow is not adapted to it.
+For example, such mode can be used to run tests with JDK11 starting from Jenkins 2.163.
 
 Two options can be passed to PCT CLI for such purpose:
 
 * `testJDKHome` - A path to JDK HOME to be used for running tests in plugins
 * `testJavaArgs` - Java test arguments to be used for test runs.
-                   For JDK 11 this option may be used to pass modules and the classpath
+                   This option may be used to pass custom classpath and, in Java 11, additional modules
 
 You can run the example by running the following command:
 
-    make demo-jdk11 -e TEST_JDK_HOME=${YOUR_JDK11_HOME}
+    make demo-jdk11 -e TEST_JDK_HOME=${YOUR_JDK11_HOME} -e PLUGIN_NAME=git
+    
+When using the Docker image, it is possible to use `JDK_VERSION` variable to select 
+the version to use. The version needs to be bundled in the docker image.
+Currently Java 8 and Java 11 are bundled (JDK_VERSION= {8, 11}).
+    
+    make demo-jdk11-docker -e JDK_VERSION=11 PLUGIN_NAME=git
 
 Full list of options for JDK11 can be found [here](./Makefile).
-
-When using the docker image, it is possible to use `JDK_VERSION` variable to select 
-the version to use. The version needs to be bundled in the docker image. By specifying 
-`11`, the modules and jaxb libraries are also added to the command line. 
 
 ### Running PCT with different version of dependencies
 

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -146,12 +146,7 @@ mkdir -p "${PCT_OUTPUT_DIR}"
 # Determine if we test the plugin against another JDK
 ###
 TEST_JDK_HOME=${TEST_JAVA_ARGS:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-openjdk-amd64"}
-if [[ "${JDK_VERSION}" = "11" ]] ; then
-  echo "JDK_VERSION detected is 11. Adding JAXB and modules to the command lines."
-  TEST_JAVA_ARGS="'${TEST_JAVA_ARGS:-} -p /pct/jdk11-libs/jaxb-api.jar:/pct/jdk11-libs/javax.activation.jar --add-modules java.xml.bind,java.activation -cp /pct/jdk11-libs/jaxb-impl.jar:/pct/jdk11-libs/jaxb-core.jar -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true'"
-else
-  TEST_JAVA_ARGS="'${TEST_JAVA_ARGS:-} -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true'"
-fi
+TEST_JAVA_ARGS="'${TEST_JAVA_ARGS:-} -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true'"
 
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710
 pctExitCode=0


### PR DESCRIPTION
This change updates the Docker image, documentation and demos so that the changes are compliant with the Java 11 support improvements in Jenkins 2.163 and above.

https://issues.jenkins-ci.org/browse/JENKINS-55962

@jenkinsci/java11-support @raul-arabaolaza 
