### PR TITLE
[JENKINS-58051] Hook for plugins not using standard tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
 
 will run the PCT on the `mailer` plugin, but replacing the `display-url-api` dependency of Mailer (which is `1.0`) with the version `2.3.0`.
 
+### Running the PCT for plugins not following standard tag
+
+If a plugin does not follow the standard tagging of the Jenkins community the PCT will not be able to
+find and checkout the proper code from github. For those cases the PCT provides a hook that will override the
+default checkout mechanism.
+
+This hook reads the property file []nonstandardtagplugins.properties](./plugins-compat-tester/src/main/resources/) to get the information about the tag format used for the affected plugins. Each plugin that wishes to use this mechanism
+has to add a new property with the artifactId of the plugin as key and a value compatible with [String.format](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#format-java.lang.String-java.lang.Object...-) the only argument
+allowed for the format string is the version to chekout
+
+
 ## Developer Info
 
 ### Debugging PCT in Docker

--- a/README.md
+++ b/README.md
@@ -155,9 +155,17 @@ If a plugin does not follow the standard tagging of the Jenkins community the PC
 find and checkout the proper code from github. For those cases the PCT provides a hook that will override the
 default checkout mechanism.
 
-This hook reads the property file []nonstandardtagplugins.properties](./plugins-compat-tester/src/main/resources/) to get the information about the tag format used for the affected plugins. Each plugin that wishes to use this mechanism
+This hook reads the property file [nonstandardtagplugins.properties](./plugins-compat-tester/src/main/resources/) to get the information about the tag format used for the affected plugins. Each plugin that wishes to use this mechanism
 has to add a new property with the artifactId of the plugin as key and a value compatible with [String.format](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#format-java.lang.String-java.lang.Object...-) the only argument
-allowed for the format string is the version to chekout
+allowed for the format string is the version to chekout.
+
+You can also specify a minimum version for the plugin to be processed by the hook, for that you add a new entry in the aforementioned properties file with the key `artifactId-minimumVersion` and value
+the lowest version of the plugin for the hook to activate, if you do that the hook will ignore any run of the plugin if the specified version is lower than the one in the properties file.
+
+```
+electricflow=cloudbees-flow-%s
+electricflow-minimumVersion=1.1.8
+```
 
 
 ## Developer Info

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NonStandardTagHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NonStandardTagHook.java
@@ -1,0 +1,94 @@
+package org.jenkins.tools.test.hook;
+
+import hudson.model.UpdateSite;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTag;
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.repository.ScmRepository;
+import org.jenkins.tools.test.SCMManagerFactory;
+import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.PomData;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This hook allows plugin using a non standard tag format on github to be checked out.
+ *
+ * The affected plugins are loaded from a properties file whose key is the artifactId and the value is a string to be formatted
+ * for the tag value, this value will be calculated using String.format passing the current version as the only parameter
+ */
+public class NonStandardTagHook  extends PluginCompatTesterHookBeforeCheckout {
+
+    final Properties affectedPlugins;
+    final List<String> transformedPlugins = new LinkedList<>();
+
+    public NonStandardTagHook()  {
+        affectedPlugins = new Properties();
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream("nonstandardtagplugins.properties")) {
+            affectedPlugins.load(inputStream);
+            affectedPlugins.keySet().forEach(e -> transformedPlugins.add(e.toString()));
+        } catch (IOException e) {
+            System.err.println("WARNING: NonStandardTagHook was not able to load affected plugins, the hook will do nothing");
+            e.printStackTrace();
+        }
+        ;
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) throws Exception {
+        PomData pomData = (PomData)info.get("pomData");
+        return affectedPlugins.containsKey(pomData.artifactId);
+    }
+
+    @Override
+    public Map<String, Object> action(Map<String, Object> info) throws Exception {
+        PluginCompatTesterConfig config = (PluginCompatTesterConfig)info.get("config");
+        PomData pomData = (PomData)info.get("pomData");
+        UpdateSite.Plugin plugin = (UpdateSite.Plugin) info.get("plugin");
+
+        // We should not execute the hook if using localCheckoutDir
+        boolean shouldExecuteHook = config.getLocalCheckoutDir() == null || !config.getLocalCheckoutDir().exists();
+
+        if (shouldExecuteHook) {
+            System.out.println("Executing " + this.getClass().getSimpleName() + " for " + pomData.artifactId);
+
+                // Checkout to the parent directory. All other processes will be on the child directory
+                File checkoutPath = new File(config.workDirectory.getAbsolutePath() + "/" + pomData.artifactId);
+
+                String scmTag =  String.format(affectedPlugins.get(pomData.artifactId).toString(), plugin.version);
+                System.out.println("Checking out from SCM tag " + scmTag);
+                ScmManager scmManager = SCMManagerFactory.getInstance().createScmManager();
+                ScmRepository repository = scmManager.makeScmRepository(pomData.getConnectionUrl());
+                CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(checkoutPath), new ScmTag(scmTag));
+
+                if (!result.isSuccess()) {
+                    // Throw an exception if there are any download errors.
+                    throw new RuntimeException(result.getProviderMessage() + "||" + result.getCommandOutput());
+                }
+
+
+            // Checkout already happened, don't run through again
+            info.put("runCheckout", false);
+
+
+            info.put("checkoutDir", checkoutPath);
+            info.put("pluginDir", checkoutPath);
+        }
+        return info;
+
+    }
+
+    @Override
+    public List<String> transformedPlugins() {
+        return transformedPlugins;
+    }
+}

