### PR TITLE
Update parent POM from 1.50 to 1.52

### DIFF
--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -12,6 +12,16 @@
   <name>Plugins compatibility tester model layer</name>
   <description>Jenkins Plugin Compatibility Tester (PCT) model layer</description>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+	<groupId>com.google.code.findbugs</groupId>
+	<artifactId>annotations</artifactId>
+	<version>3.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
       <dependency>
         <groupId>org.jvnet.hudson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.50</version>
+    <version>1.52</version>
   </parent>
 
   <groupId>org.jenkins-ci.tests</groupId>


### PR DESCRIPTION
Supercedes #195. Fixes the error from that PR …

```
+-org.jenkins-ci.tests:plugins-compat-tester-model:0.2.1-SNAPSHOT
  +-org.reflections:reflections:0.9.10
    +-com.google.code.findbugs:annotations:2.0.1
and
+-org.jenkins-ci.tests:plugins-compat-tester-model:0.2.1-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:1.625.3
    +-org.jenkins-ci:version-number:1.6 (managed) <-- org.jenkins-ci:version-number:1.1
      +-com.google.code.findbugs:annotations:3.0.0
```

… by adding a `dependencyManagement` section and choosing the higher version.