### PR TITLE
Update hooks to make more plugins works properly with PCT

### DIFF
--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PomData.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PomData.java
@@ -36,6 +36,7 @@ import java.util.List;
  */
 public class PomData {
     public final String artifactId;
+    public final String groupId;
 
     @Nonnull
     private final String packaging;
@@ -45,8 +46,9 @@ public class PomData {
     private String connectionUrl;
     private List<String> warningMessages = new ArrayList<String>();
 
-    public PomData(String artifactId, @CheckForNull String packaging, String connectionUrl, @CheckForNull MavenCoordinates parent){
+    public PomData(String artifactId, @CheckForNull String packaging, String connectionUrl, @CheckForNull MavenCoordinates parent, String groupId){
         this.artifactId = artifactId;
+        this.groupId = groupId;
         this.packaging = packaging != null ? packaging : "jar";
         this.setConnectionUrl(connectionUrl);
         this.parent = parent;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -63,7 +63,7 @@ public class BlueOceanHook extends AbstractMultiParentHook {
         } else {
             LOGGER.log(Level.WARNING, "Artifact {0} has no parent POM, likely it was incrementalified (JEP-305). " +
                     "Will guess the plugin by artifact ID. FTR JENKINS-55169", data.artifactId);
-            return data.artifactId.contains("blueocean");
+            return data.artifactId.contains("blueocean") || data.groupId.contains("blueocean");
         }
     }
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -63,7 +63,7 @@ public class BlueOceanHook extends AbstractMultiParentHook {
         } else {
             LOGGER.log(Level.WARNING, "Artifact {0} has no parent POM, likely it was incrementalified (JEP-305). " +
                     "Will guess the plugin by artifact ID. FTR JENKINS-55169", data.artifactId);
-            return data.artifactId.contains("blueocean") || data.groupId.contains("blueocean");
+            return data.artifactId.contains("blueocean") || (data.groupId.contains("blueocean") && data.artifactId.contains("jenkins-design-language"));
         }
     }
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -84,7 +84,8 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
 
     @Override
     public boolean check(Map<String, Object> info) throws Exception {
-        return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info) || ConfigurationAsCodeHook.isCascPlugin(info);
+        return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info) ||
+        ConfigurationAsCodeHook.isCascPlugin(info) || PipelineRestApiHook.isPSVPlugin(info);
     }
 
     private boolean isEslintFile(Path file) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -85,7 +85,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
     @Override
     public boolean check(Map<String, Object> info) throws Exception {
         return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info) ||
-        ConfigurationAsCodeHook.isCascPlugin(info) || PipelineRestApiHook.isPSVPlugin(info);
+        ConfigurationAsCodeHook.isCascPlugin(info) || PipelineRestApiHook.isPipelineStageViewPlugin(info);
     }
 
     private boolean isEslintFile(Path file) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineRestApiHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineRestApiHook.java
