### PR TITLE
[JENKINS-56321] Scan detached plugins to get proper group id

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -608,8 +608,9 @@ public class PluginCompatTester {
                     top.put("core", new JSONObject().accumulate("name", "core").accumulate("version", m.group(1)).accumulate("url", "https://foobar"));
                 }
 
-                //TODO: should it also scan detached plugins info?
-                m = Pattern.compile("WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi").matcher(name);
+                // We should also scan detached plugins to make sure we get the proper groupId for detached not using the
+                // default org.jenkins-ci one
+                m = Pattern.compile("WEB-INF/(?:(optional-|detached-))?plugins/([^/.]+)[.][hj]pi").matcher(name);
                 if (m.matches()) {
                     JSONObject plugin = new JSONObject().accumulate("url", "");
                     InputStream is = jf.getInputStream(entry);


### PR DESCRIPTION
[JENKINS-56321](https://issues.jenkins-ci.org/browse/JENKINS-56321)

Detached plugins are added with default group id, this makes `jaxb` to be added with the wrong group id. Given that detached are always embedded into the war it makes sense to also scan group ids for detached plugins as is done for embedded ones. As a result, any detached plugin with a group id different from `org.jenkins-ci.plugins` (like '`jaxb`) is going to be properly added  