### PR TITLE
[JENKINS-58069] Add a hook for JCasC Plugin to enable PCT runs with it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,13 @@ itBranches['CasC tests success'] = {
         checkout scm
 
         stage('Build PCT CLI') {
-            sh 'make allNoDocker'
+            withEnv([
+                "JAVA_HOME=${tool 'jdk8'}",
+                "PATH+MVN=${tool 'mvn'}/bin",
+                'PATH+JDK=$JAVA_HOME/bin',
+            ]) {
+                sh 'make allNoDocker'
+            }
         }
 
         stage("Run known successful case(s)") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,5 +118,28 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK8'] = {
     }
 }
 
+itBranches['CasC tests success'] = {
+    node('linux') {
+        checkout scm
+
+        stage('Build PCT CLI') {
+            sh 'make allNoDocker'
+        }
+
+        stage("Run known successful case(s)") {
+            sh '''java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
+                         -reportFile $(pwd)/out/pct-report.xml \
+                         -workDirectory $(pwd)/out/work \
+                         -skipTestCache true \
+                         -includePlugins configuration-as-code
+            '''
+
+            archiveArtifacts artifacts: "out/**"
+
+            sh 'cat out/pct-report.html | grep "Tests : Success"'
+        }
+    }
+}
+
 itBranches.failFast = false
 parallel itBranches

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,16 +127,22 @@ itBranches['CasC tests success'] = {
         }
 
         stage("Run known successful case(s)") {
-            sh '''java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
-                         -reportFile $(pwd)/out/pct-report.xml \
-                         -workDirectory $(pwd)/out/work \
-                         -skipTestCache true \
-                         -includePlugins configuration-as-code
-            '''
+            withEnv([
+                "JAVA_HOME=${tool 'jdk8'}",
+                "PATH+MVN=${tool 'mvn'}/bin",
+                'PATH+JDK=$JAVA_HOME/bin',
+            ]) {
+                sh '''java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
+                             -reportFile $(pwd)/out/pct-report.xml \
+                             -workDirectory $(pwd)/out/work \
+                             -skipTestCache true \
+                             -includePlugins configuration-as-code
+                '''
 
-            archiveArtifacts artifacts: "out/**"
+                archiveArtifacts artifacts: "out/**"
 
-            sh 'cat out/pct-report.html | grep "Tests : Success"'
+                sh 'cat out/pct-report.html | grep "Tests : Success"'
+            }
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,15 @@ JENKINS_VERSION=2.164.3
 .PHONY: all
 all: clean package docker
 
+.PHONY: allNoDocker
+allNoDocker: clean package
+
 .PHONY: clean
 clean:
 	mvn clean
 
 plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar:
-	mvn verify
+	mvn package
 .PHONY: package
 package: plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar
 

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeExecution.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeExecution.java
@@ -5,7 +5,7 @@ import org.jenkins.tools.test.model.PomData;
 import java.util.Map;
 
 /**
- * An abstract class that marks a hook that runs before the compilation stage of the
+ * An abstract class that marks a hook that runs before the execution stage of the
  * Plugins Compat Tester.
  *
  * This exists simply for the ability to check when a subclass should be implemented.

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
@@ -1,0 +1,48 @@
+package org.jenkins.tools.test.hook;
+
+import hudson.model.UpdateSite;
+import org.jenkins.tools.test.model.PomData;
+
+import java.util.Map;
+
+public class ConfigurationAsCodeHook extends AbstractMultiParentHook {
+
+    @Override
+    protected String getParentFolder() {
+        return "configuration-as-code-plugin";
+    }
+
+    @Override
+    protected String getParentUrl() {
+        return "scm:git:git://github.com/jenkinsci/configuration-as-code-plugin.git";
+    }
+
+    @Override
+    protected String getParentProjectName() {
+        return "configuration-as-code";
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) {
+        return isCascPlugin(info);
+    }
+
+    @Override
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
+        return "plugin";
+    }
+
+    public static boolean isCascPlugin(Map<String, Object> moreInfo) {
+        PomData data = (PomData) moreInfo.get("pomData");
+        return isCascPlugin(data);
+    }
+
+    public static boolean isCascPlugin(PomData data) {
+        if (data.parent != null) {
+            // Non-incrementals
+            return data.parent.groupId.equalsIgnoreCase("io.jenkins.configuration-as-code");
+        }
+
+        return "configuration-as-code".equalsIgnoreCase(data.artifactId);
+    }
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -37,7 +37,6 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
         try {
             System.out.println("Executing multi-parent compile hook");
             PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
-            MavenCoordinates core = (MavenCoordinates) moreInfo.get("core");
 
             runner = config.getExternalMaven() == null ? new InternalMavenRunner() : new ExternalMavenRunner(config.getExternalMaven());
             mavenConfig = getMavenConfig(config);
@@ -85,7 +84,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
 
     @Override
     public boolean check(Map<String, Object> info) throws Exception {
-        return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info);
+        return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info) || ConfigurationAsCodeHook.isCascPlugin(info);
     }
 
     private boolean isEslintFile(Path file) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -36,6 +36,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean isStructs = StructsHook.isStructsPlugin(pomData);
         boolean isBO = BlueOceanHook.isBOPlugin(pomData);
         boolean isDeclarativePipeline = DeclarativePipelineHook.isDPPlugin(pomData);
+        boolean isCasC = ConfigurationAsCodeHook.isCascPlugin(pomData);
         boolean pluginPOM = pomData.isPluginPOM();
         if (parent != null) {
             isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
@@ -56,7 +57,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
         boolean coreRequiresPluginOver233 = coreCoordinates.compareVersionTo(CORE_WITHOUT_WAR_FOR_TEST) >= 0;
 
-        if (isDeclarativePipeline || isBO || isCB || isStructs || (pluginPOM && parentV2)) {
+        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || (pluginPOM && parentV2)) {
             List<String> argsToMod = (List<String>)info.get("args");
             argsToMod.add("-Djenkins.version=" + coreCoordinates.version);
             // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores


### PR DESCRIPTION
[JENKINS-58069](https://issues.jenkins-ci.org/browse/JENKINS-58069)

Create a multimodule hook for the configuration-as-code plugin.

![Screen Shot 2019-06-18 at 13 02 56](https://user-images.githubusercontent.com/6572596/59686690-edcd5400-91dc-11e9-9791-ed443c4901d3.png)


