### PR TITLE
update pipeline-stage-view hook to adapt the use of incrementals in new versions

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -81,7 +81,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
     @Override
     public boolean check(Map<String, Object> info) {
         return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info) ||
-        SwarmHook.isSwarmPlugin(info) || ConfigurationAsCodeHook.isCascPlugin(info) || PipelineRestApiHook.isPipelineStageViewPlugin(info);
+        SwarmHook.isSwarmPlugin(info) || ConfigurationAsCodeHook.isCascPlugin(info) || PipelineStageViewHook.isPipelineStageViewPlugin(info);
     }
 
     private boolean isEslintFile(Path file) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -4,7 +4,7 @@ import hudson.model.UpdateSite;
 import java.util.Map;
 import org.jenkins.tools.test.model.PomData;
 
-public class PipelineRestApiHook extends AbstractMultiParentHook {
+public class PipelineStageViewHook extends AbstractMultiParentHook {
 
     @Override
     protected String getParentFolder() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -23,7 +23,7 @@ public class PipelineRestApiHook extends AbstractMultiParentHook {
 
     @Override
     protected String getPluginFolderName(UpdateSite.Plugin currentPlugin){
-        return "rest-api";
+        return (currentPlugin.getDisplayName() == "pipeline-rest-api") ? "rest-api" : "ui";
     }
 
     @Override
@@ -37,6 +37,6 @@ public class PipelineRestApiHook extends AbstractMultiParentHook {
     }
 
     public static boolean isPipelineStageViewPlugin(PomData data) {
-        return data.artifactId.contains("pipeline-rest-api");
+        return data.groupId.equals("org.jenkins-ci.plugins.pipeline-stage-view") || data.artifactId.contains("pipeline-rest-api");
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -23,7 +23,7 @@ public class PipelineRestApiHook extends AbstractMultiParentHook {
 
     @Override
     protected String getPluginFolderName(UpdateSite.Plugin currentPlugin){
-        return (currentPlugin.getDisplayName() == "pipeline-rest-api") ? "rest-api" : "ui";
+        return (currentPlugin.getDisplayName().equals("pipeline-rest-api")) ? "rest-api" : "ui";
     }
 
     @Override

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -37,7 +37,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean isBO = BlueOceanHook.isBOPlugin(pomData);
         boolean isDeclarativePipeline = DeclarativePipelineHook.isDPPlugin(pomData);
         boolean isCasC = ConfigurationAsCodeHook.isCascPlugin(pomData);
-        boolean isPipelineStageViewPlugin = PipelineRestApiHook.isPipelineStageViewPlugin(pomData);
+        boolean isPipelineStageViewPlugin = PipelineStageViewHook.isPipelineStageViewPlugin(pomData);
         boolean isSwarm = SwarmHook.isSwarmPlugin(pomData);
         boolean pluginPOM = pomData.isPluginPOM();
         if (parent != null) {


### PR DESCRIPTION
This updates the pipeline-stage-view to adapt the Hook to make PCT works with version 2.13 od the plugin

This Hook is also compatible with lower versions cc/ @olamy @dwnusbaum @oleg-nenashev  @raul-arabaolaza 

This PR supersede https://github.com/jenkinsci/plugin-compat-tester/pull/231 unless it is adapted properly (in that case this PR can be closed). I tried to update the PR but I am not having permissions to do it, that's the reason why I have to create a new one.