### PR TITLE
Jacoco hook

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
@@ -15,7 +15,7 @@ public class JacocoHook extends PluginCompatTesterHookBeforeExecution {
     @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
-        return "org.jenkins-ci.plugins".equals(data.groupId) && "jacoco".equals(data.artifactId);
+        return "jacoco".equals(data.artifactId);
     }
 
     @Override

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
@@ -1,0 +1,38 @@
+package org.jenkins.tools.test.hook;
+
+import org.jenkins.tools.test.model.PomData;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+/**
+ * Workaround for JaCoCo plugin since it needs execute the jacoco:prepare-agent goal before execution.
+ */
+public class JacocoHook extends PluginCompatTesterHookBeforeExecution {
+
+    @Override
+    public boolean check(Map<String, Object> info) {
+        PomData data = (PomData) info.get("pomData");
+        return "org.jenkins-ci.plugins".equals(data.groupId) && "jacoco".equals(data.artifactId);
+    }
+
+    @Override
+    public Map<String, Object> action(Map<String, Object> info) throws Exception {
+        List<String> args = (List<String>) info.get("args");
+
+        if (args != null) {
+            int index = IntStream.range(0, args.size()).filter(i -> args.get(i).startsWith("hpi:")).findFirst().orElse(-1);
+            if (index == -1) {
+                index = IntStream.range(0, args.size()).filter(i -> args.get(i).equals("surefire:test")).findFirst().orElse(-1);
+            }
+            if (index != -1) {
+                args.add(index, "jacoco:prepare-agent");
+            }
+        }
+
+        return info;
+    }
+
+}

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
@@ -26,11 +26,6 @@ public class JacocoHookTest {
         info.put("pomData", pomData);
         assertTrue(hook.check(info));
 
-        pomData = new PomData("jacoco", "hpi", "it-does-not-matter", "whatever", parent, "fake-groupId");
-        info = new HashMap<>();
-        info.put("pomData", pomData);
-        assertFalse(hook.check(info));
-
         pomData = new PomData("other-plugin", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
         info = new HashMap<>();
         info.put("pomData", pomData);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
@@ -1,0 +1,76 @@
+package org.jenkins.tools.test.hook;
+
+import com.google.common.collect.Lists;
+import org.jenkins.tools.test.model.MavenCoordinates;
+import org.jenkins.tools.test.model.PomData;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JacocoHookTest {
+
+    @Test
+    public void testCheckMethod() {
+        final JacocoHook hook = new JacocoHook();
+        final MavenCoordinates parent = new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.57");
+
+        PomData pomData = new PomData("jacoco", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        Map<String, Object> info = new HashMap<>();
+        info.put("pomData", pomData);
+        assertTrue(hook.check(info));
+
+        pomData = new PomData("jacoco", "hpi", "it-does-not-matter", "whatever", parent, "fake-groupId");
+        info = new HashMap<>();
+        info.put("pomData", pomData);
+        assertFalse(hook.check(info));
+
+        pomData = new PomData("other-plugin", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        info = new HashMap<>();
+        info.put("pomData", pomData);
+        assertFalse(hook.check(info));
+    }
+
+    @Test
+    public void testAction() throws Exception {
+        final JacocoHook hook = new JacocoHook();
+
+        Map<String, Object> info = new HashMap<>();
+        info.put("args", Lists.newArrayList(
+                "--define=forkCount=1",
+                "hpi:resolve-test-dependencies",
+                "hpi:test-hpl",
+                "surefire:test"));
+        Map<String, Object> afterAction = hook.action(info);
+        List<String> args = (List<String>) afterAction.get("args");
+        assertThat(args.size(), is(5));
+        assertThat(args.get(1), is("jacoco:prepare-agent"));
+
+        info = new HashMap<>();
+        info.put("args", Lists.newArrayList(
+                "--define=forkCount=1",
+                "other-plugin:other-goal",
+                "surefire:test"));
+        afterAction = hook.action(info);
+        args = (List<String>) afterAction.get("args");
+        assertThat(args.size(), is(4));
+        assertThat(args.get(2), is("jacoco:prepare-agent"));
+
+        info = new HashMap<>();
+        info.put("args", Lists.newArrayList(
+                "element1",
+                "element2",
+                "element3",
+                "element4"));
+        afterAction = hook.action(info);
+        args = (List<String>) afterAction.get("args");
+        assertThat(args.size(), is(4));
+        assertFalse(args.contains("jacoco:prepare-agent"));
+    }
+}


### PR DESCRIPTION
Executing PCT for `jacoco-plugin` will fail because for the testing, this plugin needs to execute the `jacoco:prepare-agent` goal of jacoco maven plugin. We need a hook to make this plugin executable from PCT.

@raul-arabaolaza 
@centic9 