### PR TITLE
Allow to use multiple plugins at once in docker image when using a war file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ The command below will run PCT for a branch in a custom repository.
 docker run --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -e CHECKOUT_SRC=https://github.com/oleg-nenashev/job-restrictions-plugin.git -e VERSION=JENKINS-26374 jenkins/pct
 ```
 
+#### Full PCT runs using a war file as input with Docker
+
+The PCT cli supports to pass a war file containing plugins (generated with Custom war Packager for example) as input, in this case the version of
+the plugins is infered from the war file contents.
+
+In such scenarios is tipical to want to run the PCT for all plugins contained in the war file, to avoid having to spawn a new docker container for each plugin
+you can use the env variables `DO_NOT_OVERRIDE_PCT_CHECKOUT=true` and `FAIL_ON_ERROR=false` to let the PCT CLI (instead of the `run-pct` script) checkout the proper
+versions of the plugins and make sure the PCT does not stop before testing all plugins.
+
+By using those env variables you can pass a comma separated list of plugins ids using the `ARTIFACT_ID` env variable
+
+```shell
+docker run -ti --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out -v my/jenkins.war:/pct/jenkins.war:ro -e ARTIFACT_ID=ssh-slaves,credentials -e DO_NOT_OVERRIDE_PCT_CHECKOUT=true -e FAIL_ON_ERROR=false jenkins/pct
+```
+
 #### Configuration
 
 Environment variables:

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -25,6 +25,7 @@ if [ -n "${ARTIFACT_ID}" ]; then
 fi
 
 CUSTOM_MAVEN_SETTINGS=${M2_SETTINGS_FILE:-"/pct/m2-settings.xml"}
+FAIL_ON_ERROR=${FAIL_ON_ERROR:-"true"}
 
 if [ -f "${CUSTOM_MAVEN_SETTINGS}" ] ; then
     echo "Using a custom Maven settings file"
@@ -155,7 +156,7 @@ echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
   -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
   -skipTestCache true \
-  -failOnError \
+  -failOnError ${FAIL_ON_ERROR}\
   ${LOCAL_CHECKOUT_ARG} \
   -includePlugins "${ARTIFACT_ID}" \
   -mvn "/usr/bin/mvn" \

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -27,12 +27,13 @@ fi
 CUSTOM_MAVEN_SETTINGS=${M2_SETTINGS_FILE:-"/pct/m2-settings.xml"}
 
 # Set failOnError by default unless env FAIL_ON_ERROR is false
+FAIL_ON_ERROR_ARG=""
 if [ -n "${FAIL_ON_ERROR}" ]; then
     if [ "${FAIL_ON_ERROR}" != "false" ] ; then
-        FAIL_ON_ERROR="-failOnError"
+        FAIL_ON_ERROR_ARG="-failOnError"
     fi
 else
-    FAIL_ON_ERROR="-failOnError"
+    FAIL_ON_ERROR_ARG="-failOnError"
 fi
 
 if [ -f "${CUSTOM_MAVEN_SETTINGS}" ] ; then
@@ -164,7 +165,7 @@ echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
   -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
   -skipTestCache true \
-  ${FAIL_ON_ERROR}\
+  ${FAIL_ON_ERROR_ARG}\
   ${LOCAL_CHECKOUT_ARG} \
   -includePlugins "${ARTIFACT_ID}" \
   -mvn "/usr/bin/mvn" \

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -42,9 +42,7 @@ else
       exit -1
     fi
   else
-    if [ -z "${DO_NOT_CHECKOUT}" ] ; then
-        CHECKOUT_SRC="https://github.com/jenkinsci/${ARTIFACT_ID}-plugin.git"
-    fi
+    CHECKOUT_SRC="https://github.com/jenkinsci/${ARTIFACT_ID}-plugin.git"
   fi
 fi
 

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -25,7 +25,15 @@ if [ -n "${ARTIFACT_ID}" ]; then
 fi
 
 CUSTOM_MAVEN_SETTINGS=${M2_SETTINGS_FILE:-"/pct/m2-settings.xml"}
-FAIL_ON_ERROR=${FAIL_ON_ERROR:-"true"}
+
+# Set failOnError by default unless env FAIL_ON_ERROR is false
+if [ -n "${FAIL_ON_ERROR}" ]; then
+    if [ "${FAIL_ON_ERROR}" != "false" ] ; then
+        FAIL_ON_ERROR="-failOnError"
+    fi
+else
+    FAIL_ON_ERROR="-failOnError"
+fi
 
 if [ -f "${CUSTOM_MAVEN_SETTINGS}" ] ; then
     echo "Using a custom Maven settings file"
@@ -156,7 +164,7 @@ echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
   -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
   -skipTestCache true \
-  -failOnError ${FAIL_ON_ERROR}\
+  ${FAIL_ON_ERROR}\
   ${LOCAL_CHECKOUT_ARG} \
   -includePlugins "${ARTIFACT_ID}" \
   -mvn "/usr/bin/mvn" \

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -42,7 +42,9 @@ else
       exit -1
     fi
   else
-    CHECKOUT_SRC="https://github.com/jenkinsci/${ARTIFACT_ID}-plugin.git"
+    if [ -z "${DO_NOT_CHECKOUT}" ] ; then
+        CHECKOUT_SRC="https://github.com/jenkinsci/${ARTIFACT_ID}-plugin.git"
+    fi
   fi
 fi
 
@@ -105,7 +107,7 @@ if [[ "$DEBUG" ]] ; then
 fi
 
 LOCAL_CHECKOUT_ARG=""
-if [ "${SHOULD_CHECKOUT}" -eq 1 ] ; then
+if [ "${SHOULD_CHECKOUT}" -eq 1 ] && [ -z "${DO_NOT_OVERRIDE_PCT_CHECKOUT}" ] ; then
   ###
   # Checkout sources
   ###


### PR DESCRIPTION
As the PCT CLI is able to inspect the war file and get version from there
there is no need to do the checkout previously in the run-pct script. This can save a lot of time when running the PCT for every plugin inside a war file as input as you do not need to download full maven deps for every plugin in the war file

Simply add the `DO_NOT_OVERRIDE_PCT_CHECKOUT=true` env variable to the docker run
Also in those cases you should run the entire test suite even if one plugin fails, so you also need to disable the default `failOnError` passed by the docker image to PCT cli, to do that add the following env variable `FAIL_ON_ERROR=false`  