### PR TITLE
Fix the Declarative Pipeline plugin discovery in `DeclarativePipelineHook` (regression in 0.0.3)

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -44,7 +44,7 @@ public class DeclarativePipelineHook extends AbstractMultiParentHook {
 
     public static boolean isDPPlugin(PomData data) {
         if (data.parent != null) {
-            return data.parent.artifactId.equalsIgnoreCase("blueocean-parent");
+            return data.parent.artifactId.equalsIgnoreCase("pipeline-model-parent");
         } else {
             LOGGER.log(Level.WARNING, "Artifact {0} has no parent POM, likely it was incrementalified (JEP-305). " +
                     "Will guess the plugin by artifact ID. FTR JENKINS-55169", data.artifactId);


### PR DESCRIPTION
Stumbled across what I suspect was a copy-paste mistake in #99.