### PR TITLE
Add a /commit.txt with the build sha in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,10 @@ COPY --from=builder /pct/src/plugins-compat-tester-cli/target/plugins-compat-tes
 COPY src/main/docker/run-pct.sh /usr/local/bin/run-pct
 COPY src/main/docker/pct-default-settings.xml /pct/default-m2-settings.xml
 
+# TODO: remove .git addition and generate a commit.txt file once we don't use Docker Hub anymore
+ADD .git /tmp/repo
+RUN cd /tmp/repo && git rev-parse HEAD > /commit.txt && rm -rf /tmp/repo
+
 EXPOSE 5005
 
 VOLUME /pct/plugin-src


### PR DESCRIPTION
This will allow making sure easily what version of the sources were used to
build a given image.

Given the entrypoint is overridden, the usage would be:

```
docker run --entrypoint cat jenkins/pct /commit.txt
```

cc @jenkinsci/java11-support 