### PR TITLE
Store executed tests on reports xml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,9 @@ for (int i = 0; i < platforms.size(); ++i) {
     branches[label] = {
         node(label) {
             timestamps {
-                stage('Checkout') {
+                stage('Checkout Test') {
                     checkout scm
+                    sh "ls -liart"
                     dir('plugins-compat-tester/src/test/resources') {
                         def exists = fileExists "m2-settings.xml"
                         if (exists) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ properties([[$class: 'BuildDiscarderProperty',
  */
 List platforms = ['linux', 'windows']
 Map branches = [:]
-def settingsXml
 
 for (int i = 0; i < platforms.size(); ++i) {
     String label = platforms[i]
@@ -18,22 +17,11 @@ for (int i = 0; i < platforms.size(); ++i) {
             timestamps {
                 stage('Checkout') {
                     checkout scm
-                    dir('plugins-compat-tester/src/test/resources') {
-                        def exists = fileExists "m2-settings.xml"
-                        if (exists) {
-                            def location = pwd()
-                            settingsXml = "${location}/m2-settings.xml"
-                        }
-                    }
                 }
 
                 stage('Build') {
                   timeout(30) {
-                    if (settingsXml) {
-                        infra.runMaven(["clean", "install", "-Dmaven.test.failure.ignore=true"], 8, null, settingsXml, true)
-                    } else {
-                        infra.runMaven(["clean", "install", "-Dmaven.test.failure.ignore=true"])
-                    }
+                    infra.runMaven(["clean", "install", "-Dmaven.test.failure.ignore=true"])
                   }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,15 +16,13 @@ for (int i = 0; i < platforms.size(); ++i) {
     branches[label] = {
         node(label) {
             timestamps {
-                stage('Checkout Test') {
+                stage('Checkout') {
                     checkout scm
-                    sh "ls -liart"
                     dir('plugins-compat-tester/src/test/resources') {
                         def exists = fileExists "m2-settings.xml"
                         if (exists) {
                             def location = pwd()
                             settingsXml = "${location}/m2-settings.xml"
-                            println settingsXml
                         }
                     }
                 }
@@ -32,10 +30,8 @@ for (int i = 0; i < platforms.size(); ++i) {
                 stage('Build') {
                   timeout(30) {
                     if (settingsXml) {
-                        println "yes"
                         infra.runMaven(["clean", "install", "-Dmaven.test.failure.ignore=true"], 8, null, settingsXml, true)
                     } else {
-                        println "no"
                         infra.runMaven(["clean", "install", "-Dmaven.test.failure.ignore=true"])
                     }
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ for (int i = 0; i < platforms.size(); ++i) {
                         if (exists) {
                             def location = pwd()
                             settingsXml = "${location}/m2-settings.xml"
+                            println settingsXml
                         }
                     }
                 }
@@ -30,8 +31,10 @@ for (int i = 0; i < platforms.size(); ++i) {
                 stage('Build') {
                   timeout(30) {
                     if (settingsXml) {
+                        println "yes"
                         infra.runMaven(["clean", "install", "-Dmaven.test.failure.ignore=true"], 8, null, settingsXml, true)
                     } else {
+                        println "no"
                         infra.runMaven(["clean", "install", "-Dmaven.test.failure.ignore=true"])
                     }
                   }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -141,6 +141,13 @@ public class CliOptions {
 
     @Parameter(names = "-failOnError", description = "Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code")
     private boolean failOnError;
+    
+    @Parameter(names = "-storeAll", 
+            description = "By default only failed tests are stored in PCT report file. \n" + 
+                    "If set, the PCT will store ALL executed test names for each plugin in report file. \n" + 
+                    "Disabled by default because it may bloat reports for plugins which thousands of tests."
+    )
+    private Boolean storeAll = null;
 
     public String getUpdateCenterUrl() {
         return updateCenterUrl;
@@ -233,6 +240,10 @@ public class CliOptions {
 
     public boolean isFailOnError() {
         return failOnError;
+    }
+    
+    public Boolean isStoreAll() {
+        return storeAll;
     }
 
     public static class PluginConverter implements IStringConverter<PCTPlugin> {

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -139,6 +139,12 @@ public class PluginCompatTesterCli {
             //TODO: also interpolate it for the case when a single plugin passed?
             config.setFailOnError(true);
         }
+        
+        if (options.isStoreAll() != null) {
+            config.setStoreAll(options.isStoreAll().booleanValue());
+        } else {
+            config.setStoreAll(false);
+        }
 
         if(options.getOverridenPlugins() != null && !options.getOverridenPlugins().isEmpty()) {
             config.setOverridenPlugins(options.getOverridenPlugins());

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
@@ -26,7 +26,10 @@
 package org.jenkins.tools.test.model;
 
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
@@ -44,16 +47,18 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
     public final String errorMessage;
     public final List<String> warningMessages;
 
+    private final Set<String> executedTests;
+
     private String buildLogPath = "";
 
     public PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, List<String> warningMessages,
+                              String errorMessage, List<String> warningMessages, Set<String> executedTests,
                               String buildLogPath){
         // Create new result with current date
-        this(coreCoordinates, status, errorMessage, warningMessages, buildLogPath, new Date());
+        this(coreCoordinates, status, errorMessage, warningMessages, executedTests, buildLogPath, new Date());
     }
-    public PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, List<String> warningMessages,
+    private PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
+                              String errorMessage, List<String> warningMessages, Set<String> executedTests,
                               String buildLogPath, Date compatTestExecutedOn){
         this.coreCoordinates = coreCoordinates;
 
@@ -62,6 +67,7 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
         this.errorMessage = errorMessage;
         this.warningMessages = warningMessages;
 
+        this.executedTests = executedTests;
         this.buildLogPath = buildLogPath;
 
         this.compatTestExecutedOn = compatTestExecutedOn;
@@ -92,5 +98,9 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
 
     public void setBuildLogPath(String buildLogPath) {
         this.buildLogPath = buildLogPath;
+    }
+
+    public Set<String> getExecutedTests() {
+        return executedTests;
     }
 }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
@@ -47,18 +47,18 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
     public final String errorMessage;
     public final List<String> warningMessages;
 
-    private final Set<String> executedTests;
+    private final Set<String> testDetails;
 
     private String buildLogPath = "";
 
     public PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, List<String> warningMessages, Set<String> executedTests,
+                              String errorMessage, List<String> warningMessages, Set<String> testDetails,
                               String buildLogPath){
         // Create new result with current date
-        this(coreCoordinates, status, errorMessage, warningMessages, executedTests, buildLogPath, new Date());
+        this(coreCoordinates, status, errorMessage, warningMessages, testDetails, buildLogPath, new Date());
     }
     private PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, List<String> warningMessages, Set<String> executedTests,
+                              String errorMessage, List<String> warningMessages, Set<String> testDetails,
                               String buildLogPath, Date compatTestExecutedOn){
         this.coreCoordinates = coreCoordinates;
 
@@ -67,7 +67,7 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
         this.errorMessage = errorMessage;
         this.warningMessages = warningMessages;
 
-        this.executedTests = executedTests;
+        this.testDetails = testDetails;
         this.buildLogPath = buildLogPath;
 
         this.compatTestExecutedOn = compatTestExecutedOn;
@@ -100,7 +100,7 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
         this.buildLogPath = buildLogPath;
     }
 
-    public Set<String> getExecutedTests() {
-        return executedTests;
+    public Set<String> getTestsDetails() {
+        return testDetails;
     }
 }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -136,6 +136,9 @@ public class PluginCompatTesterConfig {
     // Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code
     private boolean failOnError;
 
+    // Flag to indicate if we want to store all the tests names or only failed ones on PCT report files
+    private boolean storeAll;
+
     public PluginCompatTesterConfig(File workDirectory, File reportFile, File m2SettingsFile){
         this(DEFAULT_UPDATE_CENTER_URL, DEFAULT_PARENT_GAV,
                 workDirectory, reportFile, m2SettingsFile);
@@ -433,5 +436,13 @@ public class PluginCompatTesterConfig {
 
     public void setFailOnError(boolean failOnError) {
         this.failOnError = failOnError;
+    }
+
+    public void setStoreAll(boolean storeAll) {
+        this.storeAll = storeAll;
+    }
+    
+    public boolean isStoreAll() {
+        return storeAll;
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -518,8 +518,6 @@ public class PluginCompatTester {
             }
 
             List<String> args = new ArrayList<>();
-            args.add("-X");
-            args.add("-U");
             args.add("--define=forkCount=1");
             args.add("hpi:resolve-test-dependencies");
             args.add("hpi:test-hpl");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -316,6 +316,7 @@ public class PluginCompatTester {
                         }
                         errorMessage = e.getErrorMessage();
                         warningMessages.addAll(e.getPomWarningMessages());
+                        executedTests.addAll(e.getExecutedTests());
                     } catch (Error e){
                         // Rethrow the error ... something is wrong !
                         throw e;
@@ -538,14 +539,15 @@ public class PluginCompatTester {
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, args.toArray(new String[args.size()]));
 
             return new TestExecutionResult(((PomData)forExecutionHooks.get("pomData")).getWarningMessages(), new ExecutedTestNamesSolver().solve(runner.getExecutedTests(), pluginCheckoutDir));
-        }catch(ExecutedTestNamesSolverException | PomExecutionException e){
-            PomExecutionException e2 = new PomExecutionException(e);
-            e2.getPomWarningMessages().addAll(pomData.getWarningMessages());
+        } catch (ExecutedTestNamesSolverException e) {
+            throw new PomExecutionException(e);
+        } catch (PomExecutionException e){
+            e.getPomWarningMessages().addAll(pomData.getWarningMessages());
             if (ranCompile) {
                 // So the status is considered to be TEST_FAILURES not COMPILATION_ERROR:
-                e2.succeededPluginArtifactIds.add("maven-compiler-plugin");
+                e.succeededPluginArtifactIds.add("maven-compiler-plugin");
             }
-            throw e2;
+            throw e;
         }
     }
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -518,6 +518,8 @@ public class PluginCompatTester {
             }
 
             List<String> args = new ArrayList<>();
+            args.add("-X");
+            args.add("-U");
             args.add("--define=forkCount=1");
             args.add("hpi:resolve-test-dependencies");
             args.add("hpi:test-hpl");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -235,7 +235,6 @@ public class PluginCompatTester {
 
         boolean failed = false;
         SCMManagerFactory.getInstance().start();
-    ExecutedTestNamesSolver testNamesSolver = new ExecutedTestNamesSolver();
         ROOT_CYCLE: for(MavenCoordinates coreCoordinates : testedCores){
             System.out.println("Starting plugin tests on core coordinates : "+coreCoordinates.toString());
             for (Plugin plugin : pluginsToCheck.values()) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -298,7 +298,7 @@ public class PluginCompatTester {
                     }
 
                     List<String> warningMessages = new ArrayList<>();
-                    Set<String> executedTests = new HashSet<>();
+                    Set<String> executedTests = new TreeSet<>();
                     if (errorMessage == null) {
                     try {
                         TestExecutionResult result = testPluginAgainst(actualCoreCoordinates, plugin, mconfig, pomData, pluginsToCheck, pluginGroupIds, pcth, config.getOverridenPlugins());

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -238,8 +238,6 @@ public class PluginCompatTester {
         ROOT_CYCLE: for(MavenCoordinates coreCoordinates : testedCores){
             System.out.println("Starting plugin tests on core coordinates : "+coreCoordinates.toString());
             for (Plugin plugin : pluginsToCheck.values()) {
-                System.out.println(">>>> " + plugin.name.toLowerCase());
-                System.out.println(">>>> " + config.getIncludePlugins());
                 if(config.getIncludePlugins()==null || config.getIncludePlugins().contains(plugin.name.toLowerCase())){
                     PluginInfos pluginInfos = new PluginInfos(plugin.name, plugin.version, plugin.url);
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -238,6 +238,8 @@ public class PluginCompatTester {
         ROOT_CYCLE: for(MavenCoordinates coreCoordinates : testedCores){
             System.out.println("Starting plugin tests on core coordinates : "+coreCoordinates.toString());
             for (Plugin plugin : pluginsToCheck.values()) {
+                System.out.println(">>>> " + plugin.name.toLowerCase());
+                System.out.println(">>>> " + config.getIncludePlugins());
                 if(config.getIncludePlugins()==null || config.getIncludePlugins().contains(plugin.name.toLowerCase())){
                     PluginInfos pluginInfos = new PluginInfos(plugin.name, plugin.version, plugin.url);
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/ExecutedTestNamesSolverException.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/ExecutedTestNamesSolverException.java
@@ -1,0 +1,22 @@
+package org.jenkins.tools.test.exception;
+
+public class ExecutedTestNamesSolverException  extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public ExecutedTestNamesSolverException() {
+            super();
+    }
+
+    public ExecutedTestNamesSolverException(String msg) {
+            super(msg);
+    }
+
+    public ExecutedTestNamesSolverException(String msg, Exception e) {
+            super(msg, e);
+    }
+
+    public ExecutedTestNamesSolverException(Exception e) {
+            super(e);
+    }
+} 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.jenkins.tools.test.util.ExecutedTestNamesDetails;
+
 /**
  * Exception thrown during a plugin's Maven execution
  *
@@ -44,22 +46,22 @@ public class PomExecutionException extends Exception {
     private final List<Throwable> exceptionsThrown;
     public final List<String> succeededPluginArtifactIds;
     private final List<String> pomWarningMessages;
-    private final Set<String> executedTests;
+    private final ExecutedTestNamesDetails testDetails;
 
     public PomExecutionException(Throwable cause) {
-        this(cause.toString(), Collections.emptyList(), Collections.singletonList(cause), Collections.emptyList(), Collections.emptySet());
+        this(cause.toString(), Collections.emptyList(), Collections.singletonList(cause), Collections.emptyList(), new ExecutedTestNamesDetails());
     }
 
     public PomExecutionException(PomExecutionException exceptionToCopy){
-        this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.pomWarningMessages, exceptionToCopy.executedTests);
+        this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.pomWarningMessages, exceptionToCopy.testDetails);
     }
 
-    public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, List<String> pomWarningMessages, Set<String> executedTests){
+    public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, List<String> pomWarningMessages, ExecutedTestNamesDetails testDetails){
         super(message, exceptionsThrown.isEmpty() ? null : exceptionsThrown.iterator().next());
         this.exceptionsThrown = new ArrayList<>(exceptionsThrown);
         this.succeededPluginArtifactIds = new ArrayList<>(succeededPluginArtifactIds);
         this.pomWarningMessages = new ArrayList<>(pomWarningMessages);
-        this.executedTests = new TreeSet<>(executedTests);
+        this.testDetails = testDetails;
     }
 
     public String getErrorMessage(){
@@ -79,7 +81,7 @@ public class PomExecutionException extends Exception {
         return pomWarningMessages;
     }
     
-    public Set<String> getExecutedTests() {
-        return executedTests;
+    public ExecutedTestNamesDetails getTestDetails() {
+        return testDetails;
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Exception thrown during a plugin's Maven execution
@@ -42,20 +44,22 @@ public class PomExecutionException extends Exception {
     private final List<Throwable> exceptionsThrown;
     public final List<String> succeededPluginArtifactIds;
     private final List<String> pomWarningMessages;
+    private final Set<String> executedTests;
 
     public PomExecutionException(Throwable cause) {
-        this(cause.toString(), Collections.emptyList(), Collections.singletonList(cause), Collections.emptyList());
+        this(cause.toString(), Collections.emptyList(), Collections.singletonList(cause), Collections.emptyList(), Collections.emptySet());
     }
 
     public PomExecutionException(PomExecutionException exceptionToCopy){
-        this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.pomWarningMessages);
+        this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.pomWarningMessages, exceptionToCopy.executedTests);
     }
 
-    public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, List<String> pomWarningMessages){
+    public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, List<String> pomWarningMessages, Set<String> executedTests){
         super(message, exceptionsThrown.isEmpty() ? null : exceptionsThrown.iterator().next());
         this.exceptionsThrown = new ArrayList<>(exceptionsThrown);
         this.succeededPluginArtifactIds = new ArrayList<>(succeededPluginArtifactIds);
         this.pomWarningMessages = new ArrayList<>(pomWarningMessages);
+        this.executedTests = new TreeSet<>(executedTests);
     }
 
     public String getErrorMessage(){
@@ -73,5 +77,9 @@ public class PomExecutionException extends Exception {
 
     public List<String> getPomWarningMessages() {
         return pomWarningMessages;
+    }
+    
+    public Set<String> getExecutedTests() {
+        return executedTests;
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 
 import org.jenkins.tools.test.exception.PomExecutionException;
+import org.jenkins.tools.test.util.ExecutedTestNamesSolver;
 
 /**
  * Runs external Maven executable.
@@ -36,8 +37,9 @@ public class ExternalMavenRunner implements MavenRunner {
 
     /**
      * Constructor.
-     * @param mvn Path to Maven.
-     *            If {@code null}, a default Maven executable from {@code PATH} will be used
+     * 
+     * @param mvn Path to Maven. If {@code null}, a default Maven executable from
+     *            {@code PATH} will be used
      */
     public ExternalMavenRunner(@CheckForNull File mvn) {
         this.mvn = mvn;
@@ -49,7 +51,8 @@ public class ExternalMavenRunner implements MavenRunner {
     }
 
     @Override
-    public void run(Config config, File baseDirectory, File buildLogFile, String... goals) throws PomExecutionException {
+    public void run(Config config, File baseDirectory, File buildLogFile, String... goals)
+            throws PomExecutionException {
         List<String> cmd = new ArrayList<>();
         cmd.add(mvn != null ? mvn.getAbsolutePath() : "mvn");
         cmd.add("--show-version");
@@ -58,7 +61,7 @@ public class ExternalMavenRunner implements MavenRunner {
         if (config.userSettingsFile != null) {
             cmd.add("--settings=" + config.userSettingsFile);
         }
-        for (Map.Entry<String,String> entry : config.userProperties.entrySet()) {
+        for (Map.Entry<String, String> entry : config.userProperties.entrySet()) {
             cmd.add("--define=" + entry);
         }
         cmd.addAll(Arrays.asList(goals));
@@ -67,18 +70,19 @@ public class ExternalMavenRunner implements MavenRunner {
             Process p = new ProcessBuilder(cmd).directory(baseDirectory).redirectErrorStream(true).start();
             List<String> succeededPluginArtifactIds = new ArrayList<>();
             try (InputStream is = p.getInputStream();
-                    BufferedReader r =
-                            new BufferedReader(
-                                    new InputStreamReader(is, Charset.defaultCharset()));
+                    BufferedReader r = new BufferedReader(new InputStreamReader(is, Charset.defaultCharset()));
                     FileOutputStream os = new FileOutputStream(buildLogFile, true);
-                    PrintWriter w =
-                            new PrintWriter(new OutputStreamWriter(os, Charset.defaultCharset()))) {
+                    PrintWriter w = new PrintWriter(new OutputStreamWriter(os, Charset.defaultCharset()))) {
                 String completed = null;
                 Pattern pattern = Pattern.compile("\\[INFO\\] --- (.+):.+:.+ [(].+[)] @ .+ ---");
                 String line;
+                boolean testPhase = false;
                 while ((line = r.readLine()) != null) {
                     System.out.println(line);
                     w.println(line);
+                    if(line.contains("T E S T S")) {
+                        testPhase = true;
+                    }
                     Matcher m = pattern.matcher(line);
                     if (m.matches()) {
                         if (completed != null) {
@@ -87,7 +91,7 @@ public class ExternalMavenRunner implements MavenRunner {
                         completed = m.group(1);
                     } else if (line.equals("[INFO] BUILD SUCCESS") && completed != null) {
                         succeededPluginArtifactIds.add(completed);
-                    } else if (line.startsWith("[INFO] Running") && !line.contains("InjectedTest")) {
+                    } else if (testPhase && line.startsWith("[INFO] Running") && !line.contains("InjectedTest")) {
                         this.executedTests.add(line.split("Running")[1].trim());
                     }
                 }
@@ -96,7 +100,9 @@ public class ExternalMavenRunner implements MavenRunner {
                 System.out.println("executed classname tests: " + getExecutedTests());
             }
             if (p.waitFor() != 0) {
-                throw new PomExecutionException(cmd + " failed in " + baseDirectory, succeededPluginArtifactIds, /* TODO */Collections.emptyList(), Collections.emptyList());
+                throw new PomExecutionException(cmd + " failed in " + baseDirectory, succeededPluginArtifactIds,
+                        /* TODO */Collections.emptyList(), Collections.emptyList(),
+                        new ExecutedTestNamesSolver().solve(getExecutedTests(), baseDirectory));
             }
         } catch (PomExecutionException x) {
             throw x;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -105,8 +105,10 @@ public class ExternalMavenRunner implements MavenRunner {
                         new ExecutedTestNamesSolver().solve(getExecutedTests(), baseDirectory));
             }
         } catch (PomExecutionException x) {
+            x.printStackTrace();
             throw x;
         } catch (Exception x) {
+            x.printStackTrace();
             throw new PomExecutionException(x);
         }
     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.jenkins.tools.test.util.ExecutedTestNamesDetails;
+
 /**
  * POJO containing plugin compatibility test result
  *
@@ -36,20 +38,20 @@ import java.util.Set;
  */
 public class TestExecutionResult {
 
-    private final Set<String> executedTests;
+    private final ExecutedTestNamesDetails testDetails;
 
     public final List<String> pomWarningMessages;
 
     public TestExecutionResult(List<String> pomWarningMessages){
-        this(pomWarningMessages, Collections.emptySet());
+        this(pomWarningMessages, new ExecutedTestNamesDetails());
     }
 
-    public TestExecutionResult(List<String> pomWarningMessages, Set<String> executedTests){
+    public TestExecutionResult(List<String> pomWarningMessages, ExecutedTestNamesDetails testDetails){
         this.pomWarningMessages = Collections.unmodifiableList(pomWarningMessages);
-        this.executedTests = executedTests;
+        this.testDetails = testDetails;
     }
 
-    public Set<String> getExecutedTests() {
-        return Collections.unmodifiableSet(executedTests);
+    public ExecutedTestNamesDetails getTestDetails() {
+        return testDetails;
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
@@ -27,6 +27,7 @@ package org.jenkins.tools.test.model;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * POJO containing plugin compatibility test result
@@ -34,9 +35,21 @@ import java.util.List;
  * @author Frederic Camblor
  */
 public class TestExecutionResult {
+
+    private final Set<String> executedTests;
+
     public final List<String> pomWarningMessages;
 
     public TestExecutionResult(List<String> pomWarningMessages){
+        this(pomWarningMessages, Collections.emptySet());
+    }
+
+    public TestExecutionResult(List<String> pomWarningMessages, Set<String> executedTests){
         this.pomWarningMessages = Collections.unmodifiableList(pomWarningMessages);
+        this.executedTests = executedTests;
+    }
+
+    public Set<String> getExecutedTests() {
+        return Collections.unmodifiableSet(executedTests);
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesDetails.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesDetails.java
@@ -1,0 +1,55 @@
+package org.jenkins.tools.test.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class ExecutedTestNamesDetails {
+    
+    private static final String FAILED = "FAILED";
+    
+    private static final String EXECUTED = "EXECUTED";
+    
+    private Map<String, Set<String>> tests;
+    
+    public ExecutedTestNamesDetails() {
+        this.tests = new HashMap<>();
+        this.tests.put(FAILED, new TreeSet<String>());
+        this.tests.put(EXECUTED, new TreeSet<String>());
+    }
+    
+    public void addFailedTest(String test) {
+        add(FAILED, test);
+    }
+    
+    public void addExecutedTest(String test) {
+        add(EXECUTED, test);
+    }
+    
+    public Set<String> getAll() {
+        Set<String> result = new TreeSet<>(this.tests.get(EXECUTED));
+        result.addAll(this.tests.get(FAILED));
+        return Collections.unmodifiableSet(result);
+    }
+    
+    public Set<String> getFailed() {
+        return get(FAILED);
+    }
+    
+    public Set<String> getExecuted() {
+        return get(EXECUTED);
+    }
+    
+    private Set<String> get(String key) {
+        return Collections.unmodifiableSet(new TreeSet<>(this.tests.get(key)));
+    }
+    
+    private void add(String key, String test) {
+        this.tests.get(key).add(test);
+    }
+    
+    
+
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
@@ -1,6 +1,7 @@
 package org.jenkins.tools.test.util;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Set;
@@ -8,10 +9,12 @@ import java.util.TreeSet;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.jenkins.tools.test.exception.ExecutedTestNamesSolverException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
 public class ExecutedTestNamesSolver {
 
@@ -68,7 +71,7 @@ public class ExecutedTestNamesSolver {
                 }
             }
 
-        } catch (Exception e) {
+        } catch (ParserConfigurationException | SAXException | IOException e) {
             throw new ExecutedTestNamesSolverException(e);
         }
         

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
@@ -47,6 +47,7 @@ public class ExecutedTestNamesSolver {
                 File testReport = Paths.get(testReportPath).toFile();
                 if (!testReport.exists()) {
                     System.out.println(String.format(WARNING_MSG, testReportPath));
+                    continue;
                 }
                 
                 Document document = builder.parse(testReport);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
@@ -1,0 +1,85 @@
+package org.jenkins.tools.test.util;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.jenkins.tools.test.exception.ExecutedTestNamesSolverException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+public class ExecutedTestNamesSolver {
+
+    private static final String WARNING_MSG = "[WARNING] Unable to retrieve info from: %s";
+    
+    private static final String TEST_PLACEHOLDER = "TEST-%s.xml";
+
+    public Set<String> solve(Set<String> executedTests, File baseDirectory) throws ExecutedTestNamesSolverException {
+
+        System.out.println("[INFO] -------------------------------------------------------");
+        System.out.println("[INFO] Solving test names");
+        System.out.println("[INFO] -------------------------------------------------------");
+        
+        Set<String> testNames = new TreeSet<>();
+        try {
+            
+            String surefireReportsDirectoryPath = baseDirectory.getAbsolutePath() + File.separator + "target" + File.separator + "surefire-reports";
+            File surefireReportsDirectory = Paths.get(surefireReportsDirectoryPath).toFile();
+            if (!surefireReportsDirectory.exists()) {
+                System.out.println(String.format(WARNING_MSG, surefireReportsDirectoryPath));
+                return Collections.emptySet();
+            }
+            
+            System.out.println(String.format("[INFO] Reading %s", surefireReportsDirectoryPath));
+            
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            for (String testName : executedTests) {
+                String reference = String.format(TEST_PLACEHOLDER, testName);
+                String testReportPath = surefireReportsDirectoryPath + File.separator + reference;
+                File testReport = Paths.get(testReportPath).toFile();
+                if (!testReport.exists()) {
+                    System.out.println(String.format(WARNING_MSG, testReportPath));
+                }
+                
+                Document document = builder.parse(testReport);
+                Node testsuite = document.getChildNodes().item(0);
+                String nodeValue = testsuite.getAttributes().getNamedItem("tests").getNodeValue();
+                Integer testCount = Integer.valueOf(nodeValue);
+                int found = 0;
+                for (int i = 0; i < testsuite.getChildNodes().getLength(); i++) {
+                    Node testcase = testsuite.getChildNodes().item(i);
+                    if (testcase.getAttributes() != null && testcase.getAttributes().getNamedItem("classname") != null) {
+                        String clazzName = testcase.getAttributes().getNamedItem("classname").getNodeValue();
+                        String test = testcase.getAttributes().getNamedItem("name").getNodeValue();
+                        found++;
+                        testNames.add(String.format("%s.%s", clazzName, test));
+                    }
+                }
+                
+                if (testCount.intValue() != found) {
+                    System.out.println(String.format("[WARNING] Extracted: %s, Expected: %s from %s", found, testCount, testReportPath));
+                } else {
+                    System.out.println(String.format("[INFO] Extracted %s testnames from %s", testCount, testReportPath));
+                }
+            }
+
+        } catch (Exception e) {
+            throw new ExecutedTestNamesSolverException(e);
+        }
+        
+        System.out.println("[INFO] ");
+        System.out.println("[INFO] Results:");
+        System.out.println("[INFO] ");
+        for (String testName : testNames) {
+            System.out.println(String.format("[INFO] - %s", testName));
+        }
+        
+        return testNames;
+    }
+    
+}

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -131,12 +131,14 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("accurev", entry.getKey().pluginName);
+            assertEquals("ant", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
             assertNotNull(result.getExecutedTests());
+            assertEquals(1, result.getExecutedTests().size());
+            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTest.emptyParameterTest"));
         }
     }    
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -85,7 +85,7 @@ public class PluginCompatTesterTest {
 
     @Test
     public void testWithUrl() throws Throwable {
-        ImmutableList<String> includedPlugins = ImmutableList.of("accurev"
+        ImmutableList<String> includedPlugins = ImmutableList.of("ant"
         /*
          * "accurev", "active-directory", "analysis-collector", "scm-sync-configuration"
          */

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -89,7 +89,7 @@ public class PluginCompatTesterTest {
     @Test
     public void testWithUrl() throws Throwable {
         PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
-        config.setStoreAll(true);
+        config.setStoreAll(true); 
 
         PluginCompatTester tester = new PluginCompatTester(config);
         PluginCompatReport report = tester.testPlugins();

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -67,7 +67,7 @@ import org.springframework.core.io.ClassPathResource;
  */
 public class PluginCompatTesterTest {
 
-    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\mvn";
+    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\mvn.cmd";
 
     private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml", System.getProperty("java.io.tmpdir"), File.separator, File.separator);
     

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -85,7 +85,7 @@ public class PluginCompatTesterTest {
 
     @Test
     public void testWithUrl() throws Throwable {
-        ImmutableList<String> includedPlugins = ImmutableList.of("ant"
+        ImmutableList<String> includedPlugins = ImmutableList.of("accurev"
         /*
          * "accurev", "active-directory", "analysis-collector", "scm-sync-configuration"
          */

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -131,7 +131,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("ant", entry.getKey().pluginName);
+            assertEquals("accurev", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -40,6 +40,7 @@ import org.jenkins.tools.test.model.PluginCompatResult;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -86,7 +87,7 @@ public class PluginCompatTesterTest {
 
     @Test
     public void testWithUrl() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("ant"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
         config.setStoreAll(true);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -95,7 +96,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("ant", entry.getKey().pluginName);
+            assertEquals("active-directory", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
@@ -103,22 +104,33 @@ public class PluginCompatTesterTest {
             assertNotNull(result.getTestsDetails());
             assertFalse(result.getTestsDetails().isEmpty());
             // Let's evaluate some executed tests
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntJCasCCompatibilityTest.roundTripTest"));
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.customBuildFileTest"));
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.emptyParameterTest"));
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.invokeCustomTargetTest"));
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.invokeDefaultTargetTest"));
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntWrapperTest.smokes"));
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTargetAnnotationTest.test1"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectoryAuthenticationProviderTest.testEscape"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testAdvancedOptionsVisibleWithNonNativeAuthentication"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testCacheOptionAlwaysVisible"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultiDomainSingleDomainOneDisplayName"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultiDomainTwoDomainsOneDisplayName"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultipleDomainsOneDomainEndToEnd"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomain"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomainSingleServer"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomainWithTwoServers"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterComma"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterCommaAndSingleServer"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterCommaAndTwoServers"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterComma"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterCommaAndSingleServer"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterCommaAndTwoServers"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testNoGroupsAreRegistered"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testNoGroupsAreRelevant"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testSomeGroupsAreRelevant"));
         }
     }
     
     @Test
     public void testWithIsolatedTest() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("ant"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
         config.setStoreAll(true);
         Map<String, String> mavenProperties = new HashMap<>();
-        mavenProperties.put("test","AntTest#customBuildFileTest");
+        mavenProperties.put("test","ActiveDirectoryAuthenticationProviderTest#testEscape");
         config.setMavenProperties(mavenProperties);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -127,20 +139,21 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("ant", entry.getKey().pluginName);
+            assertEquals("active-directory", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
             assertNotNull(result.getTestsDetails());
+            assertFalse(result.getTestsDetails().isEmpty());
             assertEquals(1, result.getTestsDetails().size());
-            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.customBuildFileTest"));
+            assertTrue(result.getTestsDetails().contains("ActiveDirectoryAuthenticationProviderTest.testEscape"));
         }
     }  
     
     @Test
     public void testStoreOnlyFailedTests() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("ant"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("analysis-collector"));
         config.setStoreAll(false);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -149,13 +162,14 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("ant", entry.getKey().pluginName);
+            assertEquals("analysis-collector", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
             assertNotNull(result.getTestsDetails());
-            assertEquals(0, result.getTestsDetails().size());
+            // No failed tests on accurev plugin (it will store ONLY failed tests due to -storeAll=false
+            assertTrue(result.getTestsDetails().isEmpty());
         }
     } 
 
@@ -170,6 +184,7 @@ public class PluginCompatTesterTest {
         config.setTestCacheTimeout(345600000);
         config.setParentVersion("1.410");
         config.setGenerateHtmlReport(true);
+        config.setHookPrefixes(Collections.emptyList());
         return config;
     }
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -40,6 +40,7 @@ import org.jenkins.tools.test.model.PluginCompatResult;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,6 +164,7 @@ public class PluginCompatTesterTest {
                 new File(REPORT_FILE), getSettingsFile());
 
         config.setIncludePlugins(includedPlugins);
+        config.setExcludePlugins(Collections.emptyList());
         config.setSkipTestCache(true);
         config.setCacheThresholdStatus(TestStatus.TEST_FAILURES);
         config.setTestCacheTimeout(345600000);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -67,7 +67,7 @@ import org.springframework.core.io.ClassPathResource;
  */
 public class PluginCompatTesterTest {
 
-    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\mvn.bat";
+    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\..";
 
     private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml", System.getProperty("java.io.tmpdir"), File.separator, File.separator);
     

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -87,7 +87,7 @@ public class PluginCompatTesterTest {
 
     @Test
     public void testWithUrl() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("buildtriggerbadge"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
         config.setStoreAll(true);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -96,7 +96,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("buildtriggerbadge", entry.getKey().pluginName);
+            assertEquals("active-directory", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
@@ -104,20 +104,33 @@ public class PluginCompatTesterTest {
             assertNotNull(result.getTestsDetails());
             assertFalse(result.getTestsDetails().isEmpty());
             // Let's evaluate some executed tests
-            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.externallyAddedCause"));
-            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.externallyDisabledCause"));
-            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.stupidlyMockedUpstreamCause"));
-            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.RunListenerImplTest.checkBadges"));
-            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.RunListenerImplTest.sameIconMultipleTimesCorrection"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectoryAuthenticationProviderTest.testEscape"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testAdvancedOptionsVisibleWithNonNativeAuthentication"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testCacheOptionAlwaysVisible"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultiDomainSingleDomainOneDisplayName"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultiDomainTwoDomainsOneDisplayName"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultipleDomainsOneDomainEndToEnd"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomain"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomainSingleServer"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomainWithTwoServers"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterComma"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterCommaAndSingleServer"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterCommaAndTwoServers"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterComma"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterCommaAndSingleServer"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterCommaAndTwoServers"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testNoGroupsAreRegistered"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testNoGroupsAreRelevant"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testSomeGroupsAreRelevant"));
         }
     }
     
     @Test
     public void testWithIsolatedTest() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("buildtriggerbadge"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
         config.setStoreAll(true);
         Map<String, String> mavenProperties = new HashMap<>();
-        mavenProperties.put("test","BuildTriggerBadgeActionTest#externallyAddedCause");
+        mavenProperties.put("test","ActiveDirectoryAuthenticationProviderTest#testEscape");
         config.setMavenProperties(mavenProperties);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -126,7 +139,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("buildtriggerbadgevvvvvv", entry.getKey().pluginName);
+            assertEquals("active-directory", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
@@ -134,13 +147,13 @@ public class PluginCompatTesterTest {
             assertNotNull(result.getTestsDetails());
             assertFalse(result.getTestsDetails().isEmpty());
             assertEquals(1, result.getTestsDetails().size());
-            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.externallyAddedCause"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectoryAuthenticationProviderTest.testEscape"));
         }
     }  
     
     @Test
     public void testStoreOnlyFailedTests() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("buildtriggerbadge"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("analysis-collector"));
         config.setStoreAll(false);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -149,13 +162,13 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("buildtriggerbadge", entry.getKey().pluginName);
+            assertEquals("analysis-collector", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
             assertNotNull(result.getTestsDetails());
-            // No failed tests on buildtriggerbadge plugin (it will store ONLY failed tests due to -storeAll=false
+            // No failed tests on accurev plugin (it will store ONLY failed tests due to -storeAll=false
             assertTrue(result.getTestsDetails().isEmpty());
         }
     } 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -69,7 +69,7 @@ public class PluginCompatTesterTest {
 
     private static final String MAVEN_INSTALLATION_LINUX = "/usr/bin/mvn";
     
-    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\";
+    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\mvn.bat";
 
     private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml", System.getProperty("java.io.tmpdir"), File.separator, File.separator);
     

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -112,16 +112,16 @@ public class PluginCompatTesterTest {
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
-            assertNotNull(result.getExecutedTests());
-            assertFalse(result.getExecutedTests().isEmpty());
+            assertNotNull(result.getTestsDetails());
+            assertFalse(result.getTestsDetails().isEmpty());
             // Let's evaluate some executed tests
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntJCasCCompatibilityTest.roundTripTest"));
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTest.customBuildFileTest"));
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTest.emptyParameterTest"));
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTest.invokeCustomTargetTest"));
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTest.invokeDefaultTargetTest"));
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntWrapperTest.smokes"));
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTargetAnnotationTest.test1"));
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntJCasCCompatibilityTest.roundTripTest"));
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.customBuildFileTest"));
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.emptyParameterTest"));
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.invokeCustomTargetTest"));
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.invokeDefaultTargetTest"));
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntWrapperTest.smokes"));
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTargetAnnotationTest.test1"));
         }
     }
     
@@ -153,9 +153,9 @@ public class PluginCompatTesterTest {
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
-            assertNotNull(result.getExecutedTests());
-            assertEquals(1, result.getExecutedTests().size());
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTest.customBuildFileTest"));
+            assertNotNull(result.getTestsDetails());
+            assertEquals(1, result.getTestsDetails().size());
+            assertTrue(result.getTestsDetails().contains("hudson.tasks.AntTest.customBuildFileTest"));
         }
     }    
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -186,6 +186,17 @@ public class PluginCompatTesterTest {
         config.setParentVersion("1.410");
         config.setGenerateHtmlReport(true);
         config.setHookPrefixes(Collections.emptyList());
+        
+        File ciJenkinsIoLinuxMvn = Paths.get("/home/jenkins/tools/hudson.tasks.Maven_MavenInstallation/mvn").toFile();
+        if (ciJenkinsIoLinuxMvn.exists()) {
+            config.setExternalMaven(ciJenkinsIoLinuxMvn);
+        } else {
+            File ciJenkinsIoWinMvn = Paths.get("C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\").toFile();
+            if (ciJenkinsIoWinMvn.exists()) {
+                config.setExternalMaven(ciJenkinsIoWinMvn);
+            }
+        }
+        
         return config;
     }
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -67,7 +67,7 @@ import org.springframework.core.io.ClassPathResource;
  */
 public class PluginCompatTesterTest {
 
-    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\..";
+    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\mvn";
 
     private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml", System.getProperty("java.io.tmpdir"), File.separator, File.separator);
     

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -67,7 +67,8 @@ import org.springframework.core.io.ClassPathResource;
  */
 public class PluginCompatTesterTest {
 
-    private static final String REPORT_FILE = "../reports/PluginCompatReport.xml";
+    private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml", System.getProperty("java.io.tmpdir"), File.separator, File.separator);
+    
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
@@ -168,7 +169,7 @@ public class PluginCompatTesterTest {
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
             assertNotNull(result.getTestsDetails());
-            // No failed tests on accurev plugin (it will store ONLY failed tests due to -storeAll=false
+            // No failed tests on this plugin (it will store ONLY failed tests due to -storeAll=false
             assertTrue(result.getTestsDetails().isEmpty());
         }
     } 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -85,7 +85,7 @@ public class PluginCompatTesterTest {
 
     @Test
     public void testWithUrl() throws Throwable {
-        ImmutableList<String> includedPlugins = ImmutableList.of("ant"
+        ImmutableList<String> includedPlugins = ImmutableList.of("workflow-api"
         /*
          * "accurev", "active-directory", "analysis-collector", "scm-sync-configuration"
          */
@@ -107,7 +107,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("ant", entry.getKey().pluginName);
+            assertEquals("workflow-api", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -130,7 +130,7 @@ public class PluginCompatTesterTest {
     @Test
     public void testWithIsolatedTest() throws Throwable {
         PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
-        config.setStoreAll(true);
+        config.setStoreAll(true); 
         Map<String, String> mavenProperties = new HashMap<>();
         mavenProperties.put("test","ActiveDirectoryAuthenticationProviderTest#testEscape");
         config.setMavenProperties(mavenProperties);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -105,7 +105,7 @@ public class PluginCompatTesterTest {
             assertNotNull(result);
             assertNotNull(result.getTestsDetails());
             assertFalse(result.getTestsDetails().isEmpty());
-            // Let's evaluate some executed tests
+            // Let's evaluate some executed tests 
             assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectoryAuthenticationProviderTest.testEscape"));
             assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testAdvancedOptionsVisibleWithNonNativeAuthentication"));
             assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testCacheOptionAlwaysVisible"));

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -87,7 +87,7 @@ public class PluginCompatTesterTest {
 
     @Test
     public void testWithUrl() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("buildtriggerbadge"));
         config.setStoreAll(true);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -96,7 +96,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("active-directory", entry.getKey().pluginName);
+            assertEquals("buildtriggerbadge", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
@@ -104,33 +104,20 @@ public class PluginCompatTesterTest {
             assertNotNull(result.getTestsDetails());
             assertFalse(result.getTestsDetails().isEmpty());
             // Let's evaluate some executed tests
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectoryAuthenticationProviderTest.testEscape"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testAdvancedOptionsVisibleWithNonNativeAuthentication"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testCacheOptionAlwaysVisible"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultiDomainSingleDomainOneDisplayName"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultiDomainTwoDomainsOneDisplayName"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveMultipleDomainsOneDomainEndToEnd"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomain"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomainSingleServer"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveSingleDomainWithTwoServers"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterComma"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterCommaAndSingleServer"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithSpaceAfterCommaAndTwoServers"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterComma"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterCommaAndSingleServer"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectorySecurityRealmTest.testReadResolveTwoDomainsWithoutSpaceAfterCommaAndTwoServers"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testNoGroupsAreRegistered"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testNoGroupsAreRelevant"));
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.RemoveIrrelevantGroupsTest.testSomeGroupsAreRelevant"));
+            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.externallyAddedCause"));
+            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.externallyDisabledCause"));
+            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.stupidlyMockedUpstreamCause"));
+            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.RunListenerImplTest.checkBadges"));
+            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.RunListenerImplTest.sameIconMultipleTimesCorrection"));
         }
     }
     
     @Test
     public void testWithIsolatedTest() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("buildtriggerbadge"));
         config.setStoreAll(true);
         Map<String, String> mavenProperties = new HashMap<>();
-        mavenProperties.put("test","ActiveDirectoryAuthenticationProviderTest#testEscape");
+        mavenProperties.put("test","BuildTriggerBadgeActionTest#externallyAddedCause");
         config.setMavenProperties(mavenProperties);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -139,7 +126,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("active-directory", entry.getKey().pluginName);
+            assertEquals("buildtriggerbadgevvvvvv", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
@@ -147,13 +134,13 @@ public class PluginCompatTesterTest {
             assertNotNull(result.getTestsDetails());
             assertFalse(result.getTestsDetails().isEmpty());
             assertEquals(1, result.getTestsDetails().size());
-            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectoryAuthenticationProviderTest.testEscape"));
+            assertTrue(result.getTestsDetails().contains("org.jenkinsci.plugins.buildtriggerbadge.BuildTriggerBadgeActionTest.externallyAddedCause"));
         }
     }  
     
     @Test
     public void testStoreOnlyFailedTests() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("analysis-collector"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("buildtriggerbadge"));
         config.setStoreAll(false);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -162,13 +149,13 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("analysis-collector", entry.getKey().pluginName);
+            assertEquals("buildtriggerbadge", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);
             assertNotNull(result);
             assertNotNull(result.getTestsDetails());
-            // No failed tests on accurev plugin (it will store ONLY failed tests due to -storeAll=false
+            // No failed tests on buildtriggerbadge plugin (it will store ONLY failed tests due to -storeAll=false
             assertTrue(result.getTestsDetails().isEmpty());
         }
     } 
@@ -185,7 +172,6 @@ public class PluginCompatTesterTest {
         config.setParentVersion("1.410");
         config.setGenerateHtmlReport(true);
         config.setHookPrefixes(Collections.emptyList());
-        config.setExternalMaven(getSettingsFile());
         return config;
     }
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -110,7 +110,7 @@ public class PluginCompatTesterTest {
     
     @Test
     public void testWithIsolatedTest() throws Throwable {
-        ImmutableList<String> includedPlugins = ImmutableList.of("ant");
+        ImmutableList<String> includedPlugins = ImmutableList.of("accurev");
 
         PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
                 new File("../reports/PluginCompatReport.xml"), getSettingsFile());
@@ -122,7 +122,7 @@ public class PluginCompatTesterTest {
         config.setParentVersion("1.410");
         config.setGenerateHtmlReport(true);
         Map<String, String> mavenProperties = new HashMap<>();
-        mavenProperties.put("test","AntTest#emptyParameterTest");
+        mavenProperties.put("test","AccurevSCMTest#testConfigRoundtrip");
         config.setMavenProperties(mavenProperties);
 
         PluginCompatTester tester = new PluginCompatTester(config);
@@ -138,7 +138,7 @@ public class PluginCompatTesterTest {
             assertNotNull(result);
             assertNotNull(result.getExecutedTests());
             assertEquals(1, result.getExecutedTests().size());
-            assertTrue(result.getExecutedTests().contains("hudson.tasks.AntTest.emptyParameterTest"));
+            assertTrue(result.getExecutedTests().contains("hudson.plugins.accurev.AccurevSCMTest.testConfigRoundtrip"));
         }
     }    
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -94,7 +94,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("workflow-api", entry.getKey().pluginName);
+            assertEquals("ant", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -67,6 +67,10 @@ import org.springframework.core.io.ClassPathResource;
  */
 public class PluginCompatTesterTest {
 
+    private static final String MAVEN_INSTALLATION_LINUX = "/home/jenkins/tools/hudson.tasks.Maven_MavenInstallation/mvn";
+    
+    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\";
+
     private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml", System.getProperty("java.io.tmpdir"), File.separator, File.separator);
     
     @Rule
@@ -187,12 +191,14 @@ public class PluginCompatTesterTest {
         config.setGenerateHtmlReport(true);
         config.setHookPrefixes(Collections.emptyList());
         
-        File ciJenkinsIoLinuxMvn = Paths.get("/home/jenkins/tools/hudson.tasks.Maven_MavenInstallation/mvn").toFile();
+        File ciJenkinsIoLinuxMvn = Paths.get(MAVEN_INSTALLATION_LINUX).toFile();
         if (ciJenkinsIoLinuxMvn.exists()) {
+            System.out.println(String.format("Using mvn: %s", MAVEN_INSTALLATION_LINUX));
             config.setExternalMaven(ciJenkinsIoLinuxMvn);
         } else {
-            File ciJenkinsIoWinMvn = Paths.get("C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\").toFile();
+            File ciJenkinsIoWinMvn = Paths.get(MAVEN_INSTALLATION_WINDOWS).toFile();
             if (ciJenkinsIoWinMvn.exists()) {
+                System.out.println(String.format("Using mvn: %s", MAVEN_INSTALLATION_WINDOWS));
                 config.setExternalMaven(ciJenkinsIoWinMvn);
             }
         }

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -67,8 +67,6 @@ import org.springframework.core.io.ClassPathResource;
  */
 public class PluginCompatTesterTest {
 
-    private static final String MAVEN_INSTALLATION_LINUX = "/usr/bin/mvn";
-    
     private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\mvn.bat";
 
     private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml", System.getProperty("java.io.tmpdir"), File.separator, File.separator);
@@ -191,16 +189,10 @@ public class PluginCompatTesterTest {
         config.setGenerateHtmlReport(true);
         config.setHookPrefixes(Collections.emptyList());
         
-        File ciJenkinsIoLinuxMvn = Paths.get(MAVEN_INSTALLATION_LINUX).toFile();
-        if (ciJenkinsIoLinuxMvn.exists()) {
-            System.out.println(String.format("Using mvn: %s", MAVEN_INSTALLATION_LINUX));
-            config.setExternalMaven(ciJenkinsIoLinuxMvn);
-        } else {
-            File ciJenkinsIoWinMvn = Paths.get(MAVEN_INSTALLATION_WINDOWS).toFile();
-            if (ciJenkinsIoWinMvn.exists()) {
-                System.out.println(String.format("Using mvn: %s", MAVEN_INSTALLATION_WINDOWS));
-                config.setExternalMaven(ciJenkinsIoWinMvn);
-            }
+        File ciJenkinsIoWinMvn = Paths.get(MAVEN_INSTALLATION_WINDOWS).toFile();
+        if (ciJenkinsIoWinMvn.exists()) {
+            System.out.println(String.format("Using mvn: %s", MAVEN_INSTALLATION_WINDOWS));
+            config.setExternalMaven(ciJenkinsIoWinMvn);
         }
         
         return config;

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -67,7 +67,7 @@ import org.springframework.core.io.ClassPathResource;
  */
 public class PluginCompatTesterTest {
 
-    private static final String MAVEN_INSTALLATION_LINUX = "/home/jenkins/tools/hudson.tasks.Maven_MavenInstallation/mvn";
+    private static final String MAVEN_INSTALLATION_LINUX = "/usr/bin/mvn";
     
     private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\";
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -147,7 +147,7 @@ public class PluginCompatTesterTest {
             assertNotNull(result.getTestsDetails());
             assertFalse(result.getTestsDetails().isEmpty());
             assertEquals(1, result.getTestsDetails().size());
-            assertTrue(result.getTestsDetails().contains("ActiveDirectoryAuthenticationProviderTest.testEscape"));
+            assertTrue(result.getTestsDetails().contains("hudson.plugins.active_directory.ActiveDirectoryAuthenticationProviderTest.testEscape"));
         }
     }  
     
@@ -185,6 +185,7 @@ public class PluginCompatTesterTest {
         config.setParentVersion("1.410");
         config.setGenerateHtmlReport(true);
         config.setHookPrefixes(Collections.emptyList());
+        config.setExternalMaven(getSettingsFile());
         return config;
     }
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -40,7 +40,6 @@ import org.jenkins.tools.test.model.PluginCompatResult;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -85,7 +85,7 @@ public class PluginCompatTesterTest {
 
     @Test
     public void testWithUrl() throws Throwable {
-        PluginCompatTesterConfig config = getConfig(ImmutableList.of("workflow-api"));
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("ant"));
         config.setStoreAll(true);
 
         PluginCompatTester tester = new PluginCompatTester(config);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -26,16 +26,25 @@
 package org.jenkins.tools.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 
 import org.jenkins.tools.test.model.MavenCoordinates;
+import org.jenkins.tools.test.model.PluginCompatReport;
+import org.jenkins.tools.test.model.PluginCompatResult;
+
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.PluginInfos;
 import org.jenkins.tools.test.model.PomData;
 import org.jenkins.tools.test.model.TestStatus;
 import org.junit.After;
@@ -56,30 +65,28 @@ public class PluginCompatTesterTest {
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-	@Before
-	public void setUp() throws Exception {
-		SCMManagerFactory.getInstance().start();
-	}
-	
-	@After
-	public void tearDown() {
-		SCMManagerFactory.getInstance().stop();
-	}
+    @Before
+    public void setUp() throws Exception {
+        SCMManagerFactory.getInstance().start();
+    }
 
-	@Test
-	public void testWithUrl() throws Throwable {
-        ImmutableList<String> includedPlugins = ImmutableList.of(
-                "accurev"
-                /* "active-directory",
-                "analysis-collector",
-                "scm-sync-configuration" */
+    @After
+    public void tearDown() {
+        SCMManagerFactory.getInstance().stop();
+    }
+
+    @Test
+    public void testWithUrl() throws Throwable {
+        ImmutableList<String> includedPlugins = ImmutableList.of("accurev"
+        /*
+         * "active-directory", "analysis-collector", "scm-sync-configuration"
+         */
         );
 
         PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
-                new File("../reports/PluginCompatReport.xml"),
-                getSettingsFile());
+                new File("../reports/PluginCompatReport.xml"), getSettingsFile());
 
-		config.setIncludePlugins(includedPlugins);
+        config.setIncludePlugins(includedPlugins);
         config.setSkipTestCache(true);
         config.setCacheThresholdStatus(TestStatus.TEST_FAILURES);
         config.setTestCacheTimeout(345600000);
@@ -87,165 +94,213 @@ public class PluginCompatTesterTest {
         config.setGenerateHtmlReport(true);
 
         PluginCompatTester tester = new PluginCompatTester(config);
-		tester.testPlugins();
-	}
+        PluginCompatReport report = tester.testPlugins();
+        assertNotNull(report);
+        Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
+        assertNotNull(pluginCompatTests);
+        for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
+            assertEquals("accurev", entry.getKey().pluginName);
+            List<PluginCompatResult> results = entry.getValue();
+            assertEquals(1, results.size());
+            PluginCompatResult result = results.get(0);
+            assertNotNull(result);
+            assertNotNull(result.getExecutedTests());
+        }
+    }
+    
+    @Test
+    public void testWithIsolatedTest() throws Throwable {
+        ImmutableList<String> includedPlugins = ImmutableList.of("ant");
+
+        PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
+                new File("../reports/PluginCompatReport.xml"), getSettingsFile());
+
+        config.setIncludePlugins(includedPlugins);
+        config.setSkipTestCache(true);
+        config.setCacheThresholdStatus(TestStatus.TEST_FAILURES);
+        config.setTestCacheTimeout(345600000);
+        config.setParentVersion("1.410");
+        config.setGenerateHtmlReport(true);
+        Map<String, String> mavenProperties = new HashMap<>();
+        mavenProperties.put("test","AntTest#emptyParameterTest");
+        config.setMavenProperties(mavenProperties);
+
+        PluginCompatTester tester = new PluginCompatTester(config);
+        PluginCompatReport report = tester.testPlugins();
+        assertNotNull(report);
+        Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
+        assertNotNull(pluginCompatTests);
+        for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
+            assertEquals("accurev", entry.getKey().pluginName);
+            List<PluginCompatResult> results = entry.getValue();
+            assertEquals(1, results.size());
+            PluginCompatResult result = results.get(0);
+            assertNotNull(result);
+            assertNotNull(result.getExecutedTests());
+        }
+    }    
 
     @Test(expected = RuntimeException.class)
     public void testWithoutAlternativeUrl() throws Throwable {
         String pluginName = "workflow-api";
         String version = "2.39";
         String nonWorkingConnectionURL = "scm:git:git://github.com/test/workflow-api-plugin.git";
-        MavenCoordinates mavenCoordinates = new MavenCoordinates("org.jenkins-ci.plugins","plugin","3.54");
+        MavenCoordinates mavenCoordinates = new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.54");
 
         PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
-                new File("../reports/PluginCompatReport.xml"),
-                getSettingsFile());
+                new File("../reports/PluginCompatReport.xml"), getSettingsFile());
         config.setIncludePlugins(ImmutableList.of(pluginName));
 
         PluginCompatTester pct = new PluginCompatTester(config);
-        PomData pomData = new PomData(pluginName, "hpi",  nonWorkingConnectionURL, pluginName + "-" + version, mavenCoordinates, "org.jenkins-ci.plugins.workflow") ;
-        pct.cloneFromSCM(pomData, pluginName, version, new File(config.workDirectory.getAbsolutePath() + File.separator + pluginName + File.separator));
+        PomData pomData = new PomData(pluginName, "hpi", nonWorkingConnectionURL, pluginName + "-" + version,
+                mavenCoordinates, "org.jenkins-ci.plugins.workflow");
+        pct.cloneFromSCM(pomData, pluginName, version,
+                new File(config.workDirectory.getAbsolutePath() + File.separator + pluginName + File.separator));
     }
 
-	@Test(expected = Test.None.class)
-	public void testWithAlternativeUrl() throws Throwable {
+    @Test(expected = Test.None.class)
+    public void testWithAlternativeUrl() throws Throwable {
         String pluginName = "workflow-api";
         String version = "2.39";
         String nonWorkingConnectionURL = "scm:git:git://github.com/test/workflow-api-plugin.git";
-        MavenCoordinates mavenCoordinates = new MavenCoordinates("org.jenkins-ci.plugins","plugin","3.54");
+        MavenCoordinates mavenCoordinates = new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.54");
 
         PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),
-				new File("../reports/PluginCompatReport.xml"),
-				getSettingsFile());
-		config.setIncludePlugins(ImmutableList.of(pluginName));
-		config.setFallbackGitHubOrganization("jenkinsci");
+                new File("../reports/PluginCompatReport.xml"), getSettingsFile());
+        config.setIncludePlugins(ImmutableList.of(pluginName));
+        config.setFallbackGitHubOrganization("jenkinsci");
 
         PluginCompatTester pct = new PluginCompatTester(config);
-        PomData pomData = new PomData(pluginName, "hpi",  nonWorkingConnectionURL, pluginName + "-" + version, mavenCoordinates, "org.jenkins-ci.plugins.workflow") ;
-        pct.cloneFromSCM(pomData, pluginName, version, new File(config.workDirectory.getAbsolutePath() + File.separator + pluginName + File.separator));
-	}
+        PomData pomData = new PomData(pluginName, "hpi", nonWorkingConnectionURL, pluginName + "-" + version,
+                mavenCoordinates, "org.jenkins-ci.plugins.workflow");
+        pct.cloneFromSCM(pomData, pluginName, version,
+                new File(config.workDirectory.getAbsolutePath() + File.separator + pluginName + File.separator));
+    }
 
-	@Test
-	public void testMatcher() {
+    @Test
+    public void testMatcher() {
 
-		String fileName = "WEB-INF/lib/jenkins-core-2.7.3-alpha-33.jar";
-		Matcher m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-alpha-33", m.group(1));
+        String fileName = "WEB-INF/lib/jenkins-core-2.7.3-alpha-33.jar";
+        Matcher m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-alpha-33", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-ALPHA-33.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-ALPHA-33", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-ALPHA-33.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-ALPHA-33", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-ALPHA-33-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-ALPHA-33-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-ALPHA-33-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-ALPHA-33-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-alpha-33-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-alpha-33-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-alpha-33-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-alpha-33-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-beta-33.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-beta-33", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-beta-33.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-beta-33", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-BETA-33.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-BETA-33", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-BETA-33.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-BETA-33", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-BETA-33-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-BETA-33-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-BETA-33-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-BETA-33-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-BETA-33-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-BETA-33-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-BETA-33-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-BETA-33-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-33.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-rc-33", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-33.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-rc-33", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-RC-33.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-RC-33", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-RC-33.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-RC-33", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-RC-33-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-RC-33-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-RC-33-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-RC-33-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-33-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-rc-33-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-33-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-rc-33-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-RC33.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-RC33", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-RC33.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-RC33", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-alpha33-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-alpha33-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-alpha33-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-alpha33-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-rc-SNAPSHOT", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-rc-SNAPSHOT", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-milestone.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-milestone", m.group(1));
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-milestone.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-milestone", m.group(1));
 
-		fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-milestone.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-		assertEquals("Invalid group", "2.7.3-rc-milestone", m.group(1));	}
+        fileName = "WEB-INF/lib/jenkins-core-2.7.3-rc-milestone.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+        assertEquals("Invalid group", "2.7.3-rc-milestone", m.group(1));
+    }
 
-	@Test
-	@Issue("JENKINS-50454")
-	public void testCustomWarPackagerVersions() {
-	//TODO: needs more filtering
-		String fileName = "WEB-INF/lib/jenkins-core-256.0-my-branch-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
-		Matcher m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
+    @Test
+    @Issue("JENKINS-50454")
+    public void testCustomWarPackagerVersions() {
+        // TODO: needs more filtering
+        String fileName = "WEB-INF/lib/jenkins-core-256.0-my-branch-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
+        Matcher m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
 
-		fileName = "WEB-INF/lib/jenkins-core-256.0-2090468d82e49345519a2457f1d1e7426f01540b-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
-		m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
-		assertTrue("No matches",m.matches());
-	}
+        fileName = "WEB-INF/lib/jenkins-core-256.0-2090468d82e49345519a2457f1d1e7426f01540b-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
+        m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertTrue("No matches", m.matches());
+    }
 
-	private static File getSettingsFile() throws IOException {
-		// Check whether we run in ci.jenkins.io with Azure settings
-		File ciJenkinsIOSettings = new File(new File("settings-azure.xml").getAbsolutePath().replace("/plugins-compat-tester/settings-azure.xml", "@tmp/settings-azure.xml"));
-		System.out.println("Will check Maven settings from " + ciJenkinsIOSettings.getAbsolutePath());
-		if (ciJenkinsIOSettings.exists()) {
-			System.out.println("Will use the ci.jenkins.io Azure settings file for testing: " + ciJenkinsIOSettings.getAbsolutePath());
-			return ciJenkinsIOSettings;
-		}
-		// Default fallback for local runs
-		return new ClassPathResource("m2-settings.xml").getFile();
-	}
+    private static File getSettingsFile() throws IOException {
+        // Check whether we run in ci.jenkins.io with Azure settings
+        File ciJenkinsIOSettings = new File(new File("settings-azure.xml").getAbsolutePath()
+                .replace("/plugins-compat-tester/settings-azure.xml", "@tmp/settings-azure.xml"));
+        System.out.println("Will check Maven settings from " + ciJenkinsIOSettings.getAbsolutePath());
+        if (ciJenkinsIOSettings.exists()) {
+            System.out.println("Will use the ci.jenkins.io Azure settings file for testing: "
+                    + ciJenkinsIOSettings.getAbsolutePath());
+            return ciJenkinsIOSettings;
+        }
+        // Default fallback for local runs
+        return new ClassPathResource("m2-settings.xml").getFile();
+    }
 
 }

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -148,7 +148,7 @@ public class PluginCompatTesterTest {
         Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
         assertNotNull(pluginCompatTests);
         for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
-            assertEquals("accurev", entry.getKey().pluginName);
+            assertEquals("ant", entry.getKey().pluginName);
             List<PluginCompatResult> results = entry.getValue();
             assertEquals(1, results.size());
             PluginCompatResult result = results.get(0);

--- a/plugins-compat-tester/src/test/resources/m2-settings.xml
+++ b/plugins-compat-tester/src/test/resources/m2-settings.xml
@@ -267,6 +267,28 @@ under the License.
         </pluginRepository>
       </pluginRepositories>
     </profile>
+    <profile>
+      <!-- JEP-305 -->
+      <id>consume-incrementals</id>
+      <repositories>
+        <repository>
+          <id>incrementals</id>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>incrementals</id>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
   </profiles>
 
   <!-- activeProfiles


### PR DESCRIPTION
- Provides the names of the executed tests under the PCT
```
[INFO] -------------------------------------------------------
[INFO] Solving test names
[INFO] -------------------------------------------------------
[INFO] Reading /tmp/pct/work/ant/target/surefire-reports
[INFO] Extracted 3 testnames from /tmp/pct/work/ant/target/surefire-reports/TEST-hudson.tasks.AntWrapperTest.xml
[INFO] Extracted 1 testnames from /tmp/pct/work/ant/target/surefire-reports/TEST-hudson.tasks._ant.AntTargetAnnotationTest.xml
[INFO] Extracted 3 testnames from /tmp/pct/work/ant/target/surefire-reports/TEST-hudson.tasks._ant.AntTargetNoteTest.xml
[INFO] Extracted 15 testnames from /tmp/pct/work/ant/target/surefire-reports/TEST-hudson.tasks.AntTest.xml
[INFO] Extracted 1 testnames from /tmp/pct/work/ant/target/surefire-reports/TEST-hudson.tasks.AntJCasCCompatibilityTest.xml
[INFO] 
[INFO] Results:
[INFO] 
[INFO] - hudson.tasks.AntJCasCCompatibilityTest.roundTripTest
[INFO] - hudson.tasks.AntTest.customBuildFileTest
[INFO] - hudson.tasks.AntTest.emptyParameterTest
[INFO] - hudson.tasks.AntTest.invokeCustomTargetTest
[INFO] - hudson.tasks.AntTest.invokeDefaultTargetTest
[INFO] - hudson.tasks.AntTest.jenkinsEnvVarsFromBuildScriptTest
[INFO] - hudson.tasks.AntTest.optionsInTargetFieldTest
[INFO] - hudson.tasks.AntTest.propertyReplacedByEmptyBuildParameter
[INFO] - hudson.tasks.AntTest.propertyReplacedByVariable
[INFO] - hudson.tasks.AntTest.testConfigRoundtrip
[INFO] - hudson.tasks.AntTest.testEscapeXmlInParameters
[INFO] - hudson.tasks.AntTest.testGlobalConfigAjax
[INFO] - hudson.tasks.AntTest.testParameterExpansion
[INFO] - hudson.tasks.AntTest.testParameterExpansionByShell
[INFO] - hudson.tasks.AntTest.testSensitiveParameters
[INFO] - hudson.tasks.AntTest.unexistingCustomBuildFileTest
[INFO] - hudson.tasks.AntWrapperTest.configRoundTrip
[INFO] - hudson.tasks.AntWrapperTest.durability
[INFO] - hudson.tasks.AntWrapperTest.smokes
[INFO] - hudson.tasks._ant.AntTargetAnnotationTest.test1
[INFO] - hudson.tasks._ant.AntTargetNoteTest.testAnnotateTarget
[INFO] - hudson.tasks._ant.AntTargetNoteTest.testAnnotateTargetContainingColon
[INFO] - hudson.tasks._ant.AntTargetNoteTest.testDisabled
```
- Stores the info inside the xml reports
```
<compatResult>
   <coreCoordinates>
      <groupId>org.jenkins-ci.plugins</groupId>
      <artifactId>plugin</artifactId>
      <version>2.222.1</version>
   </coreCoordinates>
   <status>SUCCESS</status>
   <compatTestExecutedOn>2020-04-06 10:28:57.703 UTC</compatTestExecutedOn>
   <warningMessages />
   <executedTests>
      <string>hudson.tasks.AntTest.optionsInTargetFieldTest</string>
      <string>hudson.tasks.AntTest.invokeDefaultTargetTest</string>
      <string>hudson.tasks.AntWrapperTest.smokes</string>
      <string>hudson.tasks.AntTest.testEscapeXmlInParameters</string>
      <string>hudson.tasks.AntTest.customBuildFileTest</string>
      <string>hudson.tasks.AntTest.jenkinsEnvVarsFromBuildScriptTest</string>
      <string>hudson.tasks.AntTest.testConfigRoundtrip</string>
      <string>hudson.tasks._ant.AntTargetNoteTest.testAnnotateTarget</string>
      <string>hudson.tasks._ant.AntTargetNoteTest.testDisabled</string>
      <string>hudson.tasks._ant.AntTargetNoteTest.testAnnotateTargetContainingColon</string>
      <string>hudson.tasks.AntTest.propertyReplacedByEmptyBuildParameter</string>
      <string>hudson.tasks.AntTest.testParameterExpansion</string>
      <string>hudson.tasks.AntTest.testParameterExpansionByShell</string>
      <string>hudson.tasks.AntWrapperTest.configRoundTrip</string>
      <string>hudson.tasks.AntTest.testGlobalConfigAjax</string>
      <string>hudson.tasks.AntJCasCCompatibilityTest.roundTripTest</string>
      <string>hudson.tasks.AntTest.unexistingCustomBuildFileTest</string>
      <string>hudson.tasks.AntTest.propertyReplacedByVariable</string>
      <string>hudson.tasks.AntTest.testSensitiveParameters</string>
      <string>hudson.tasks._ant.AntTargetAnnotationTest.test1</string>
      <string>hudson.tasks.AntTest.invokeCustomTargetTest</string>
      <string>hudson.tasks.AntWrapperTest.durability</string>
      <string>hudson.tasks.AntTest.emptyParameterTest</string>
   </executedTests>
   <buildLogPath>logs/ant/v1.11_against_org.jenkins-ci.plugins_plugin_2.222.1.log</buildLogPath>
</compatResult>
```