--- a/plugins-compat-tester/src/main/resources/nonstandardtagplugins.properties
+++ b/plugins-compat-tester/src/main/resources/nonstandardtagplugins.properties
@@ -1,0 +1,1 @@
+electricflow=cloudbees-flow-%s

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
@@ -1,0 +1,168 @@
+package org.jenkins.tools.test;
+
+
+import hudson.model.UpdateSite;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.manager.NoSuchScmProviderException;
+import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.repository.ScmRepository;
+import org.apache.maven.scm.repository.ScmRepositoryException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.jenkins.tools.test.hook.NonStandardTagHook;
+import org.jenkins.tools.test.model.MavenCoordinates;
+import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.PomData;
+import org.jenkins.tools.test.model.TestStatus;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static hudson.model.UpdateSite.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+@RunWith(PowerMockRunner.class)
+public class NonStandardTagHookTest {
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+
+    @Test
+    public void testConstruction() {
+        NonStandardTagHook hook = new NonStandardTagHook();
+        List<String> transformedPlugins = hook.transformedPlugins();
+        assertNotNull("The list of transformed plugins must be non null", transformedPlugins);
+        assertEquals("List of affected plugins must be of size 2", 2, transformedPlugins.size());
+        assertEquals("The element in transformedPlugins must be 'artifactID'", "artifactID", transformedPlugins.get(0));
+    }
+
+    @Test
+    public void testCheckMethod() {
+        NonStandardTagHook hook = new NonStandardTagHook();
+        Map<String, Object> info = new HashMap<>();
+        JSONObject pluginData = new JSONObject();
+        pluginData.put("name", "electricflow");
+        pluginData.put("version", "1.1.8");
+        pluginData.put("url", "example.com");
+        pluginData.put("dependencies", new JSONArray());
+        UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source", pluginData);
+        info.put("plugin", plugin);
+        try {
+            assertTrue("Check should be true", hook.check(info));
+        } catch (Exception e) {
+            fail("Exception calling check method " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCheckMethodWithMinimumVersion() {
+        NonStandardTagHook hook = new NonStandardTagHook();
+        Map<String, Object> info = new HashMap<>();
+        JSONObject pluginData = new JSONObject();
+        pluginData.put("name", "electricflow");
+        pluginData.put("version", "1.1.7");
+        pluginData.put("url", "example.com");
+        pluginData.put("dependencies", new JSONArray());
+        UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source", pluginData);
+        info.put("plugin", plugin);
+        try {
+            assertFalse("Check should be false", hook.check(info));
+        } catch (Exception e) {
+            fail("Exception calling check method " + e.getMessage());
+        }
+    }
+
+    @Test
+    @PrepareForTest({SCMManagerFactory.class,NonStandardTagHook.class})
+    public void testActionGeneratesProperInfo() throws Exception {
+        spy(SCMManagerFactory.class);
+        SCMManagerFactory mockFactory = mock(SCMManagerFactory.class);
+        ScmManager mockManager = mock(ScmManager.class);
+        CheckOutScmResult mockResult = mock(CheckOutScmResult.class);
+        when(mockResult.isSuccess()).thenReturn(Boolean.TRUE);
+        when(mockManager.checkOut(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(mockResult);
+        when(mockManager.makeScmRepository(Mockito.anyString())).thenReturn(mock(ScmRepository.class));
+        when(mockFactory.createScmManager()).thenReturn(mockManager);
+        when(SCMManagerFactory.getInstance()).thenReturn(mockFactory);
+
+
+        Map<String, Object> info = new HashMap<>();
+        PomData data = new PomData("artifactID", "hpi", null, null);
+        info.put("pomData", data);
+        JSONObject pluginData = new JSONObject();
+        pluginData.put("name","artifactId");
+        pluginData.put("version","9.9.99");
+        pluginData.put("url", "example.com");
+        pluginData.put("dependencies", new JSONArray());
+        UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source",pluginData);
+        info.put("plugin", plugin);
+        PluginCompatTesterConfig config = new PluginCompatTesterConfig(new File("/tmp/noexists"), null, null);
+        info.put("config", config);
+
+        NonStandardTagHook hook = new NonStandardTagHook();
+        Map<String, Object> returnedConfig = hook.action(info);
+        assertEquals("Checkout dir is not the expected", new File("/tmp/noexists/artifactID"), returnedConfig.get("checkoutDir"));
+        assertEquals("Checkout dir is not the same as plugin dir", returnedConfig.get("checkoutDir"), returnedConfig.get("pluginDir"));
+        assertEquals("RunCheckout should be false", Boolean.FALSE, returnedConfig.get("runCheckout"));
+
+    }
+
+    @Test
+    public void testActuallyPerformsTheCheckoutWithVersionGreaterThanMinimum() {
+
+        try {
+            SCMManagerFactory.getInstance().start();
+
+            PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
+                    new File("../reports/PluginCompatReport.xml"),
+                    new ClassPathResource("m2-settings.xml").getFile());
+            config.setIncludePlugins(Arrays.asList("electricflow"));
+            config.setSkipTestCache(true);
+            config.setCacheThresholStatus(TestStatus.TEST_FAILURES);
+            config.setTestCacheTimeout(345600000);
+            config.setParentVersion("1.410");
+            config.setGenerateHtmlReport(true);
+
+            Map<String, Object> info = new HashMap<>();
+            PomData data = new PomData("electricflow", "hpi", "scm:git:git://github.com/jenkinsci/electricflow-plugin.git", new MavenCoordinates("org.jenkins-ci.plugins", "electricflow", "1.1.8"));
+            info.put("pomData", data);
+            JSONObject pluginData = new JSONObject();
+            pluginData.put("name", "electricflow");
+            pluginData.put("version", "1.1.8");
+            pluginData.put("url", "example.com");
+            pluginData.put("dependencies", new JSONArray());
+            UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source", pluginData);
+            info.put("plugin", plugin);
+            info.put("config", config);
+
+
+            NonStandardTagHook hook = new NonStandardTagHook();
+            Map<String, Object> returnedConfig = hook.action(info);
+            assertEquals("RunCheckout should be false", Boolean.FALSE, returnedConfig.get("runCheckout"));
+        } catch (Exception e) {
+            fail("No expection should be thrown when invoking the hook for valid data but got: " + e);
+        }
+    }
+}

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
@@ -118,12 +118,12 @@ public class NonStandardTagHookTest {
         pluginData.put("dependencies", new JSONArray());
         UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source",pluginData);
         info.put("plugin", plugin);
-        PluginCompatTesterConfig config = new PluginCompatTesterConfig(new File("/tmp/noexists"), null, null);
+        PluginCompatTesterConfig config = new PluginCompatTesterConfig(new File(testFolder.getRoot(), "noexists"), null, null);
         info.put("config", config);
 
         NonStandardTagHook hook = new NonStandardTagHook();
         Map<String, Object> returnedConfig = hook.action(info);
-        assertEquals("Checkout dir is not the expected", new File("/tmp/noexists/artifactID"), returnedConfig.get("checkoutDir"));
+        assertEquals("Checkout dir is not the expected", new File(testFolder.getRoot(), "noexists/artifactID"), returnedConfig.get("checkoutDir"));
         assertEquals("Checkout dir is not the same as plugin dir", returnedConfig.get("checkoutDir"), returnedConfig.get("pluginDir"));
         assertEquals("RunCheckout should be false", Boolean.FALSE, returnedConfig.get("runCheckout"));
 

--- a/plugins-compat-tester/src/test/resources/nonstandardtagplugins.properties
+++ b/plugins-compat-tester/src/test/resources/nonstandardtagplugins.properties
@@ -1,2 +1,3 @@
+artifactID=artifactId-%s
 electricflow=cloudbees-flow-%s
 electricflow-minimumVersion=1.1.8

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <!-- Components -->
 
     <!-- Test libs -->
-    <powermock.version>1.4.8</powermock.version>
+    <powermock.version>1.6.1</powermock.version>
     <findbugs.effort>Max</findbugs.effort>
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>


### PR DESCRIPTION
[JENKINS-58051](https://issues.jenkins-ci.org/browse/JENKINS-58051) This PR introduces a hook that can be extended trivially by plugins not following the standard tag conventions in Jenkins to make the PCT able to checkout them from Github  