### PR TITLE
[JENKINS-56312] Prevent adding splits with the wrong JDK

### DIFF
--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -337,8 +337,19 @@ public class PluginCompatTesterConfig {
             LOGGER.info("testJdkHome unset, using java available from the PATH");
             javaCmdAbsolutePath = "java";
         }
-        final Process process = new ProcessBuilder().command(javaCmdAbsolutePath, "-fullversion").redirectErrorStream(true).start();
+        final Process process = new ProcessBuilder().command(javaCmdAbsolutePath, "-XshowSettings:properties -version").redirectErrorStream(true).start();
         final String javaVersionOutput = IOUtils.toString(process.getInputStream());
+        final String[] lines = javaVersionOutput.split("[\\r\\n]+");
+        for (String line: lines) {
+            String trimed = line.trim();
+            if (trimed.contains("java.specification.version")) {
+                //java.specification.version = version
+                return trimed.split("=")[1].trim();
+            }
+        }
+        // Default to fullversion output as before
+        final Process process2 = new ProcessBuilder().command(javaCmdAbsolutePath, "-fullversion").redirectErrorStream(true).start();
+        final String javaVersionOutput2 = IOUtils.toString(process2.getInputStream());
         // Expected format is something like openjdk full version "1.8.0_181-8u181-b13-2~deb9u1-b13"
         // We shorten it by removing the "full version" in the middle
         return javaVersionOutput.

--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -222,5 +222,9 @@
       <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -924,7 +924,7 @@ public class PluginCompatTester {
                 if (jdkVersion.isNewerThan(new VersionNumber(tokens[3]))) {
                     filterSplits.add(split);
                 } else {
-                    System.out.println("Not adding " + split + "as split because jdk specified " + tokens[3] + " is newer than running jdk " + jdkVersion);
+                    System.out.println("Not adding " + split + " as split because jdk specified " + tokens[3] + " is newer than running jdk " + jdkVersion);
                 }
             } else {
                 filterSplits.add(split);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -923,7 +923,7 @@ public class PluginCompatTester {
         for (String split : splits) {
             String[] tokens = split.trim().split("\\s+");
             if (tokens.length == 4 ) { // We have a jdk field in the splits file
-                if (jdkVersion.isNewerThan(new VersionNumber(tokens[3]))) {
+                if (jdkVersion.isNewerThan(new JavaSpecificationVersion(tokens[3]))) {
                     filterSplits.add(split);
                 } else {
                     System.out.println("Not adding " + split + " as split because jdk specified " + tokens[3] + " is newer than running jdk " + jdkVersion);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -34,6 +34,8 @@ import hudson.model.UpdateSite;
 import hudson.model.UpdateSite.Plugin;
 import hudson.util.VersionNumber;
 import java.io.BufferedReader;
+
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
@@ -877,7 +879,7 @@ public class PluginCompatTester {
     private void populateSplits(File war) throws IOException {
         System.out.println("Checking " + war + " for plugin split metadata…");
         System.out.println("Checking jdk version as splits may depend on a jdk version");
-        VersionNumber jdkVersion = new VersionNumber(config.getTestJavaVersion()); // From Java 9 onwards there is a standard for versions see JEP-223
+        JavaSpecificationVersion jdkVersion = new JavaSpecificationVersion(config.getTestJavaVersion()); // From Java 9 onwards there is a standard for versions see JEP-223
         try (JarFile jf = new JarFile(war, false)) {
             Enumeration<JarEntry> warEntries = jf.entries();
             while (warEntries.hasMoreElements()) {
@@ -916,7 +918,7 @@ public class PluginCompatTester {
         throw new IOException("no jenkins-core-*.jar found in " + war);
     }
 
-    private List<String> removeSplitsBasedOnJDK(List<String> splits, VersionNumber jdkVersion) {
+    private List<String> removeSplitsBasedOnJDK(List<String> splits, JavaSpecificationVersion jdkVersion) {
         List<String> filterSplits = new LinkedList();
         for (String split : splits) {
             String[] tokens = split.trim().split("\\s+");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -76,6 +76,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -875,6 +876,8 @@ public class PluginCompatTester {
     /** Use JENKINS-47634 to load metadata from jenkins-core.jar if available. */
     private void populateSplits(File war) throws IOException {
         System.out.println("Checking " + war + " for plugin split metadata…");
+        System.out.println("Checking jdk version as splits may depend on a jdk version");
+        VersionNumber jdkVersion = new VersionNumber(config.getTestJavaVersion()); // From Java 9 onwards there is a standard for versions see JEP-223
         try (JarFile jf = new JarFile(war, false)) {
             Enumeration<JarEntry> warEntries = jf.entries();
             while (warEntries.hasMoreElements()) {
@@ -887,6 +890,9 @@ public class PluginCompatTester {
                         while ((entry = jis.getNextJarEntry()) != null) {
                             if (entry.getName().equals("jenkins/split-plugins.txt")) {
                                 splits = configLines(jis).collect(Collectors.toList());
+                                // Since https://github.com/jenkinsci/jenkins/pull/3865 splits can depend on jdk version
+                                // So make sure we are not applying splits not intended for our JDK
+                                splits = removeSplitsBasedOnJDK(splits, jdkVersion);
                                 System.out.println("found splits: " + splits);
                                 found++;
                             } else if (entry.getName().equals("jenkins/split-plugin-cycles.txt")) {
@@ -909,6 +915,24 @@ public class PluginCompatTester {
         }
         throw new IOException("no jenkins-core-*.jar found in " + war);
     }
+
+    private List<String> removeSplitsBasedOnJDK(List<String> splits, VersionNumber jdkVersion) {
+        List<String> filterSplits = new LinkedList();
+        for (String split : splits) {
+            String[] tokens = split.trim().split("\\s+");
+            if (tokens.length == 4 ) { // We have a jdk field in the splits file
+                if (jdkVersion.isNewerThan(new VersionNumber(tokens[3]))) {
+                    filterSplits.add(split);
+                } else {
+                    System.out.println("Not adding " + split + "as split because jdk specified " + tokens[3] + " is newer than running jdk " + jdkVersion);
+                }
+            } else {
+                filterSplits.add(split);
+            }
+        }
+        return filterSplits;
+    }
+
     // Matches syntax in ClassicPluginStrategy:
     private static Stream<String> configLines(InputStream is) throws IOException {
         return IOUtils.readLines(is, StandardCharsets.UTF_8).stream().filter(line -> !line.matches("#.*|\\s*"));

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>version-number</artifactId>
+        <version>1.6</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>15.0</version>


### PR DESCRIPTION
[JENKINS-56312](https://issues.jenkins-ci.org/browse/JENKINS-56312) Only add splits with JDK field if testJDK is newer than the specified JDK version.

This is the first of two fixes to prevent failures related to the PCT adding `jaxb` plugin to builds outside of java 11, second one will make sure the added `jaxb` dependency uses the proper groupId instead of `org.jenkins-ci.plugins` 