### PR TITLE
Add mvn settings for a lone mvn command which lacked one

### DIFF
--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -129,7 +129,7 @@ if [ "${SHOULD_CHECKOUT}" -eq 1 ] && [ -z "${DO_NOT_OVERRIDE_PCT_CHECKOUT}" ] ; 
     mkdir "${TMP_CHECKOUT_DIR}"
     cp -r /pct/plugin-src/. "${TMP_CHECKOUT_DIR}"
     # Due to whatever reason PCT blows up if you have work in the repo
-    cd "${TMP_CHECKOUT_DIR}" && mvn -B clean && rm -rf work
+    cd "${TMP_CHECKOUT_DIR}" && mvn -B clean -s "${MVN_SETTINGS_FILE}" && rm -rf work
   else
     echo "Checking out from ${CHECKOUT_SRC}:${VERSION}"
     git clone "${CHECKOUT_SRC}"


### PR DESCRIPTION
While working on some other things, it was brought to my attention by @imonteroperez that the line I've modified was lacking a `-s "{MVN_SETTINGS_FILE}"` like the others around it. Without this, if a particular PCT run is relying upon those settings for different repository locations and the like, this line will fail. 

For example:
```
+ echo 'Located custom plugin sources on the volume'
Located custom plugin sources on the volume
+ mkdir /pct/tmp/localCheckoutDir/undefined
+ cp -r /pct/plugin-src/. /pct/tmp/localCheckoutDir/undefined
+ cd /pct/tmp/localCheckoutDir/undefined
+ mvn -B clean
Picked up JAVA_TOOL_OPTIONS: -Xmx1g
[INFO] Scanning for projects...
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/cloudbees/jenkins/plugins/jenkins-plugins/80/jenkins-plugins-80.pom
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for com.cloudbees.jenkins.plugins.pipeline:some-plugin:0.9-SNAPSHOT: Could not find artifact com.cloudbees.jenkins.plugins:jenkins-plugins:pom:80 in central (https://repo.maven.apache.org/maven2) and 'parent.relativePath' points at no local POM @ line 4, column 13
```