### PR TITLE
Add Swarm support to PCT

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -85,7 +85,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
     @Override
     public boolean check(Map<String, Object> info) throws Exception {
         return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info) ||
-        ConfigurationAsCodeHook.isCascPlugin(info) || PipelineRestApiHook.isPipelineStageViewPlugin(info);
+        SwarmHook.isSwarmPlugin(info) || ConfigurationAsCodeHook.isCascPlugin(info) || PipelineRestApiHook.isPipelineStageViewPlugin(info);
     }
 
     private boolean isEslintFile(Path file) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
@@ -1,0 +1,42 @@
+package org.jenkins.tools.test.hook;
+
+import hudson.model.UpdateSite;
+import java.util.Map;
+import org.jenkins.tools.test.model.PomData;
+
+public class SwarmHook extends AbstractMultiParentHook {
+
+    @Override
+    protected String getParentFolder() {
+        return "swarm";
+    }
+
+    @Override
+    protected String getParentUrl() {
+        return "scm:git:git://github.com/jenkinsci/swarm-plugin.git";
+    }
+
+    @Override
+    protected String getParentProjectName() {
+        return "swarm-plugin";
+    }
+
+    @Override
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
+        return "plugin";
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) throws Exception {
+        return isSwarmPlugin(info);
+    }
+
+    public static boolean isSwarmPlugin(Map<String, Object> moreInfo) {
+        PomData data = (PomData) moreInfo.get("pomData");
+        return isSwarmPlugin(data);
+    }
+
+    public static boolean isSwarmPlugin(PomData data) {
+        return data.parent.artifactId.equalsIgnoreCase("swarm-plugin");
+    }
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -38,6 +38,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean isDeclarativePipeline = DeclarativePipelineHook.isDPPlugin(pomData);
         boolean isCasC = ConfigurationAsCodeHook.isCascPlugin(pomData);
         boolean isPipelineStageViewPlugin = PipelineRestApiHook.isPipelineStageViewPlugin(pomData);
+        boolean isSwarm = SwarmHook.isSwarmPlugin(pomData);
         boolean pluginPOM = pomData.isPluginPOM();
         if (parent != null) {
             isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
@@ -58,7 +59,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
         boolean coreRequiresPluginOver233 = coreCoordinates.compareVersionTo(CORE_WITHOUT_WAR_FOR_TEST) >= 0;
 
-        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || isPipelineStageViewPlugin || (pluginPOM && parentV2)) {
+        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || isPipelineStageViewPlugin || isSwarm || (pluginPOM && parentV2)) {
             List<String> argsToMod = (List<String>)info.get("args");
             argsToMod.add("-Djenkins.version=" + coreCoordinates.version);
             // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores

--- a/src/it/war-with-plugins-test/packager-config.yml
+++ b/src/it/war-with-plugins-test/packager-config.yml
@@ -50,6 +50,10 @@ plugins:
     source:
       version: 1.18
   - groupId: "org.jenkins-ci.plugins"
+    artifactId: "swarm"
+    source:
+      version: 3.17
+  - groupId: "org.jenkins-ci.plugins"
     artifactId: "matrix-project"
     source:
       version: 1.12


### PR DESCRIPTION
Adding Swarm support to PCT following the existing examples for Pipeline: Delarative, Pipeline: REST API, and Structs.

First, I added a new `SwarmHook` class with the details of the Swarm plugin's structure. Then, I updated `MultiParentCompileHook` and `TransformPom` to add references to `SwarmHook` following the existing examples.

I added an integration test in `src/it/war-with-plugins-test/packager-config.yml`, but I'm not sure how to run it. I tested PCT against Swarm locally in the BOM project before and after this change. Before, it failed; after, it passed.