### PR TITLE
Remove duplicated version-number dependency and use inherited version

### DIFF
--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -20,7 +20,6 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.tests</groupId>
@@ -222,9 +221,5 @@
       <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>version-number</artifactId>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jenkins-ci.tests:plugins-compat-tester:jar:0.0.3-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.jenkins-ci:version-number:jar -> version 1.4 vs (?) @ line 225, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```