@@ -1,0 +1,51 @@
+package org.jenkins.tools.test.hook;
+
+
+import org.jenkins.tools.test.model.PomData;
+import hudson.model.UpdateSite;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
+public class PipelineRestApiHook extends AbstractMultiParentHook {
+
+    private static final Logger LOGGER = Logger.getLogger(PipelineRestApiHook.class.getName());
+
+    @Override
+    protected String getParentFolder() {
+        return "pipeline-stage-view";
+    }
+
+    @Override
+    protected String getParentUrl() {
+        return "scm:git:git://github.com/jenkinsci/pipeline-stage-view-plugin.git";
+    }
+
+    @Override
+    protected String getParentProjectName() {
+        return "pipeline-stage-view";
+    }
+
+    @Override
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin){
+        return "rest-api";
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) throws Exception {
+        return isPSVPlugin(info);
+    }
+
+    public static boolean isPSVPlugin(Map<String, Object> moreInfo) {
+        PomData data = (PomData) moreInfo.get("pomData");
+        return isPSVPlugin(data);
+    }
+
+    public static boolean isPSVPlugin(PomData data) {
+        return data.artifactId.contains("pipeline-rest-api");
+    }
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineRestApiHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineRestApiHook.java
@@ -37,15 +37,15 @@ public class PipelineRestApiHook extends AbstractMultiParentHook {
 
     @Override
     public boolean check(Map<String, Object> info) throws Exception {
-        return isPSVPlugin(info);
+        return isPipelineStageViewPlugin(info);
     }
 
-    public static boolean isPSVPlugin(Map<String, Object> moreInfo) {
+    public static boolean isPipelineStageViewPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
-        return isPSVPlugin(data);
+        return isPipelineStageViewPlugin(data);
     }
 
-    public static boolean isPSVPlugin(PomData data) {
+    public static boolean isPipelineStageViewPlugin(PomData data) {
         return data.artifactId.contains("pipeline-rest-api");
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -37,7 +37,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean isBO = BlueOceanHook.isBOPlugin(pomData);
         boolean isDeclarativePipeline = DeclarativePipelineHook.isDPPlugin(pomData);
         boolean isCasC = ConfigurationAsCodeHook.isCascPlugin(pomData);
-        boolean isPSVPlugin = PipelineRestApiHook.isPSVPlugin(pomData);
+        boolean isPipelineStageViewPlugin = PipelineRestApiHook.isPipelineStageViewPlugin(pomData);
         boolean pluginPOM = pomData.isPluginPOM();
         if (parent != null) {
             isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
@@ -58,7 +58,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
         boolean coreRequiresPluginOver233 = coreCoordinates.compareVersionTo(CORE_WITHOUT_WAR_FOR_TEST) >= 0;
 
-        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || isPSVPlugin || (pluginPOM && parentV2)) {
+        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || isPipelineStageViewPlugin || (pluginPOM && parentV2)) {
             List<String> argsToMod = (List<String>)info.get("args");
             argsToMod.add("-Djenkins.version=" + coreCoordinates.version);
             // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -37,6 +37,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean isBO = BlueOceanHook.isBOPlugin(pomData);
         boolean isDeclarativePipeline = DeclarativePipelineHook.isDPPlugin(pomData);
         boolean isCasC = ConfigurationAsCodeHook.isCascPlugin(pomData);
+        boolean isPSVPlugin = PipelineRestApiHook.isPSVPlugin(pomData);
         boolean pluginPOM = pomData.isPluginPOM();
         if (parent != null) {
             isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
@@ -57,7 +58,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
         boolean coreRequiresPluginOver233 = coreCoordinates.compareVersionTo(CORE_WITHOUT_WAR_FOR_TEST) >= 0;
 
-        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || (pluginPOM && parentV2)) {
+        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || isPSVPlugin || (pluginPOM && parentV2)) {
             List<String> argsToMod = (List<String>)info.get("args");
             argsToMod.add("-Djenkins.version=" + coreCoordinates.version);
             // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -111,6 +111,7 @@ public class PluginRemoting {
 	public PomData retrievePomData() throws PluginSourcesUnavailableException {
 		String scmConnection = null;
         String artifactId = null;
+        String groupId = null;
         String packaging;
 		String pomContent = this.retrievePomContent();
         @CheckForNull MavenCoordinates parent = null;
@@ -124,10 +125,12 @@ public class PluginRemoting {
             XPath xpath = xpathFactory.newXPath();
 			XPathExpression scmConnectionXPath = xpath.compile("/project/scm/connection/text()");
             XPathExpression artifactIdXPath = xpath.compile("/project/artifactId/text()");
+            XPathExpression groupIdXPath = xpath.compile("/project/groupId/text()");
             XPathExpression packagingXPath = xpath.compile("/project/packaging/text()");
 
 			scmConnection = (String)scmConnectionXPath.evaluate(doc, XPathConstants.STRING);
             artifactId = (String)artifactIdXPath.evaluate(doc, XPathConstants.STRING);
+            groupId = (String)groupIdXPath.evaluate(doc, XPathConstants.STRING);
             packaging = StringUtils.trimToNull((String)packagingXPath.evaluate(doc, XPathConstants.STRING));
 
             String parentNode = xpath.evaluate("/project/parent", doc);
@@ -152,7 +155,7 @@ public class PluginRemoting {
 			throw new PluginSourcesUnavailableException("Problem while retrieving plugin's scm connection", e);
 		}
 		
-		PomData pomData = new PomData(artifactId, packaging, scmConnection, parent);
+		PomData pomData = new PomData(artifactId, packaging, scmConnection, parent, groupId);
         computeScmConnection(pomData);
         return pomData;
 	}

--- a/plugins-compat-tester/src/main/resources/nonstandardtagplugins.properties
+++ b/plugins-compat-tester/src/main/resources/nonstandardtagplugins.properties
@@ -1,2 +1,3 @@
 electricflow=cloudbees-flow-%s
 electricflow-minimumVersion=1.1.8
+github=v%s

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
@@ -54,7 +54,7 @@ public class NonStandardTagHookTest {
         NonStandardTagHook hook = new NonStandardTagHook();
         List<String> transformedPlugins = hook.transformedPlugins();
         assertNotNull("The list of transformed plugins must be non null", transformedPlugins);
-        assertEquals("List of affected plugins must be of size 2", 2, transformedPlugins.size());
+        assertEquals("List of affected plugins must be of size 3", 3, transformedPlugins.size());
         assertEquals("The element in transformedPlugins must be 'artifactID'", "artifactID", transformedPlugins.get(0));
     }
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
@@ -109,7 +109,7 @@ public class NonStandardTagHookTest {
 
 
         Map<String, Object> info = new HashMap<>();
-        PomData data = new PomData("artifactID", "hpi", null, null);
+        PomData data = new PomData("artifactID", "hpi", null, null, null);
         info.put("pomData", data);
         JSONObject pluginData = new JSONObject();
         pluginData.put("name","artifactId");
@@ -146,7 +146,7 @@ public class NonStandardTagHookTest {
             config.setGenerateHtmlReport(true);
 
             Map<String, Object> info = new HashMap<>();
-            PomData data = new PomData("electricflow", "hpi", "scm:git:git://github.com/jenkinsci/electricflow-plugin.git", new MavenCoordinates("org.jenkins-ci.plugins", "electricflow", "1.1.8"));
+            PomData data = new PomData("electricflow", "hpi", "scm:git:git://github.com/jenkinsci/electricflow-plugin.git", new MavenCoordinates("org.jenkins-ci.plugins", "electricflow", "1.1.8"), "org.jenkins-ci.plugins");
             info.put("pomData", data);
             JSONObject pluginData = new JSONObject();
             pluginData.put("name", "electricflow");

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
@@ -43,7 +43,7 @@ public class ScmConnectionSpecialCasesTest {
 
     private static void runComputeScmConnectionAgainst(String scmUrlToTest, String artifactId, String expectedComputedScmUrl) {
         PomData pom = new PomData(artifactId, "hpi", scmUrlToTest,
-                new MavenCoordinates("org.jenkins-ci.main", "jenkins-cli", "2.150.1"));
+                new MavenCoordinates("org.jenkins-ci.main", "jenkins-cli", "2.150.1"), "org.jenkins-ci.main");
         PluginRemoting.computeScmConnection(pom);
         assertThat(pom.getConnectionUrl(), is(equalTo(expectedComputedScmUrl)));
     }

--- a/plugins-compat-tester/src/test/resources/nonstandardtagplugins.properties
+++ b/plugins-compat-tester/src/test/resources/nonstandardtagplugins.properties
@@ -1,3 +1,4 @@
 artifactID=artifactId-%s
 electricflow=cloudbees-flow-%s
 electricflow-minimumVersion=1.1.8
+github=v%s


### PR DESCRIPTION
This PR is about making plugins working with the PCT that needs hooks, special tags and so on.

Fixes included:

- `jenkins-design-language` module in blueocean
- `github` plugin
- `pipeline-rest-api`