### PR TITLE
Fix UC Default URL

### DIFF
--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -49,7 +49,7 @@ public class PluginCompatTesterConfig {
 
     private static final Logger LOGGER = Logger.getLogger(PluginCompatTesterConfig.class.getName());
 
-    public static final String DEFAULT_UPDATE_CENTER_URL = "https://updates.jenkins-ci.org/update-center.json";
+    public static final String DEFAULT_UPDATE_CENTER_URL = "https://updates.jenkins.io/current/update-center.json";
     public static final String DEFAULT_PARENT_GROUP = "org.jenkins-ci.plugins";
     public static final String DEFAULT_PARENT_ARTIFACT = "plugin";
     public static final String DEFAULT_PARENT_GAV = DEFAULT_PARENT_GROUP + ":" + DEFAULT_PARENT_ARTIFACT;


### PR DESCRIPTION
The previous one had an expired certificate that was not planned to be renewed