### PR TITLE
Remove obsolete TODO comments from the README, they do not reflect the plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,16 +193,3 @@ and then to properly setup the environment.
    make demo-jdk8 -e PLUGIN_NAME=artifact-manager-s3 -e WAR_PATH=test-wars/mywar.war -e MVN_EXECUTABLE="C:\ProgramData\chocolatey\bin\mvn.exe" -e EXTRA_OPTS="-overridenPlugins 'configuration-as-code=1.20'"
 ```
 
-### TODOs
-
-To do (refile in `plugin-compat-tester` in JIRA!):
-
-1. `InternalMavenRunner` currently still seems to run `install` goal which is very undesirable on release tags
-1. should run `surefire-report:report` goal instead (or `surefire-report:report-only` after) and display link to HTML results from index page
-1. Export *everything* to GAE, dropping the data storing in XML files (which pollutes the filesystem and can be easily delete if we are careless) and processing with XSL. (migration already started to GAE datastorage, but not completely finished, especially on build logs). (jglick: this is undesirable, need to be able to review local results without uploading them)
-1. Improve GAE app to allow plugin maintainers to subscribe to notifications on plugin compatibility tests for their plugins against new jenkins versions released.
-1. Remove possibility, on GAE app, to select both "every plugins" and "every cores" results... because it generates too much results and crash GAE datastore
-1. most plugin tests fail to build using internal Maven; `PlexusWagonProvider.lookup` with a `roleHint=https` fails for no clear reason, and some missing `SNAPSHOT`s cause a build failure related to https://github.com/stapler/stapler-adjunct-codemirror/commit/da995b03a1f165fef7c9d34eadb15797f58399cd
-1. testing a module not at the root of its Git repo fails (`findbugs` succeeds but tests against old Jenkins core)
-1. testing `analysis-core` fails because it uses `org.jvnet.hudson.plugins:analysis-pom` as a parent
-1. when testing a plugin depending on other plugins, bump up the dependency to the latest released version…or even build the dependency from `master` sources


### PR DESCRIPTION
These comments were quite obsolete for a while, and I see no benefit in keeping them. Some comments have been already fixed actually.

I also created https://issues.jenkins-ci.org/browse/JENKINS-58113 and https://issues.jenkins-ci.org/browse/JENKINS-58114 to remove Maven Internal and GAE support from PCT. All these modes represent a serious maintenance burden while they do not seem to actually work or to be used by anyone.


