### PR TITLE
Evaluate optional dependencies

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -872,10 +872,11 @@ public class PluginCompatTester {
             runner.run(mconfig, pluginCheckoutDir, tmp, "dependency:resolve");
             try (BufferedReader br =
                     Files.newBufferedReader(tmp.toPath(), Charset.defaultCharset())) {
-                Pattern p = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(provided|compile|runtime|system)");
-                Pattern p2 = Pattern.compile("\\[INFO\\]    ([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(test)");
+                Pattern p = Pattern.compile("\\[INFO\\]([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(provided|compile|runtime|system)(\\(optional\\))?");
+                Pattern p2 = Pattern.compile("\\[INFO\\]([^:]+):([^:]+):([a-z-]+):(([^:]+):)?([^:]+):(test)");
                 String line;
                 while ((line = br.readLine()) != null) {
+                    line = line.replace(" ", "");
                     Matcher m = p.matcher(line);
                     Matcher m2 = p2.matcher(line);
                     String groupId;


### PR DESCRIPTION
* The current pattern does not evaluate properly optional dependencies from `dependency:resolve` execution
* Before this PR this kind of lines were not evaluated:
```
[INFO]    org.jenkins-ci.plugins:matrix-auth:jar:1.2:compile (optional) 
[INFO]    org.jenkins-ci.plugins:credentials:jar:2.1.16:compile (optional) 
[INFO]    org.jenkins-ci.plugins:structs:jar:1.7:compile (optional) 
```
* After this PR `optional` dependencies are evaluated on adding/replacing dependencies before testing.