### PR TITLE
Do not force maven.test.redirectTestOutputToFile=false on test runs

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -503,7 +503,6 @@ public class PluginCompatTester {
             }
 
             List<String> args = new ArrayList<>();
-            args.add("--define=maven.test.redirectTestOutputToFile=false");
             args.add("--define=forkCount=1");
             args.add("hpi:resolve-test-dependencies");
             args.add("hpi:test-hpl");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -518,9 +518,10 @@ public class PluginCompatTester {
             forExecutionHooks.put("config", config);
             forExecutionHooks.put("pluginDir", pluginCheckoutDir);
             pcth.runBeforeExecution(forExecutionHooks);
+            args = (List<String>)forExecutionHooks.get("args");
 
             // Execute with tests
-            runner.run(mconfig, pluginCheckoutDir, buildLogFile, ((List<String>)forExecutionHooks.get("args")).toArray(new String[args.size()]));
+            runner.run(mconfig, pluginCheckoutDir, buildLogFile, args.toArray(new String[args.size()]));
 
             return new TestExecutionResult(((PomData)forExecutionHooks.get("pomData")).getWarningMessages());
         }catch(PomExecutionException e){


### PR DESCRIPTION
PCT build logs in, e.g., https://github.com/jenkinsci/bom/pull/107 are gigantic. I do not really need to see the full output from every test. Would rather just see the names of tests being run, as https://github.com/jenkinsci/plugin-pom/blob/58a771dfab9e26ad2545875240022189a7db4af4/pom.xml#L1084-L1094 does. If a user really wants the full output, they should be able to readd this option in `-mavenProperties`, which from my reading of https://github.com/jenkinsci/plugin-compat-tester/blob/c3bcaa8565e804effd242e1f78d7bcb58da025dd/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java#L35-L38 _cannot_ be used to override properties defined here.

(I am leaving `forkCount=1` alone for now, even though this is in fact the default in https://github.com/jenkinsci/plugin-pom/blob/58a771dfab9e26ad2545875240022189a7db4af4/pom.xml#L64-L65, since at least I normally override it to `1C` in my local `~/.m2/settings.xml` which would apply by default in PCT as well, perhaps to the detriment of reproducibility. But it is suspect too.)