### PR TITLE
Allow use your own fork for testing versions of plugins

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -83,12 +83,12 @@ public class CliOptions {
                     "If not set, see includePlugins behaviour.")
     private String excludePlugins = null;
 
-    @Parameter(names = "-alternativePluginOrganization",
+    @Parameter(names = "-fallbackGitHubOrganization",
             description = "Include an alternative organization to use as a fallback to download the plugin.\n" +
                     "It is useful to use your own fork releases for an specific plugin if the " +
                     "version is not found in the official repository.\n" +
-                    "If set, The PCT will try to use the alternative if a plugin tag is not found in the regular URL.")
-    private String alternativePluginOrganization = null;
+                    "If set, The PCT will try to use the fallback if a plugin tag is not found in the regular URL.")
+    private String fallbackGitHubOrganization = null;
 
     @Parameter(names = "-m2SettingsFile",
             description = "Maven settings file used while executing maven")
@@ -186,8 +186,8 @@ public class CliOptions {
         return excludePlugins;
     }
 
-    public String getAlternativePluginOrganization() {
-        return alternativePluginOrganization;
+    public String getFallbackGitHubOrganization() {
+        return fallbackGitHubOrganization;
     }
 
     @CheckForNull

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -84,10 +84,10 @@ public class CliOptions {
     private String excludePlugins = null;
 
     @Parameter(names = "-alternativePluginOrganization",
-            description = "Include an alternative organization to use to download the plugin.\n" +
+            description = "Include an alternative organization to use as fallback to download the plugin.\n" +
                     "It is usefull to use your own fork releases for an specific plugin if the " +
                     "version is not found into the official repository.\n" +
-                    "If not set, regular URL will be use for each plugin.")
+                    "If set, The PCT will try to use the alternative if a plugin tag is not found in the regular URL.")
     private String alternativePluginOrganization = null;
 
     @Parameter(names = "-m2SettingsFile",

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -83,6 +83,13 @@ public class CliOptions {
                     "If not set, see includePlugins behaviour.")
     private String excludePlugins = null;
 
+    @Parameter(names = "-alternativePluginOrganization",
+            description = "Include an alternative organization to use to download the plugin.\n" +
+                    "It is usefull to use your own fork releases for an specific plugin if the " +
+                    "version is not found into the official repository.\n" +
+                    "If not set, regular URL will be use for each plugin.")
+    private String alternativePluginOrganization = null;
+
     @Parameter(names = "-m2SettingsFile",
             description = "Maven settings file used while executing maven")
     private File m2SettingsFile;
@@ -177,6 +184,10 @@ public class CliOptions {
 
     public String getExcludePlugins() {
         return excludePlugins;
+    }
+
+    public String getAlternativePluginOrganization() {
+        return alternativePluginOrganization;
     }
 
     @CheckForNull

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -84,9 +84,9 @@ public class CliOptions {
     private String excludePlugins = null;
 
     @Parameter(names = "-alternativePluginOrganization",
-            description = "Include an alternative organization to use as fallback to download the plugin.\n" +
-                    "It is usefull to use your own fork releases for an specific plugin if the " +
-                    "version is not found into the official repository.\n" +
+            description = "Include an alternative organization to use as a fallback to download the plugin.\n" +
+                    "It is useful to use your own fork releases for an specific plugin if the " +
+                    "version is not found in the official repository.\n" +
                     "If set, The PCT will try to use the alternative if a plugin tag is not found in the regular URL.")
     private String alternativePluginOrganization = null;
 

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -132,6 +132,9 @@ public class PluginCompatTesterCli {
         if (options.getTestJavaArgs() != null && !options.getTestJavaArgs().isEmpty()) {
             config.setTestJavaArgs(options.getTestJavaArgs());
         }
+        if (options.getAlternativePluginOrganization() != null){
+            config.setAlternativePluginOrganization(options.getAlternativePluginOrganization());
+        }
         if (options.isFailOnError()) {
             //TODO: also interpolate it for the case when a single plugin passed?
             config.setFailOnError(true);

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -132,8 +132,8 @@ public class PluginCompatTesterCli {
         if (options.getTestJavaArgs() != null && !options.getTestJavaArgs().isEmpty()) {
             config.setTestJavaArgs(options.getTestJavaArgs());
         }
-        if (options.getAlternativePluginOrganization() != null){
-            config.setAlternativePluginOrganization(options.getAlternativePluginOrganization());
+        if (options.getFallbackGitHubOrganization() != null){
+            config.setFallbackGitHubOrganization(options.getFallbackGitHubOrganization());
         }
         if (options.isFailOnError()) {
             //TODO: also interpolate it for the case when a single plugin passed?

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -100,7 +100,7 @@ public class PluginCompatTesterConfig {
     // If null, tests will be performed on every includePlugins found
     private List<String> excludePlugins = null;
 
-    // URL to be use as alternative to download plugin source from alternative
+    // URL to be used as an alternative to download plugin source from alternative
     // organtizations, like your own fork
     private String alternativePluginOrganization = null;
 

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -100,9 +100,9 @@ public class PluginCompatTesterConfig {
     // If null, tests will be performed on every includePlugins found
     private List<String> excludePlugins = null;
 
-    // URL to be used as an alternative to download plugin source from alternative
+    // URL to be used as an alternative to download plugin source from fallback
     // organtizations, like your own fork
-    private String alternativePluginOrganization = null;
+    private String fallbackGitHubOrganization = null;
 
     // Allows to skip a plugin test if this plugin test has already been performed
     // within testCacheTimeout ms
@@ -236,12 +236,12 @@ public class PluginCompatTesterConfig {
         this.excludePlugins = excludePlugins;
     }
 
-    public String getAlternativePluginOrganization() {
-        return alternativePluginOrganization;
+    public String getFallbackGitHubOrganization() {
+        return fallbackGitHubOrganization;
     }
 
-    public void setAlternativePluginOrganization(String alternativePluginOrganization) {
-        this.alternativePluginOrganization = alternativePluginOrganization;
+    public void setFallbackGitHubOrganization(String fallbackGitHubOrganization) {
+        this.fallbackGitHubOrganization = fallbackGitHubOrganization;
     }
 
     public void setMavenProperties(@Nonnull Map<String, String> mavenProperties) {

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -100,6 +100,10 @@ public class PluginCompatTesterConfig {
     // If null, tests will be performed on every includePlugins found
     private List<String> excludePlugins = null;
 
+    // URL to be use as alternative to download plugin source from alternative
+    // organtizations, like your own fork
+    private String alternativePluginOrganization = null;
+
     // Allows to skip a plugin test if this plugin test has already been performed
     // within testCacheTimeout ms
     private long testCacheTimeout = 1000L * 60 * 60 * 24 * 100;
@@ -230,6 +234,14 @@ public class PluginCompatTesterConfig {
 
     public void setExcludePlugins(List<String> excludePlugins) {
         this.excludePlugins = excludePlugins;
+    }
+
+    public String getAlternativePluginOrganization() {
+        return alternativePluginOrganization;
+    }
+
+    public void setAlternativePluginOrganization(String alternativePluginOrganization) {
+        this.alternativePluginOrganization = alternativePluginOrganization;
     }
 
     public void setMavenProperties(@Nonnull Map<String, String> mavenProperties) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -559,7 +559,7 @@ public class PluginCompatTester {
         CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(checkoutDirectory), new ScmTag(scmTag));
 
         if (!result.isSuccess() && config.getAlternativePluginOrganization() != null) {
-            System.out.println("Using alternative organization in github");
+            System.out.println("Using alternative organization in github: " + config.getAlternativePluginOrganization());
             if (checkoutDirectory.isDirectory()) {
                 FileUtils.deleteDirectory(checkoutDirectory);
             }
@@ -568,6 +568,7 @@ public class PluginCompatTester {
             Matcher matcher = pattern.matcher(pomData.getConnectionUrl());
             matcher.find();
             String connectionURL = matcher.replaceFirst("$1" + config.getAlternativePluginOrganization() + "$3");
+            System.out.println("Using alternative url in github: " + connectionURL);
             repository = scmManager.makeScmRepository(connectionURL);
             result = scmManager.checkOut(repository, new ScmFileSet(checkoutDirectory), new ScmTag(scmTag));
             if (!result.isSuccess()) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -558,8 +558,8 @@ public class PluginCompatTester {
         ScmRepository repository = scmManager.makeScmRepository(pomData.getConnectionUrl());
         CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(checkoutDirectory), new ScmTag(scmTag));
 
-        if (!result.isSuccess() && config.getAlternativePluginOrganization() != null) {
-            System.out.println("Using alternative organization in github: " + config.getAlternativePluginOrganization());
+        if (!result.isSuccess() && config.getFallbackGitHubOrganization() != null) {
+            System.out.println("Using fallback organization in github: " + config.getFallbackGitHubOrganization());
             if (checkoutDirectory.isDirectory()) {
                 FileUtils.deleteDirectory(checkoutDirectory);
             }
@@ -567,8 +567,8 @@ public class PluginCompatTester {
             Pattern pattern = Pattern.compile("(.*/github.com/)([^/]*)(.*)");
             Matcher matcher = pattern.matcher(pomData.getConnectionUrl());
             matcher.find();
-            String connectionURL = matcher.replaceFirst("$1" + config.getAlternativePluginOrganization() + "$3");
-            System.out.println("Using alternative url in github: " + connectionURL);
+            String connectionURL = matcher.replaceFirst("$1" + config.getFallbackGitHubOrganization() + "$3");
+            System.out.println("Using fallback url in github: " + connectionURL);
             repository = scmManager.makeScmRepository(connectionURL);
             result = scmManager.checkOut(repository, new ScmFileSet(checkoutDirectory), new ScmTag(scmTag));
             if (!result.isSuccess()) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -544,7 +544,7 @@ public class PluginCompatTester {
         }
 	}
 
-    private void cloneFromSCM(PomData pomData, String name, String version, File checkoutDirectory) throws ComponentLookupException, ScmException, IOException {
+    protected void cloneFromSCM(PomData pomData, String name, String version, File checkoutDirectory) throws ComponentLookupException, ScmException, IOException {
         String scmTag;
         if (pomData.getScmTag() != null) {
             scmTag = pomData.getScmTag();

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -173,10 +173,10 @@ public class PluginCompatTester {
 
         // Determine the plugin data
         HashMap<String,String> pluginGroupIds = new HashMap<>();  // Used to track real plugin groupIds from WARs
-        
+
         // Scan bundled plugins
         // If there is any bundled plugin, only these plugins will be taken under the consideration for the PCT run
-        UpdateSite.Data data = config.getWar() == null ? extractUpdateCenterData(pluginGroupIds) : scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");        
+        UpdateSite.Data data = config.getWar() == null ? extractUpdateCenterData(pluginGroupIds) : scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");
         if (!data.plugins.isEmpty()) {
             // Scan detached plugins to recover proper Group IDs for them
             // We always poll the update center so that we extract groupIDs for dependencies
@@ -501,7 +501,7 @@ public class PluginCompatTester {
             // -Dmaven-surefire-plugin.version=2.15 -Dmaven.test.dependency.excludes=org.jenkins-ci.main:jenkins-war -Dmaven.test.additionalClasspath=/…/org/jenkins-ci/main/jenkins-war/1.580.1/jenkins-war-1.580.1.war clean test
             // (2.15+ required for ${maven.test.dependency.excludes} and ${maven.test.additionalClasspath} to be honored from CLI)
             // but it does not work; there are lots of linkage errors as some things are expected to be in the test classpath which are not.
-            // Much simpler to do use the parent POM to set up the test classpath. 
+            // Much simpler to do use the parent POM to set up the test classpath.
             MavenPom pom = new MavenPom(pluginCheckoutDir);
             try {
                 addSplitPluginDependencies(plugin.name, mconfig, pluginCheckoutDir, pom, otherPlugins, pluginGroupIds, coreCoordinates.version, overridenPlugins);
@@ -564,8 +564,6 @@ public class PluginCompatTester {
                 FileUtils.deleteDirectory(checkoutDirectory);
             }
 
-            //Change connection URL
-            String url = "git://github.com/jenkinsci/tetsing/ec2-plugin.git";
             Pattern pattern = Pattern.compile("(.*/github.com/)([^/]*)(.*)");
             Matcher matcher = pattern.matcher(pomData.getConnectionUrl());
             matcher.find();

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -30,10 +30,13 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
+
+import org.jenkins.tools.test.model.MavenCoordinates;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.PomData;
 import org.jenkins.tools.test.model.TestStatus;
 import org.junit.After;
 import org.junit.Before;
@@ -85,6 +88,41 @@ public class PluginCompatTesterTest {
 
         PluginCompatTester tester = new PluginCompatTester(config);
 		tester.testPlugins();
+	}
+
+    @Test(expected = RuntimeException.class)
+    public void testWithoutAlternativeUrl() throws Throwable {
+        String pluginName = "workflow-api";
+        String version = "2.39";
+        String nonWorkingConnectionURL = "scm:git:git://github.com/test/workflow-api-plugin.git";
+        MavenCoordinates mavenCoordinates = new MavenCoordinates("org.jenkins-ci.plugins","plugin","3.54");
+
+        PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
+                new File("../reports/PluginCompatReport.xml"),
+                getSettingsFile());
+        config.setIncludePlugins(ImmutableList.of(pluginName));
+
+        PluginCompatTester pct = new PluginCompatTester(config);
+        PomData pomData = new PomData(pluginName, "hpi",  nonWorkingConnectionURL, pluginName + "-" + version, mavenCoordinates, "org.jenkins-ci.plugins.workflow") ;
+        pct.cloneFromSCM(pomData, pluginName, version, new File(config.workDirectory.getAbsolutePath() + File.separator + pluginName + File.separator));
+    }
+
+	@Test(expected = Test.None.class)
+	public void testWithAlternativeUrl() throws Throwable {
+        String pluginName = "workflow-api";
+        String version = "2.39";
+        String nonWorkingConnectionURL = "scm:git:git://github.com/test/workflow-api-plugin.git";
+        MavenCoordinates mavenCoordinates = new MavenCoordinates("org.jenkins-ci.plugins","plugin","3.54");
+
+        PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
+				new File("../reports/PluginCompatReport.xml"),
+				getSettingsFile());
+		config.setIncludePlugins(ImmutableList.of(pluginName));
+		config.setAlternativePluginOrganization("jenkinsci");
+
+        PluginCompatTester pct = new PluginCompatTester(config);
+        PomData pomData = new PomData(pluginName, "hpi",  nonWorkingConnectionURL, pluginName + "-" + version, mavenCoordinates, "org.jenkins-ci.plugins.workflow") ;
+        pct.cloneFromSCM(pomData, pluginName, version, new File(config.workDirectory.getAbsolutePath() + File.separator + pluginName + File.separator));
 	}
 
 	@Test

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -118,7 +118,7 @@ public class PluginCompatTesterTest {
 				new File("../reports/PluginCompatReport.xml"),
 				getSettingsFile());
 		config.setIncludePlugins(ImmutableList.of(pluginName));
-		config.setAlternativePluginOrganization("jenkinsci");
+		config.setFallbackGitHubOrganization("jenkinsci");
 
         PluginCompatTester pct = new PluginCompatTester(config);
         PomData pomData = new PomData(pluginName, "hpi",  nonWorkingConnectionURL, pluginName + "-" + version, mavenCoordinates, "org.jenkins-ci.plugins.workflow") ;
@@ -241,7 +241,7 @@ public class PluginCompatTesterTest {
 		File ciJenkinsIOSettings = new File(new File("settings-azure.xml").getAbsolutePath().replace("/plugins-compat-tester/settings-azure.xml", "@tmp/settings-azure.xml"));
 		System.out.println("Will check Maven settings from " + ciJenkinsIOSettings.getAbsolutePath());
 		if (ciJenkinsIOSettings.exists()) {
-			System.out.println("Will use the ci.jenkins.io Azure settings file for testing: " + ciJenkinsIOSettings.getAbsolutePath());	
+			System.out.println("Will use the ci.jenkins.io Azure settings file for testing: " + ciJenkinsIOSettings.getAbsolutePath());
 			return ciJenkinsIOSettings;
 		}
 		// Default fallback for local runs


### PR DESCRIPTION
This feature allows testing specific releases that are not in the official repository of a plugin.

To make it work, you have to specify the github organization that you want to use. Take into account that the repo name and the tags format used have to be the same ones that in the offitail repo.

```
java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli-${PCT_VERSION}.jar \
  -reportFile $(pwd)/out/report.xml \
  -workDirectory $(pwd)/tmp/work \
  -includePlugins ${PLUGIN_ARTIFACT_ID} \
  -war jenkins.war -localCheckoutDir ${PLUGIN_SRC} \
  -skipTestCache true \
  -alternativePluginOrganization ${ORGANIZATION} \
  -failOnError \
  -mvn ${PATH_TO_MAVEN}
```

cc/ @batmat @raul-arabaolaza @varyvol 