### PR TITLE
Fixed test name solver bug for multi-module projects

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
@@ -2,8 +2,14 @@ package org.jenkins.tools.test.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -19,7 +25,7 @@ public class ExecutedTestNamesSolver {
     private static final String WARNING_MSG = "[WARNING] Unable to retrieve info from: %s";
     
     private static final String TEST_PLACEHOLDER = "TEST-%s.xml";
-
+    
     public ExecutedTestNamesDetails solve(Set<String> executedTests, File baseDirectory) throws ExecutedTestNamesSolverException {
 
         System.out.println("[INFO] -------------------------------------------------------");
@@ -27,56 +33,63 @@ public class ExecutedTestNamesSolver {
         System.out.println("[INFO] -------------------------------------------------------");
         
         ExecutedTestNamesDetails testNames = new ExecutedTestNamesDetails();
-        try {
-            
-            String surefireReportsDirectoryPath = baseDirectory.getAbsolutePath() + File.separator + "target" + File.separator + "surefire-reports";
-            File surefireReportsDirectory = Paths.get(surefireReportsDirectoryPath).toFile();
-            if (!surefireReportsDirectory.exists()) {
-                System.out.println(String.format(WARNING_MSG, surefireReportsDirectoryPath));
-                return testNames;
-            }
-            
-            System.out.println(String.format("[INFO] Reading %s", surefireReportsDirectoryPath));
-            
-            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-            for (String testName : executedTests) {
-                String reference = String.format(TEST_PLACEHOLDER, testName);
-                String testReportPath = surefireReportsDirectoryPath + File.separator + reference;
-                File testReport = Paths.get(testReportPath).toFile();
-                if (!testReport.exists()) {
-                    System.out.println(String.format(WARNING_MSG, testReportPath));
-                    continue;
+        
+        List<String> surefireReportsDirectoryPaths = getSurefireReportsDirectoryPaths(baseDirectory);
+        if(surefireReportsDirectoryPaths.isEmpty()) {
+            System.out.println("[WARNING] No surefire-reports found!");
+            return testNames;
+        }
+        
+        for (String surefireReportsDirectoryPath: surefireReportsDirectoryPaths) {
+            try {
+                File surefireReportsDirectory = Paths.get(surefireReportsDirectoryPath).toFile();
+                if (!surefireReportsDirectory.exists()) {
+                    System.out.println(String.format(WARNING_MSG, surefireReportsDirectoryPath));
+                    return testNames;
                 }
                 
-                Document document = builder.parse(testReport);
-                Node testsuite = document.getChildNodes().item(0);
-                String nodeValue = testsuite.getAttributes().getNamedItem("tests").getNodeValue();
-                Integer testCount = Integer.valueOf(nodeValue);
-                int found = 0;
-                for (int i = 0; i < testsuite.getChildNodes().getLength(); i++) {
-                    Node testcase = testsuite.getChildNodes().item(i);
-                    if (testcase.getAttributes() != null && testcase.getAttributes().getNamedItem("classname") != null) {
-                        String clazzName = testcase.getAttributes().getNamedItem("classname").getNodeValue();
-                        String test = testcase.getAttributes().getNamedItem("name").getNodeValue();
-                        found++;
-                        String testCaseName = String.format("%s.%s", clazzName, test);
-                        if (testcase.getChildNodes().getLength() != 0) {
-                            testNames.addFailedTest(testCaseName);
-                        } else {
-                            testNames.addExecutedTest(testCaseName);
+                System.out.println(String.format("[INFO] Reading %s", surefireReportsDirectoryPath));
+                
+                DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                for (String testName : executedTests) {
+                    String reference = String.format(TEST_PLACEHOLDER, testName);
+                    String testReportPath = surefireReportsDirectoryPath + File.separator + reference;
+                    File testReport = Paths.get(testReportPath).toFile();
+                    if (!testReport.exists()) {
+                        System.out.println(String.format(WARNING_MSG, testReportPath));
+                        continue;
+                    }
+                    
+                    Document document = builder.parse(testReport);
+                    Node testsuite = document.getChildNodes().item(0);
+                    String nodeValue = testsuite.getAttributes().getNamedItem("tests").getNodeValue();
+                    Integer testCount = Integer.valueOf(nodeValue);
+                    int found = 0;
+                    for (int i = 0; i < testsuite.getChildNodes().getLength(); i++) {
+                        Node testcase = testsuite.getChildNodes().item(i);
+                        if (testcase.getAttributes() != null && testcase.getAttributes().getNamedItem("classname") != null) {
+                            String clazzName = testcase.getAttributes().getNamedItem("classname").getNodeValue();
+                            String test = testcase.getAttributes().getNamedItem("name").getNodeValue();
+                            found++;
+                            String testCaseName = String.format("%s.%s", clazzName, test);
+                            if (testcase.getChildNodes().getLength() != 0) {
+                                testNames.addFailedTest(testCaseName);
+                            } else {
+                                testNames.addExecutedTest(testCaseName);
+                            }
                         }
                     }
+                    
+                    if (testCount.intValue() != found) {
+                        System.out.println(String.format("[WARNING] Extracted: %s, Expected: %s from %s", found, testCount, testReportPath));
+                    } else {
+                        System.out.println(String.format("[INFO] Extracted %s testnames from %s", testCount, testReportPath));
+                    }
                 }
-                
-                if (testCount.intValue() != found) {
-                    System.out.println(String.format("[WARNING] Extracted: %s, Expected: %s from %s", found, testCount, testReportPath));
-                } else {
-                    System.out.println(String.format("[INFO] Extracted %s testnames from %s", testCount, testReportPath));
-                }
+    
+            } catch (ParserConfigurationException | SAXException | IOException e) {
+                throw new ExecutedTestNamesSolverException(e);
             }
-
-        } catch (ParserConfigurationException | SAXException | IOException e) {
-            throw new ExecutedTestNamesSolverException(e);
         }
         
         System.out.println("[INFO] ");
@@ -93,6 +106,21 @@ public class ExecutedTestNamesSolver {
         }
         
         return testNames;
+    }
+
+    private List<String> getSurefireReportsDirectoryPaths(File baseDirectory) throws ExecutedTestNamesSolverException {
+        List<String> paths = new LinkedList<>();
+        try (Stream<Path> walk = Files.walk(Paths.get(baseDirectory.getAbsolutePath()))) {
+            List<Path> result = walk.filter(Files::isDirectory)
+                    .filter(file -> file.getFileName().toString().endsWith("surefire-reports"))
+                    .collect(Collectors.toList());
+            for (Path path : result) {
+                paths.add(path.toString());
+            }
+        } catch (IOException e) {
+            throw new ExecutedTestNamesSolverException(e);
+        } 
+        return paths;
     }
     
 }


### PR DESCRIPTION
* When running PCT for single Maven project Jenkins plugins, surefire-reports used to be on `<base-directory-folder>/target` but if you run it for multimodule Maven projects it probably will not be able to locate properly where are the surefire-reports.
* Before this PR when we do something like: 
```
java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar \
[...] 
-includePlugins configuration-as-code 
-mavenProperties test=SecretSourceResolverTest \
```
We get the following result:
```
[INFO] -------------------------------------------------------
[INFO] Solving test names
[INFO] -------------------------------------------------------
[WARNING] Unable to retrieve info from: /tmp/pct/work/configuration-as-code/target/surefire-reports
org.jenkins.tools.test.exception.PomExecutionException: [/usr/bin/mvn, --show-version, --batch-mode, -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn, --define=failIfNoTests=false, --define=forkCount=1, hpi:resolve-test-dependencies, hpi:test-hpl, surefire:test, -Djenkins.version=2.222.1-cb-7, -Denforcer.skip=true] failed in /tmp/pct/work/configuration-as-code
	at org.jenkins.tools.test.maven.ExternalMavenRunner.run(ExternalMavenRunner.java:103)
	at org.jenkins.tools.test.PluginCompatTester.testPluginAgainst(PluginCompatTester.java:554)
	at org.jenkins.tools.test.PluginCompatTester.testPlugins(PluginCompatTester.java:314)
	at org.jenkins.tools.test.PluginCompatTesterCli.main(PluginCompatTesterCli.java:175)
```
Because `configuration-as-code` is a multi-module Maven project: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/pom.xml#L15..L19
* After this PR we will obtain the following result:
```
[INFO] -------------------------------------------------------
[INFO] Solving test names
[INFO] -------------------------------------------------------
[INFO] Reading /tmp/pct/work/configuration-as-code/plugin/target/surefire-reports
[INFO] Extracted 25 testnames from /tmp/pct/work/configuration-as-code/plugin/target/surefire-reports/TEST-io.jenkins.plugins.casc.SecretSourceResolverTest.xml
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Executed: 25
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_defaultValueLimit
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_emptyDefault
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_emptyDefaultEnvDefined
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_mixedMultipleEntries
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_mixedMultipleEntriesEscaped
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_mixedMultipleEntriesWithDefault
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_mixedSingleEntry
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_mixedSingleEntryEscaped
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_mixedSingleEntryWithDefault
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_multipleEntries
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_multipleEntriesEscaped
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_multipleEntriesWithDefaultValue
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_multipleEntriesWithDefaultValueAndEnvDefined
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_multipleEntriesWithoutDefaultValue
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_nothing
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_nothingBrackets
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_nothingDefault
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_nothingSpace
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_singleEntry
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_singleEntryDoubleEscaped
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_singleEntryEscaped
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_singleEntryWithDefaultValue
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_singleEntryWithDefaultValueAndWithEnvDefined
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.resolve_singleEntryWithoutDefaultValue
[INFO] - io.jenkins.plugins.casc.SecretSourceResolverTest.shouldEncodeInternalVarsProperly
[INFO] 
[INFO] Failed: 0
```
