### PR TITLE
Update jcommander to a version which supports Java 8 (release redeploy?)

### DIFF
--- a/plugins-compat-tester-cli/pom.xml
+++ b/plugins-compat-tester-cli/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.75</version>
+        <version>1.78</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
In this [commit](https://github.com/jenkinsci/plugin-compat-tester/commit/aa482f4dd6bc0c4259594acd3fd02cc36a87a81e), dependabot updated [jcommander](http://jcommander.org/) from version 1.71 to version 1.75. This version seems to be corrupted somehow.

**Local execution**
```
[INFO] Restricted to JDK 1.8 yet com.beust:jcommander:jar:1.75:compile contains com/beust/jcommander/converters/BaseConverter.class targeted to 55.0
[WARNING] Rule 4: org.apache.maven.plugins.enforcer.EnforceBytecodeVersion failed with message:
Found Banned Dependency: com.beust:jcommander:jar:1.75
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Plugins compatibility tester Aggregator 0.1.1-SNAPSHOT SUCCESS [  1.173 s]
[INFO] Plugins compatibility tester model layer ........... SUCCESS [  4.354 s]
[INFO] Plugins compatibility tester for Google App Engine client side API SUCCESS [  1.863 s]
[INFO] Plugins compatibility tester ....................... SUCCESS [  3.824 s]
[INFO] Plugins compatibility tester CLI ................... FAILURE [  0.522 s]
[INFO] Plugins compatibility tester for Google App Engine 0.1.1-SNAPSHOT SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 12.010 s
[INFO] Finished at: 2019-09-05T16:51:20+02:00
[INFO] ------------------------------------------------------------------------
```

Reverting to jcommander-1.71 and updating to jcommander-1.78 work.

Checking with @bmunozm, using an old local maven repository, jcommander-1.75 worked for her, but after removing that version from her repository, she could reproduce the same issue, so our guess is that the jar file has become corrupted somehow at some moment.

@oleg-nenashev @raul-arabaolaza 