### PR TITLE
Downgrading log level of a message which seems to be normal

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -132,7 +132,7 @@ public class PluginRemoting {
 
             String parentNode = xpath.evaluate("/project/parent", doc);
             if (StringUtils.isNotBlank(parentNode)) {
-                LOGGER.log(Level.SEVERE, parentNode.toString());
+                LOGGER.log(Level.INFO, parentNode.toString());
                 parent = new MavenCoordinates(
                         getValueOrFail(doc, xpath, "/project/parent/groupId"),
                         getValueOrFail(doc, xpath, "/project/parent/artifactId"),


### PR DESCRIPTION
Introduced in #99. E.g.:

```
… org.jenkins.tools.test.model.PluginRemoting retrievePomData
SEVERE: 
    org.jenkins-ci.plugins
    plugin
    3.32
```