### PR TITLE
Revert #156 as it makes PCT sensitive to UC; instead pass groupId: in -overridenPlugins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,7 @@ itBranches['WAR with non-default groupId plugins - smoke test'] = {
                             -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
                             -e ARTIFACT_ID=artifact-manager-s3 -e VERSION=artifact-manager-s3-1.6 \
                             jenkins/pct \
-                            -overridenPlugins 'configuration-as-code=1.20'
+                            -overridenPlugins 'io.jenkins:configuration-as-code=1.20'
               '''
               archiveArtifacts artifacts: "out/**"
 

--- a/README.md
+++ b/README.md
@@ -143,18 +143,23 @@ Plugin Compat Tester supports overriding the plugin dependency version.
 For example, we might want to validate that a newer version of a plugin is not breaking the latest version of the plugin we want to test.
 
 To do that, the option `overridenPlugins` can be passed to PCT CLI.
-The format of the value **must** be `PLUGIN_NAME=PLUGIN_VERSION`.
+The format of the value **must** be `PLUGIN_GROUP:PLUGIN_NAME=PLUGIN_VERSION`.
 
 So, running
 
 ```
 java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
   [...]
-  -overridenPlugins display-url-api=2.3.0
+  -overridenPlugins org.jenkins-ci.plugins:display-url-api=2.3.0
   -includePlugins mailer
 ```
 
 will run the PCT on the `mailer` plugin, but replacing the `display-url-api` dependency of Mailer (which is `1.0`) with the version `2.3.0`.
+
+For compatibility reasons, the `PLUGIN_GROUP:` part may be omitted,
+but only if the group ID could be inferred by other means:
+either that plugin being included in the `-war`,
+or no `-war` being passed but the plugin being present on the update center.
 
 ### Running the PCT for plugins not following standard tag
 
@@ -197,7 +202,7 @@ and then to properly setup the environment.
 
 ```batch
    set JAVA_HOME=...
-   make demo-jdk8 -e PLUGIN_NAME=artifact-manager-s3 -e WAR_PATH=test-wars/mywar.war -e MVN_EXECUTABLE="C:\ProgramData\chocolatey\bin\mvn.exe" -e EXTRA_OPTS="-overridenPlugins 'configuration-as-code=1.20'"
+   make demo-jdk8 -e PLUGIN_NAME=artifact-manager-s3 -e WAR_PATH=test-wars/mywar.war -e MVN_EXECUTABLE="C:\ProgramData\chocolatey\bin\mvn.exe" -e EXTRA_OPTS="-overridenPlugins 'io.jenkins:configuration-as-code=1.20'"
 ```
 
 ## Useful links

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -136,7 +136,7 @@ public class CliOptions {
     private boolean printHelp;
 
     @Parameter(names = "-overridenPlugins", description = "List of plugins to use to test a plugin in place of the normal dependencies." +
-          "Format: 'PLUGIN_NAME=PLUGIN_VERSION", converter = PluginConverter.class, validateWith = PluginValidator.class)
+          "Format: '[GROUP_ID:]PLUGIN_NAME=PLUGIN_VERSION", converter = PluginConverter.class, validateWith = PluginValidator.class)
     private List<PCTPlugin> overridenPlugins;
 
     @Parameter(names = "-failOnError", description = "Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code")
@@ -239,7 +239,9 @@ public class CliOptions {
         @Override
         public PCTPlugin convert(String s) {
             String[] details = s.split("=");
-            return new PCTPlugin(details[0], new VersionNumber(details[1]));
+            String name = details[0];
+            int colon = name.indexOf(':');
+            return new PCTPlugin(colon == -1 ? name : name.substring(colon + 1), colon == -1 ? null : name.substring(0, colon), new VersionNumber(details[1]));
         }
     }
 

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PCTPlugin.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PCTPlugin.java
@@ -1,18 +1,26 @@
 package org.jenkins.tools.test.model;
 
 import hudson.util.VersionNumber;
+import javax.annotation.CheckForNull;
 
 public class PCTPlugin {
     private String name;
+    private final String groupId;
     private VersionNumber version;
 
-    public PCTPlugin(String name, VersionNumber version) {
+    public PCTPlugin(String name, String groupId, VersionNumber version) {
         this.name = name;
+        this.groupId = groupId;
         this.version = version;
     }
 
     public String getName() {
         return name;
+    }
+
+    @CheckForNull
+    public String getGroupId() {
+        return groupId;
     }
 
     public VersionNumber getVersion() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -782,6 +782,15 @@ public class PluginCompatTester {
             overridenPlugins.forEach(plugin -> {
                 toReplace.put(plugin.getName(), plugin.getVersion());
                 toReplaceTest.put(plugin.getName(), plugin.getVersion());
+                if (plugin.getGroupId() != null) {
+                    if (pluginGroupIds.containsKey(plugin.getName())) {
+                        if (!plugin.getGroupId().equals(pluginGroupIds.get(plugin.getName()))) {
+                            System.err.println("WARNING: mismatch between detected and explicit group ID for " + plugin.getName());
+                        }
+                    } else {
+                        pluginGroupIds.put(plugin.getName(), plugin.getGroupId());
+                    }
+                }
             });
 
             for (String split : splits) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -179,13 +179,7 @@ public class PluginCompatTester {
         UpdateSite.Data data = config.getWar() == null ? extractUpdateCenterData(pluginGroupIds) : scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");
         if (!data.plugins.isEmpty()) {
             // Scan detached plugins to recover proper Group IDs for them
-            // We always poll the update center so that we extract groupIDs for dependencies
-            // In the case of Group ID renaming across version, groupID from the WAR file will have a priority
-            UpdateSite.Data detachedData = extractUpdateCenterData(pluginGroupIds);
-            if (config.getWar() != null) {
-                detachedData = scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:detached-)?plugins/([^/.]+)[.][hj]pi");
-            }
-
+            UpdateSite.Data detachedData = config.getWar() == null ? extractUpdateCenterData(pluginGroupIds) : scanWAR(config.getWar(), pluginGroupIds, "WEB-INF/(?:detached-)?plugins/([^/.]+)[.][hj]pi");
 
             // Add detached if and only if no added as normal one
             detachedData.plugins.forEach((key, value) -> {
@@ -595,6 +589,9 @@ public class PluginCompatTester {
      * @return Update site Data
      */
     private UpdateSite.Data extractUpdateCenterData(Map<String, String> groupIDs){
+        if (config.getWar() != null) {
+            throw new IllegalStateException("Not to be used when -war is specified");
+        }
 		URL url;
 		String jsonp;
 		try {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -193,8 +193,6 @@ public class PluginCompatTester {
         final List<String> pluginsToInclude = config.getIncludePlugins();
         if (data.plugins.isEmpty() && pluginsToInclude != null && !pluginsToInclude.isEmpty()) {
             // Update Center returns empty info OR the "-war" option is specified for WAR without bundled plugins
-            // TODO: Ideally we should do this tweak in any case, so that we can test custom plugins with Jenkins cores before unbundling
-            // But it will require us to always poll the update center...
             System.out.println("WAR file does not contain plugin info, will try to extract it from UC for included plugins");
             pluginsToCheck = new HashMap<>(pluginsToInclude.size());
             UpdateSite.Data ucData = extractUpdateCenterData(pluginGroupIds);
@@ -589,9 +587,6 @@ public class PluginCompatTester {
      * @return Update site Data
      */
     private UpdateSite.Data extractUpdateCenterData(Map<String, String> groupIDs){
-        if (config.getWar() != null) {
-            throw new IllegalStateException("Not to be used when -war is specified");
-        }
 		URL url;
 		String jsonp;
 		try {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -233,6 +233,7 @@ public class MavenPom {
             if (group != null && !group.isEmpty()) {
                 dependency.addElement(GROUP_ID_ELEMENT).addText(group);
             } else {
+                System.err.println("WARNING: no known group ID for plugin " + dep.getKey());
                 dependency.addElement(GROUP_ID_ELEMENT).addText("org.jenkins-ci.plugins");
             }
             dependency.addElement(ARTIFACT_ID_ELEMENT).addText(dep.getKey());

--- a/src/it/war-with-plugins-test/Makefile
+++ b/src/it/war-with-plugins-test/Makefile
@@ -29,7 +29,7 @@ test: out $(CUSTOM_JENKINS_WAR)
 	    -e ARTIFACT_ID=artifact-manager-s3 \
 	    -e VERSION=artifact-manager-s3-1.6 \
 	    jenkins/pct \
-	    -overridenPlugins 'configuration-as-code=1.20'
+	    -overridenPlugins 'io.jenkins:configuration-as-code=1.20'
 
 clean:
 	rm -rf out


### PR DESCRIPTION
Whatever #156 (& #169) was attempting to accomplish, it did it wrong—when `-war` is passed, the intention is that the update center should _not_ be contacted. This misbehavior is routinely breaking `bom` builds. If you need information about plugins, look in the WAR file, or add some option to pass in such metadata from a deterministic file source TBD.

I tried to run the IT but it did not work:

```
…
+ echo 'Checking out from https://github.com/jenkinsci/artifact-manager-s3-plugin.git:artifact-manager-s3-1.6'
Checking out from https://github.com/jenkinsci/artifact-manager-s3-plugin.git:artifact-manager-s3-1.6
+ git clone https://github.com/jenkinsci/artifact-manager-s3-plugin.git
Cloning into 'artifact-manager-s3-plugin'...
fatal: unable to access 'https://github.com/jenkinsci/artifact-manager-s3-plugin.git/': Could not resolve host: github.com
make: *** [Makefile:26: test] Error 128
```

Anyway, unless I am missing something, this IT does not actual test local sources, only `jenkins/pct:latest` from the Internet, so I do not see how you could use it to verify anything.