### PR TITLE
[JENKINS-57935] - Always poll the Update Center for plugin Group IDs when building WARs with plugins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ itBranches['WAR with Plugins - smoke test'] = {
                             -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
                             -e ARTIFACT_ID=artifact-manager-s3 -e VERSION=artifact-manager-s3-1.6 \
                             jenkins/pct \
-                            -overridenPlugins 'configuration-as-code=1.20' -overridenPlugins 'workflow-step-api=2.18'
+                            -overridenPlugins 'configuration-as-code=1.20'
             '''
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK11'] = {
             sh '''docker run --rm \
                          -v $(pwd)/jenkins.war:/pct/jenkins.war:ro \
                          -v $(pwd)/out:/pct/out -e JDK_VERSION=11 \
-                         -v $(pwd)/${settingsXML}:/pct/m2-settings.xml \
+                         -v $(pwd)/mvn-settings.xml:/pct/m2-settings.xml \
                          -e ARTIFACT_ID=buildtriggerbadge -e VERSION=buildtriggerbadge-2.10 \
                          jenkins/pct
             '''
@@ -113,7 +113,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK8'] = {
         stage("Run known successful case(s)") {
             sh '''docker run --rm \
                          -v $(pwd)/jenkins.war:/pct/jenkins.war:ro \
-                         -v $(pwd)/${settingsXML}:/pct/m2-settings.xml \
+                         -v $(pwd)/mvn-settings.xml:/pct/m2-settings.xml \
                          -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
                          -e ARTIFACT_ID=buildtriggerbadge -e VERSION=buildtriggerbadge-2.10 \
                          jenkins/pct
@@ -134,10 +134,12 @@ itBranches['WAR with Plugins - smoke test'] = {
         checkout scm
         dir("src/it/war-with-plugins-test") {
             def settingsXML="mvn-settings.xml"
+            infra.retrieveMavenSettingsFile(settingsXML)
+            
             infra.runMaven(["clean", "package"])
             sh '''docker run --rm \
-                            -v $(pwd)/tmp/output/target/war-with-plugins-test=1.0.war:/pct/jenkins.war:ro \
-                            -v $(pwd)/${settingsXML}:/pct/m2-settings.xml \
+                            -v $(pwd)/tmp/output/target/war-with-plugins-test-1.0.war:/pct/jenkins.war:ro \
+                            -v $(pwd)/mvn-settings.xml:/pct/m2-settings.xml \
                             -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
                             -e ARTIFACT_ID=artifact-manager-s3 -e VERSION=artifact-manager-s3-1.6 \
                             jenkins/pct

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,8 @@ itBranches['WAR with Plugins - smoke test'] = {
                             -v $(pwd)/mvn-settings.xml:/pct/m2-settings.xml \
                             -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
                             -e ARTIFACT_ID=artifact-manager-s3 -e VERSION=artifact-manager-s3-1.6 \
-                            jenkins/pct
+                            jenkins/pct \
+                            -overridenPlugins 'configuration-as-code=1.20' -overridenPlugins 'workflow-step-api=2.18'
             '''
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,9 +134,7 @@ itBranches['WAR with Plugins - smoke test'] = {
         checkout scm
         dir("src/it/war-with-plugins-test") {
             def settingsXML="mvn-settings.xml"
-            infra.retrieveMavenSettingsFile(settingsXML)
-
-            sh "mvn clean package -s ${settingsXML}"
+            infra.runMaven(["clean", "package"])
             sh '''docker run --rm \
                             -v $(pwd)/tmp/output/target/war-with-plugins-test=1.0.war:/pct/jenkins.war:ro \
                             -v $(pwd)/${settingsXML}:/pct/m2-settings.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,7 @@ properties([[$class: 'BuildDiscarderProperty',
 /* These platforms correspond to labels in ci.jenkins.io, see:
  *  https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
  */
-// TODO: restore
-List platforms = [] //'linux', 'windows']
+List platforms = ['linux', 'windows']
 Map branches = [:]
 
 for (int i = 0; i < platforms.size(); ++i) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK11'] = {
     node('docker') {
         checkout scm
         def settingsXML="mvn-settings.xml"
-        infra.retrieveMavenSettingsFile()
+        infra.retrieveMavenSettingsFile(settingsXML)
 
         // should we build the image only once and somehow export and stash/unstash it then?
         // not sure this would be that quicker
@@ -95,7 +95,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK8'] = {
     node('docker') {
         checkout scm
         def settingsXML="mvn-settings.xml"
-        infra.retrieveMavenSettingsFile()
+        infra.retrieveMavenSettingsFile(settingsXML)
 
         // should we build the image only once and somehow export and stash/unstash it then?
         // not sure this would be that quicker
@@ -134,7 +134,7 @@ itBranches['WAR with Plugins - smoke test'] = {
         checkout scm
         dir("src/it/war-with-plugins-test") {
             def settingsXML="mvn-settings.xml"
-            infra.retrieveMavenSettingsFile()
+            infra.retrieveMavenSettingsFile(settingsXML)
 
             sh "mvn clean package -s ${settingsXML}"
             sh '''docker run --rm \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK8'] = {
 }
 
 
-itBranches['WAR with Plugins - smoke test'] = {
+itBranches['WAR with non-default groupId plugins - smoke test'] = {
     node('docker') {
         checkout scm
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,11 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK8'] = {
 itBranches['WAR with Plugins - smoke test'] = {
     node('docker') {
         checkout scm
+        
+        stage('Build Docker Image') {
+          sh 'make docker'
+        }
+      
         dir("src/it/war-with-plugins-test") {
             def settingsXML="mvn-settings.xml"
             infra.retrieveMavenSettingsFile(settingsXML)
@@ -136,10 +141,6 @@ itBranches['WAR with Plugins - smoke test'] = {
               infra.runMaven(["clean", "package"])
             }
             
-            stage('Build Docker Image') {
-              sh 'make docker'
-            }
-          
             stage('Run the integration test') {
               sh '''docker run --rm \
                             -v $(pwd)/tmp/output/target/war-with-plugins-test-1.0.war:/pct/jenkins.war:ro \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,7 @@ itBranches['WAR with Plugins - smoke test'] = {
             infra.runMaven(["clean", "package"])
             sh '''docker run --rm \
                             -v $(pwd)/tmp/output/target/war-with-plugins-test=1.0.war:/pct/jenkins.war:ro \
-                            -v $(pwd)/${settingsXML}:/pct/m2-settings.xml
+                            -v $(pwd)/${settingsXML}:/pct/m2-settings.xml \
                             -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
                             -e ARTIFACT_ID=artifact-manager-s3 -e VERSION=artifact-manager-s3-1.6 \
                             jenkins/pct

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -178,8 +178,14 @@ public class PluginCompatTester {
         UpdateSite.Data data = config.getWar() == null ? extractUpdateCenterData(pluginGroupIds) : scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");        
         if (!data.plugins.isEmpty()) {
             // Scan detached plugins to recover proper Group IDs for them
-            UpdateSite.Data detachedData = config.getWar() == null ? extractUpdateCenterData(pluginGroupIds) : scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:detached-)?plugins/([^/.]+)[.][hj]pi");
-        
+            // We always poll the update center so that we extract groupIDs for dependencies
+            // In the case of Group ID renaming across version, groupID from the WAR file will have a priority
+            UpdateSite.Data detachedData = extractUpdateCenterData(pluginGroupIds);
+            if (config.getWar() != null) {
+                detachedData = scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:detached-)?plugins/([^/.]+)[.][hj]pi");
+            }
+
+
             // Add detached if and only if no added as normal one
             detachedData.plugins.entrySet().stream().forEach(entry -> {
                 if (!data.plugins.containsKey(entry.getKey())) {

--- a/src/it/war-with-plugins-test/Makefile
+++ b/src/it/war-with-plugins-test/Makefile
@@ -1,0 +1,26 @@
+#Makefile
+TEST_NAME=war-with-plugins-test
+TEST_VERSION=1.0
+CUSTOM_JENKINS_WAR=tmp/output/target/$(TEST_NAME)-$(TEST_VERSION).war
+
+.PRECIOUS: $(CUSTOM_JENKINS_WAR)
+$(CUSTOM_JENKINS_WAR): tmp
+	mvn clean package
+	touch $(CUSTOM_JENKINS_WAR).war
+
+out:
+	mkdir out
+
+.PHONY: test
+test: out
+	docker run -ti --rm -v maven-repo:/root/.m2 \
+	    -v $(CURDIR)/out:/pct/out \
+	    -v $(CURDIR)/$(CUSTOM_JENKINS_WAR):/pct/jenkins.war:ro \
+	    -e ARTIFACT_ID=artifact-manager-s3 \
+	    -e VERSION=artifact-manager-s3-1.6 \
+	    jenkins/pct \
+	    -overridenPlugins 'configuration-as-code=1.20'
+
+clean:
+	rm -rf out
+	rm =rf tmp

--- a/src/it/war-with-plugins-test/Makefile
+++ b/src/it/war-with-plugins-test/Makefile
@@ -8,19 +8,25 @@ $(CUSTOM_JENKINS_WAR): tmp
 	mvn clean package
 	touch $(CUSTOM_JENKINS_WAR).war
 
+tmp:
+	mkdir tmp
+
 out:
 	mkdir out
 
+.PHONY: build
+build: $(CUSTOM_JENKINS_WAR)
+
 .PHONY: test
-test: out
+test: out $(CUSTOM_JENKINS_WAR)
 	docker run -ti --rm -v maven-repo:/root/.m2 \
 	    -v $(CURDIR)/out:/pct/out \
 	    -v $(CURDIR)/$(CUSTOM_JENKINS_WAR):/pct/jenkins.war:ro \
 	    -e ARTIFACT_ID=artifact-manager-s3 \
 	    -e VERSION=artifact-manager-s3-1.6 \
 	    jenkins/pct \
-	    -overridenPlugins 'configuration-as-code=1.20' -overridenPlugins 'workflow-step-api=2.18'
+	    -overridenPlugins 'configuration-as-code=1.20'
 
 clean:
 	rm -rf out
-	rm =rf tmp
+	rm -rf tmp

--- a/src/it/war-with-plugins-test/Makefile
+++ b/src/it/war-with-plugins-test/Makefile
@@ -17,6 +17,10 @@ out:
 .PHONY: build
 build: $(CUSTOM_JENKINS_WAR)
 
+.PHONY: run
+run:
+	JENKINS_HOME=$(CURDIR)/work java -jar tmp/output/target/war-with-plugins-test-1.0.war
+
 .PHONY: test
 test: out $(CUSTOM_JENKINS_WAR)
 	docker run -ti --rm -v maven-repo:/root/.m2 \

--- a/src/it/war-with-plugins-test/Makefile
+++ b/src/it/war-with-plugins-test/Makefile
@@ -19,7 +19,7 @@ test: out
 	    -e ARTIFACT_ID=artifact-manager-s3 \
 	    -e VERSION=artifact-manager-s3-1.6 \
 	    jenkins/pct \
-	    -overridenPlugins 'configuration-as-code=1.20'
+	    -overridenPlugins 'configuration-as-code=1.20' -overridenPlugins 'workflow-step-api=2.18'
 
 clean:
 	rm -rf out

--- a/src/it/war-with-plugins-test/README.md
+++ b/src/it/war-with-plugins-test/README.md
@@ -1,0 +1,13 @@
+Integration test for Jenkins WAR with bundled plugins
+=====================================================
+
+The test uses [Custom WAR Packager](https://github.com/jenkinsci/custom-war-packager) as a tool to build a custom WAR.
+It basically implements a smoke test for the [JENKINS-57935](https://issues.jenkins-ci.org/browse/JENKINS-57935) fix 
+which is related to improper `groupId` resolution for optional dependencies.
+
+Running locally:
+
+```
+    make test
+```
+

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -1,0 +1,15 @@
+bundle:
+  groupId: "io.jenkins.tools.war-packager.demo"
+  artifactId: "war-with-plugins-test"
+  vendor: "Jenkins project"
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: 2.164.3
+plugins:
+  - groupId: "io.jenkins.plugins"
+    artifactId: "artifact-manager-s3"
+    source:
+      version: 1.6
+

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -41,4 +41,3 @@ plugins:
     artifactId: "junit"
     source:
       version: 1.3
-  

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -16,7 +16,7 @@ plugins:
     artifactId: "workflow-step-api"
     source:
       version: 2.18
-  - groupId: "org.jenkins-io.plugins"
+  - groupId: "org.jenkins-ci.plugins"
     artifactId: "scm-api"
     source:
       version: 2.2.7

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -37,4 +37,8 @@ plugins:
     artifactId: "workflow-job"
     source:
       version: 2.21
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "junit"
+    source:
+      version: 2.3
   

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -20,3 +20,16 @@ plugins:
     artifactId: "scm-api"
     source:
       version: 2.2.7
+  # Resolved upper bounds conflict for artifact-manager-s3
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: 1.17
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "git"
+    source:
+      version: 3.10.0
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: 2.46

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -32,4 +32,4 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: 2.46
+      version: 2.53

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -40,5 +40,5 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "junit"
     source:
-      version: 2.3
+      version: 1.3
   

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -33,3 +33,8 @@ plugins:
     artifactId: "workflow-cps"
     source:
       version: 2.53
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: 2.21
+  

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -15,11 +15,11 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-step-api"
     source:
-      version: 2.18
+      version: 2.19
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "scm-api"
     source:
-      version: 2.2.7
+      version: 2.3.0
   # Resolved upper bounds conflict for artifact-manager-s3
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ssh-credentials"
@@ -28,16 +28,28 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git"
     source:
-      version: 3.10.0
+      version: 4.0.0-rc
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: 2.53
+      version: 2.65
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
     source:
-      version: 2.21
+      version: 2.32
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "junit"
     source:
-      version: 1.3
+      version: 1.20
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "script-security"
+    source:
+      version: 1.56
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: 1.18
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "matrix-project"
+    source:
+      version: 1.12

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -12,4 +12,11 @@ plugins:
     artifactId: "artifact-manager-s3"
     source:
       version: 1.6
-
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: 2.18
+  - groupId: "org.jenkins-io.plugins"
+    artifactId: "scm-api"
+    source:
+      version: 2.2.7

--- a/src/it/war-with-plugins-test/pom.xml
+++ b/src/it/war-with-plugins-test/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.jenkins.tools.pct.it</groupId>
+  <artifactId>war-with-plugins-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.jenkins.tools.custom-war-packager</groupId>
+        <artifactId>custom-war-packager-maven-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>custom-war</goal>
+            </goals>
+            <configuration>
+              <configFilePath>packager-config.yml</configFilePath>
+              <warVersion>1.0</warVersion>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+</project>


### PR DESCRIPTION
Subsumes  #156 by updating the packager-config.yml file to generate a more up-to-date WAR file that works fine to validate the integration test.