### PR TITLE
Add a flag to disable local install of artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,6 @@ demo-jdk8: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/je
 
 .PHONY: demo-jdk11
 demo-jdk11: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar tmp/jenkins-war-$(JENKINS_VERSION).war print-java-home
-	# TODO Cleanup when/if the JAXB bundling issue is resolved.
-	# https://issues.jenkins-ci.org/browse/JENKINS-52186
 	java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -failOnError \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ The image will be able to determine this ID automatically if `CHECKOUT_SRC` or `
 * `DEBUG` - Boolean flag, which enables the Remote Debug mode (port == 5000)
 * `M2_SETTINGS_FILE` -  If set indicates the path of the custom maven settings file to use (see volumes below)
 * `INSTALL_BUNDLED_SNAPSHOTS` - Install JAR and plugin snapshots to local repository.
-        `true` by default. WAR snapshots will be always installed.
+        `true` by default.
+* `SKIP_LOCAL_SNAPSHOT_INSTALLATION` - If exists WAR snapshots (core and plugins) will not be installed, if not present war snapshots will be installed
 
 Volumes:
 

--- a/plugins-compat-tester-cli/pom.xml
+++ b/plugins-compat-tester-cli/pom.xml
@@ -18,7 +18,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>2.3</version>
+            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>package</phase>

--- a/plugins-compat-tester-gae/pom.xml
+++ b/plugins-compat-tester-gae/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-api-1.0-sdk</artifactId>
-        <version>1.5.5</version>
+        <version>1.9.73</version>
     </dependency>
     <dependency>
         <groupId>javax.servlet</groupId>

--- a/plugins-compat-tester/pom.xml
+++ b/plugins-compat-tester/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.9.2</version>
+      <version>1.10.5</version>
     </dependency>
 
     <!-- Upper bounds in Embedder -->

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -13,7 +13,7 @@ fi
 explodeWARIfNeeded() {
   if [ ! -f "${PCT_TMP}/exploded/war" ]; then
     mkdir -p "${PCT_TMP}/exploded/war"
-    unzip -q "${JENKINS_WAR_PATH}" -d "${PCT_TMP}/exploded/war"
+    unzip -o -q "${JENKINS_WAR_PATH}" -d "${PCT_TMP}/exploded/war"
   fi
 }
 
@@ -72,20 +72,22 @@ if [ -f "${JENKINS_WAR_PATH}" ]; then
     # TODO: Bug or feature?
     # Implementation-Version and Jenkins-Version may differ.
     # We specify version explicitly to use Jenkins-Version like PCT does
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" \
-        -Dpackaging=war -Dversion="${JENKINS_VERSION}" -Dfile="jenkins.war" \
-        -DpomFile="exploded/war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" \
-        -Dpackaging=jar -Dfile="exploded/war/WEB-INF/lib/jenkins-core-${JENKINS_VERSION}.jar"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" \
-        -Dpackaging=jar -Dfile="exploded/war/WEB-INF/lib/cli-${JENKINS_VERSION}.jar"
-    mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode -Dpackaging=pom ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}"  \
-        -Dfile="exploded/war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml" \
-        -DpomFile="exploded/war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml" \
-        -Dversion="${JENKINS_VERSION}" -DartifactId="jenkins-war" -DgroupId="org.jenkins-ci.main"
-    if [ "$INSTALL_BUNDLED_SNAPSHOTS" ] ; then
-        # Install HPI, JAR and POM
-        groovy /pct/scripts/installWARSnapshots.groovy "$(pwd)/exploded/war/WEB-INF/plugins" "$(pwd)/exploded" "${MVN_SETTINGS_FILE}" "${JAVA_OPTS}"
+    if [ -z "${skipLocalInstall}" ] ; then
+        mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" \
+            -Dpackaging=war -Dversion="${JENKINS_VERSION}" -Dfile="jenkins.war" \
+            -DpomFile="exploded/war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml"
+        mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" \
+            -Dpackaging=jar -Dfile="exploded/war/WEB-INF/lib/jenkins-core-${JENKINS_VERSION}.jar"
+        mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}" \
+            -Dpackaging=jar -Dfile="exploded/war/WEB-INF/lib/cli-${JENKINS_VERSION}.jar"
+        mvn org.apache.maven.plugins:maven-install-plugin:2.5:install-file --batch-mode -Dpackaging=pom ${JAVA_OPTS} -s "${MVN_SETTINGS_FILE}"  \
+            -Dfile="exploded/war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml" \
+            -DpomFile="exploded/war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.xml" \
+            -Dversion="${JENKINS_VERSION}" -DartifactId="jenkins-war" -DgroupId="org.jenkins-ci.main"
+        if [ "$INSTALL_BUNDLED_SNAPSHOTS" ] ; then
+            # Install HPI, JAR and POM
+            groovy /pct/scripts/installWARSnapshots.groovy "$(pwd)/exploded/war/WEB-INF/plugins" "$(pwd)/exploded" "${MVN_SETTINGS_FILE}" "${JAVA_OPTS}"
+        fi
     fi
   fi
 else


### PR DESCRIPTION
When you are working with snapshots (for example when doing local development) the `run-pct` script tries to install artifacts from the war file to make sure they are available for local runs. However, that could not work when using custom generated war files and is unneeded if you share somehow your local maven repo with all the needed artifacts already there (I use that approach every day)

So, this PR introduces a flag to prevent that local installation to happen if desired 