### PR TITLE
Fix SpotBugs issues + Fix the default Java versioncapturing in PluginCompatTesterConfig#getTestJavaVersion() when other options are disabled

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -27,6 +27,7 @@ package org.jenkins.tools.test;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,6 +45,10 @@ import org.jenkins.tools.test.model.TestStatus;
  */
 public class PluginCompatTesterCli {
 
+    @SuppressFBWarnings(
+            value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            justification =
+                    "We're already checking for null in each relevant instance, so why does SpotBugs complain?")
     public static void main(String[] args) throws IOException, PlexusContainerException {
         CliOptions options = new CliOptions();
         JCommander jcommander = null;

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
@@ -31,9 +31,9 @@ import hudson.util.XStream2;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -83,8 +83,9 @@ public class PluginCompatReport {
         }
 
         // Writing to a temporary report file ...
-        File tempReportPath = new File(reportPath.getAbsolutePath()+".tmp");
-        try (Writer out = new FileWriter(tempReportPath)) {
+        File tempReportPath = new File(reportPath.getAbsolutePath() + ".tmp");
+        try (Writer out =
+                Files.newBufferedWriter(tempReportPath.toPath(), Charset.defaultCharset())) {
             out.write(String.format("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>%n"));
             out.write(String.format("<?xml-stylesheet href=\"" + getXslFilename(reportPath) + "\" type=\"text/xsl\"?>%n"));
             XStream xstream = createXStream();

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -346,7 +346,7 @@ public class PluginCompatTesterConfig {
         final String javaVersionOutput2 = IOUtils.toString(process2.getInputStream());
         // Expected format is something like openjdk full version "1.8.0_181-8u181-b13-2~deb9u1-b13"
         // We shorten it by removing the "full version" in the middle
-        return javaVersionOutput.
+        return javaVersionOutput2.
                 replace(" full version ", " ").
                 replaceAll("\"", "");
     }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/comparators/MavenCoordinatesComparator.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/comparators/MavenCoordinatesComparator.java
@@ -25,6 +25,7 @@
  */
 package org.jenkins.tools.test.model.comparators;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import org.jenkins.tools.test.model.MavenCoordinates;
 
@@ -34,7 +35,7 @@ import org.jenkins.tools.test.model.MavenCoordinates;
  * @deprecated For backward compatibility only. Use {@link MavenCoordinates#compareTo} instead.
  * @author Frederic Camblor
  */
-public class MavenCoordinatesComparator implements Comparator<MavenCoordinates> {
+public class MavenCoordinatesComparator implements Comparator<MavenCoordinates>, Serializable {
     @Override
     public int compare(MavenCoordinates o1, MavenCoordinates o2) {
         return o1.compareTo(o2);

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/comparators/VersionComparator.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/comparators/VersionComparator.java
@@ -25,6 +25,7 @@
  */
 package org.jenkins.tools.test.model.comparators;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
@@ -32,7 +33,7 @@ import java.util.Comparator;
  *
  * @author Frederic Camblor
  */
-public class VersionComparator implements Comparator<String> {
+public class VersionComparator implements Comparator<String>, Serializable {
     @Override
     public int compare(String o1, String o2) {
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -39,7 +39,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -703,8 +702,7 @@ public class PluginCompatTester {
         Map<String,VersionNumber> pluginDepsTest = new HashMap<>();
         try {
             runner.run(mconfig, pluginCheckoutDir, tmp, "dependency:resolve");
-            try (Reader r = new FileReader(tmp)) {
-                BufferedReader br = new BufferedReader(r);
+            try (BufferedReader br = new BufferedReader(new FileReader(tmp))) {
                 Pattern p = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(provided|compile|runtime|system)");
                 Pattern p2 = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(test)");
                 String line;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -36,11 +36,11 @@ import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -702,7 +702,8 @@ public class PluginCompatTester {
         Map<String,VersionNumber> pluginDepsTest = new HashMap<>();
         try {
             runner.run(mconfig, pluginCheckoutDir, tmp, "dependency:resolve");
-            try (BufferedReader br = new BufferedReader(new FileReader(tmp))) {
+            try (BufferedReader br =
+                    Files.newBufferedReader(tmp.toPath(), Charset.defaultCharset())) {
                 Pattern p = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(provided|compile|runtime|system)");
                 Pattern p2 = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(test)");
                 String line;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -62,6 +62,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -610,7 +611,7 @@ public class PluginCompatTester {
      *                     in the war file
      * @return Update center data
      */
-    private UpdateSite.Data scanWAR(File war, Map<String, String> pluginGroupIds, String pluginRegExp) throws IOException {
+    private UpdateSite.Data scanWAR(File war, @Nonnull Map<String, String> pluginGroupIds, String pluginRegExp) throws IOException {
         JSONObject top = new JSONObject();
         top.put("id", DEFAULT_SOURCE_ID);
         JSONObject plugins = new JSONObject();

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -615,9 +615,6 @@ public class PluginCompatTester {
         top.put("id", DEFAULT_SOURCE_ID);
         JSONObject plugins = new JSONObject();
         try (JarFile jf = new JarFile(war)) {
-            if (pluginGroupIds == null) {
-                pluginGroupIds = new HashMap<>();
-            }
             Enumeration<JarEntry> entries = jf.entries();
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -1,5 +1,6 @@
 package org.jenkins.tools.test.hook;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,6 +29,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
 
 
     @Override
+    @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "silly rule")
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         try {
             System.out.println("Executing multi-parent compile hook");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/logging/SystemIOLoggerFilter.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/logging/SystemIOLoggerFilter.java
@@ -27,8 +27,11 @@ package org.jenkins.tools.test.logging;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Locale;
 
 /**
@@ -53,9 +56,16 @@ public class SystemIOLoggerFilter extends PrintStream {
         private SystemIOLoggerFilter loggerFilter;
         private PrintStream systemIO;
 
-        public SystemIOWrapper(SystemIOLoggerFilter loggerFilter, PrintStream systemIO) throws FileNotFoundException {
+        public SystemIOWrapper(SystemIOLoggerFilter loggerFilter, PrintStream systemIO)
+                throws IOException {
             // Should be unnecessary but PrintStream doesn't have any default constructor !
-            super(new FileOutputStream(loggerFilter.getCurrentPSFile(), true));
+            super(
+                    Files.newOutputStream(
+                            loggerFilter.getCurrentPSFile().toPath(),
+                            StandardOpenOption.CREATE,
+                            StandardOpenOption.APPEND),
+                    false,
+                    Charset.defaultCharset().toString());
             this.loggerFilter = loggerFilter;
             this.systemIO = systemIO;
         }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -40,10 +40,9 @@ public class ExternalMavenRunner implements MavenRunner {
         try {
             Process p = new ProcessBuilder(cmd).directory(baseDirectory).redirectErrorStream(true).start();
             List<String> succeededPluginArtifactIds = new ArrayList<>();
-            try (InputStream is = p.getInputStream(); FileOutputStream os = new FileOutputStream(buildLogFile, true); PrintWriter w = new PrintWriter(os)) {
+            try (InputStream is = p.getInputStream(); BufferedReader r = new BufferedReader(new InputStreamReader(is)); FileOutputStream os = new FileOutputStream(buildLogFile, true); PrintWriter w = new PrintWriter(os)) {
                 String completed = null;
                 Pattern pattern = Pattern.compile("\\[INFO\\] --- (.+):.+:.+ [(].+[)] @ .+ ---");
-                BufferedReader r = new BufferedReader(new InputStreamReader(is));
                 String line;
                 while ((line = r.readLine()) != null) {
                     System.out.println(line);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -5,7 +5,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,7 +42,13 @@ public class ExternalMavenRunner implements MavenRunner {
         try {
             Process p = new ProcessBuilder(cmd).directory(baseDirectory).redirectErrorStream(true).start();
             List<String> succeededPluginArtifactIds = new ArrayList<>();
-            try (InputStream is = p.getInputStream(); BufferedReader r = new BufferedReader(new InputStreamReader(is)); FileOutputStream os = new FileOutputStream(buildLogFile, true); PrintWriter w = new PrintWriter(os)) {
+            try (InputStream is = p.getInputStream();
+                    BufferedReader r =
+                            new BufferedReader(
+                                    new InputStreamReader(is, Charset.defaultCharset()));
+                    FileOutputStream os = new FileOutputStream(buildLogFile, true);
+                    PrintWriter w =
+                            new PrintWriter(new OutputStreamWriter(os, Charset.defaultCharset()))) {
                 String completed = null;
                 Pattern pattern = Pattern.compile("\\[INFO\\] --- (.+):.+:.+ [(].+[)] @ .+ ---");
                 String line;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -27,8 +27,10 @@ package org.jenkins.tools.test.model;
 
 import hudson.util.VersionNumber;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -244,7 +246,7 @@ public class MavenPom {
     }
 
     private void writeDocument(final File target, final Document doc) throws IOException {
-        FileWriter w = new FileWriter(target);
+        Writer w = Files.newBufferedWriter(target.toPath(), Charset.defaultCharset());
         OutputFormat format = OutputFormat.createPrettyPrint();
         XMLWriter writer = new XMLWriter(w, format);
         try {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
@@ -89,7 +90,7 @@ public class PluginRemoting {
             byte[] buf = new byte[1024];
             int n;
             while ((n = zin.read(buf, 0, 1024)) > -1)
-                sb.append(new String(buf, 0, n));
+                sb.append(new String(buf, 0, n, Charset.defaultCharset()));
 
             return sb.toString();
         } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,7 @@
 
     <!-- Test libs -->
     <powermock.version>1.6.1</powermock.version>
-    <findbugs.effort>Max</findbugs.effort>
-    <findbugs.failOnError>false</findbugs.failOnError>
+    <spotbugs.effort>Max</spotbugs.effort>
   </properties>
 
   <modules>


### PR DESCRIPTION
Fixes all SpotBugs issues and enables SpotBugs by default. Each commit fixes exactly one SpotBugs issue and should be self-explanatory. Let me know if I can explain any commit further or if any cleanup is undesired.