### PR TITLE
Add hook for sse-gateway and workflow-cps for node and node_modules issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ work/
 out/
 tmp/
 reports/
+
+### MacOS
+.DS_Store
+

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -852,7 +852,8 @@ public class PluginCompatTester {
         if (!top.has("core")) {
             throw new IOException("no jenkins-core.jar in " + war);
         }
-        System.out.println("Scanned contents of " + war + ": " + top);
+        // TODO un-comment this. I removed because it was annoying me.
+        // System.out.println("Scanned contents of " + war + ": " + top);
         return newUpdateSiteData(new UpdateSite(DEFAULT_SOURCE_ID, null), top);
     }
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -852,8 +852,7 @@ public class PluginCompatTester {
         if (!top.has("core")) {
             throw new IOException("no jenkins-core.jar in " + war);
         }
-        // TODO un-comment this. I removed because it was annoying me.
-        // System.out.println("Scanned contents of " + war + ": " + top);
+        System.out.println("Scanned contents of " + war + ": " + top);
         return newUpdateSiteData(new UpdateSite(DEFAULT_SOURCE_ID, null), top);
     }
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
@@ -63,7 +63,7 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
         }
         File nodeModulesFolder = new File(path, "node_modules");
         if (nodeModulesFolder.exists() && nodeModulesFolder.isDirectory()) {
-            System.out.println("--> node folder exists, deleting");
+            System.out.println("--> node_modules folder exists, deleting");
             FileUtils.deleteDirectory(nodeModulesFolder);
         }
     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
@@ -27,12 +27,6 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
             File pluginDir = (File) moreInfo.get("pluginDir");
             System.out.println("--> Plugin dir is " + pluginDir);
             System.out.println("--> This is sse-gateway");
-            // TODO probably do not need
-            // boolean ranCompile = moreInfo.containsKey(OVERRIDE_DEFAULT_COMPILE) && (boolean) moreInfo.get(OVERRIDE_DEFAULT_COMPILE);
-            // if (!ranCompile) {
-            //     compile(mavenConfig, pluginDir);
-            //     moreInfo.put(OVERRIDE_DEFAULT_COMPILE, true);
-            // }
             try {
                 System.out.println("--> Executing node and node_modules cleanup hook");
                 System.out.println("--> Compiling");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
@@ -54,11 +54,11 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
 
     private void removeNodeFolders(File path) throws IOException {
         File nodeFolder = new File(path, "node");
-        if (nodeFolder.exists() && nodeFolder.isDirectory()) {
+        if (nodeFolder.isDirectory()) {
             FileUtils.deleteDirectory(nodeFolder);
         }
         File nodeModulesFolder = new File(path, "node_modules");
-        if (nodeModulesFolder.exists() && nodeModulesFolder.isDirectory()) {
+        if (nodeModulesFolder.isDirectory()) {
             FileUtils.deleteDirectory(nodeModulesFolder);
         }
     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
@@ -19,17 +19,14 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
     @Override
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
-        boolean shouldExecuteHook = config.getIncludePlugins().contains("sse-gateway");
+        boolean shouldExecuteHook = (config.getIncludePlugins().contains("sse-gateway") || (config.getIncludePlugins().contains("workflow-cps")));
         runner = new ExternalMavenRunner(config.getExternalMaven());
         mavenConfig = getMavenConfig(config);
 
         if (shouldExecuteHook) {
             File pluginDir = (File) moreInfo.get("pluginDir");
-            System.out.println("--> Plugin dir is " + pluginDir);
-            System.out.println("--> This is sse-gateway");
             try {
-                System.out.println("--> Executing node and node_modules cleanup hook");
-                System.out.println("--> Compiling");
+                System.out.println("Executing node and node_modules cleanup hook");
                 compile(mavenConfig, pluginDir);
                 return moreInfo;
             } catch (Exception e) {
@@ -38,7 +35,7 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
                 throw e;
             }
         } else {
-            System.out.println("--> Not SSE Gateway so skipping hook");
+            System.out.println("Skipping hook because plugin is not workflow-cps or sse-gateway");
             return moreInfo;
         }
     }
@@ -48,9 +45,9 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
     }
 
     private void compile(MavenRunner.Config mavenConfig, File path) throws PomExecutionException, IOException {
-        System.out.println("--> Calling removeNodeFolders");
+        System.out.println("Calling removeNodeFolders");
         removeNodeFolders(path);
-        System.out.println("--> Compile plugin log in " + path);
+        System.out.println("Compile plugin log in " + path);
         File compilePomLogfile = new File(path + "/compilePluginLog.log");
         runner.run(mavenConfig, path, compilePomLogfile, "clean", "process-test-classes", "-Dmaven.javadoc.skip");
     }
@@ -58,12 +55,10 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
     private void removeNodeFolders(File path) throws IOException {
         File nodeFolder = new File(path, "node");
         if (nodeFolder.exists() && nodeFolder.isDirectory()) {
-            System.out.println("--> node folder exists, deleting");
             FileUtils.deleteDirectory(nodeFolder);
         }
         File nodeModulesFolder = new File(path, "node_modules");
         if (nodeModulesFolder.exists() && nodeModulesFolder.isDirectory()) {
-            System.out.println("--> node_modules folder exists, deleting");
             FileUtils.deleteDirectory(nodeModulesFolder);
         }
     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
@@ -35,7 +35,7 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
                 throw e;
             }
         } else {
-            System.out.println("Skipping hook because plugin is not workflow-cps or sse-gateway");
+            System.out.println("Hook not triggered. Continuing.");
             return moreInfo;
         }
     }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
@@ -1,0 +1,83 @@
+package org.jenkins.tools.test.hook;
+
+import org.apache.commons.io.FileUtils;
+import org.jenkins.tools.test.exception.PomExecutionException;
+import org.jenkins.tools.test.maven.ExternalMavenRunner;
+import org.jenkins.tools.test.maven.MavenRunner;
+import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCompile {
+
+    protected MavenRunner runner;
+    protected MavenRunner.Config mavenConfig;
+
+    @Override
+    public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
+        PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
+        boolean shouldExecuteHook = config.getIncludePlugins().contains("sse-gateway");
+        runner = new ExternalMavenRunner(config.getExternalMaven());
+        mavenConfig = getMavenConfig(config);
+
+        if (shouldExecuteHook) {
+            File pluginDir = (File) moreInfo.get("pluginDir");
+            System.out.println("--> Plugin dir is " + pluginDir);
+            System.out.println("--> This is sse-gateway");
+            // TODO probably do not need
+            // boolean ranCompile = moreInfo.containsKey(OVERRIDE_DEFAULT_COMPILE) && (boolean) moreInfo.get(OVERRIDE_DEFAULT_COMPILE);
+            // if (!ranCompile) {
+            //     compile(mavenConfig, pluginDir);
+            //     moreInfo.put(OVERRIDE_DEFAULT_COMPILE, true);
+            // }
+            try {
+                System.out.println("--> Executing node and node_modules cleanup hook");
+                System.out.println("--> Compiling");
+                compile(mavenConfig, pluginDir);
+                return moreInfo;
+            } catch (Exception e) {
+                System.out.println("Exception executing hook");
+                System.out.println(e);
+                throw e;
+            }
+        } else {
+            System.out.println("--> Not SSE Gateway so skipping hook");
+            return moreInfo;
+        }
+    }
+
+    @Override
+    public void validate(Map<String, Object> toCheck) {
+    }
+
+    private void compile(MavenRunner.Config mavenConfig, File path) throws PomExecutionException, IOException {
+        System.out.println("--> Calling removeNodeFolders");
+        removeNodeFolders(path);
+        System.out.println("--> Compile plugin log in " + path);
+        File compilePomLogfile = new File(path + "/compilePluginLog.log");
+        runner.run(mavenConfig, path, compilePomLogfile, "clean", "process-test-classes", "-Dmaven.javadoc.skip");
+    }
+
+    private void removeNodeFolders(File path) throws IOException {
+        File nodeFolder = new File(path, "node");
+        if (nodeFolder.exists() && nodeFolder.isDirectory()) {
+            System.out.println("--> node folder exists, deleting");
+            FileUtils.deleteDirectory(nodeFolder);
+        }
+        File nodeModulesFolder = new File(path, "node_modules");
+        if (nodeModulesFolder.exists() && nodeModulesFolder.isDirectory()) {
+            System.out.println("--> node folder exists, deleting");
+            FileUtils.deleteDirectory(nodeModulesFolder);
+        }
+    }
+
+    private MavenRunner.Config getMavenConfig(PluginCompatTesterConfig config) throws IOException {
+        MavenRunner.Config mconfig = new MavenRunner.Config();
+        mconfig.userSettingsFile = config.getM2SettingsFile();
+        mconfig.userProperties.putAll(config.retrieveMavenProperties());
+        return mconfig;
+    }
+}


### PR DESCRIPTION
# Description

Some Jenkins plugins end up with `node` and `node_modules` directories in their local source directories after compilation. With standard builds this is fine, and it's fine with many ways of running the PCT. However, when the PCT's `-localCheckoutDir` is used, such plugins can fail with difficult to understand errors from `gulp`. 

This PR is a hook, much like the existing ones, which works past this problem specifically for [sse-gateway](https://github.com/jenkinsci/sse-gateway-plugin) and [workflow-cps](https://github.com/jenkinsci/workflow-cps-plugin/). Following below is some example output of running the PCT against master of workflow-cps.

The issue can also be recreated with sse-gateway, with the results being slightly different. With sse-gateway, the "fixed" PCT run shows a different failure, which would be fixed if I file a PR with [this simple change](https://github.com/jenkinsci/sse-gateway-plugin/compare/master...kshultzCB:primordials-why-oh-why) to that plugin. I actually read about that [here](https://timonweb.com/posts/how-to-fix-referenceerror-primordials-is-not-defined-error/). Without my change, sse-gateway fails with an identical `Error: Cannot find module '../lib/completion'` error to the one from workflow-cps.

# Example output, before and after this PR

Without this PR:
```
➜  plugin-compat-tester git:(sse-gateway-hook) ✗ java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar -reportFile $(pwd)/out/report.xml -workDirectory $(pwd)/tmp/work -includePlugins workflow-cps -war /Users/kshultz/GitHub/unified-release/products/core-mm/target/core-mm-2.235.1.3-SNAPSHOT.war -localCheckoutDir /Users/kshultz/GitHub/workflow-cps-plugin -skipTestCache true

...snip...

[INFO] --- frontend-maven-plugin:1.9.1:yarn (yarn mvnbuild) @ workflow-cps ---
[INFO] Running 'yarn run mvnbuild' in /Users/kshultz/GitHub/plugin-compat-tester/tmp/work/workflow-cps
[INFO] yarn run v0.23.0
[INFO] $ gulp bundle 
[INFO] module.js:338
[INFO]     throw err;
[INFO]     ^
[INFO] 
[INFO] Error: Cannot find module '../lib/completion'
[INFO]     at Function.Module._resolveFilename (module.js:336:15)
[INFO]     at Function.Module._load (module.js:286:25)
[INFO]     at Module.require (module.js:365:17)
[INFO]     at require (module.js:384:17)
[INFO]     at Object.<anonymous> (/Users/kshultz/GitHub/plugin-compat-tester/tmp/work/workflow-cps/node_modules/.bin/gulp:13:18)
[INFO]     at Module._compile (module.js:434:26)
[INFO]     at Object.Module._extensions..js (module.js:452:10)
[INFO]     at Module.load (module.js:355:32)
[INFO]     at Function.Module._load (module.js:310:12)
[INFO]     at Function.Module.runMain (module.js:475:10)
[INFO] error Command failed with exit code 1.
[INFO] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.082 s
[INFO] Finished at: 2020-07-14T17:08:42-04:00
[INFO] ------------------------------------------------------------------------
```

With this PR:

```
➜  plugin-compat-tester git:(sse-gateway-hook) ✗ java -jar plugins-compat-tester-cli/target/plugins-compat-tester-cli.jar -reportFile $(pwd)/out/report.xml -workDirectory $(pwd)/tmp/work -includePlugins workflow-cps -war /Users/kshultz/GitHub/unified-release/products/core-mm/target/core-mm-2.235.1.3-SNAPSHOT.war -localCheckoutDir /Users/kshultz/GitHub/workflow-cps-plugin -skipTestCache true

...snip...

[INFO] --- frontend-maven-plugin:1.9.1:yarn (yarn install) @ workflow-cps ---
[INFO] Running 'yarn --mutex network' in /Users/kshultz/GitHub/plugin-compat-tester/tmp/work/workflow-cps
[INFO] yarn install v0.23.0
[INFO] [1/4] Resolving packages...
[INFO] success Already up-to-date.
[INFO] Done in 0.38s.
[INFO] 
[INFO] --- maven-localizer-plugin:1.26:generate (default) @ workflow-cps ---
[INFO] 
[INFO] --- frontend-maven-plugin:1.9.1:yarn (yarn mvnbuild) @ workflow-cps ---
[INFO] Running 'yarn run mvnbuild' in /Users/kshultz/GitHub/plugin-compat-tester/tmp/work/workflow-cps
[INFO] yarn run v0.23.0
[INFO] $ gulp bundle 
[INFO] [17:40:56] Maven project
[INFO] [17:40:56]  - src: src/main/js,src/main/less
[INFO] [17:40:56]  - test: src/test/js
[INFO] [17:40:56] Setting defaults
[INFO] [17:40:56] Bundle will be generated in directory 'target/generated-resources/adjuncts/org/jenkinsci/plugins/workflow/cps' as 'workflow-editor.js'.
[INFO] [17:40:56] Using gulpfile ~/GitHub/plugin-compat-tester/tmp/work/workflow-cps/gulpfile.js
[INFO] [17:40:56] Starting 'bundle'...
[INFO] [17:40:56] Finished 'bundle' after 44 ms
[INFO] Done in 0.75s.

...snip...

[INFO] Results:
[INFO] 
[WARNING] Tests run: 415, Failures: 0, Errors: 0, Skipped: 9
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12:43 min
[INFO] Finished at: 2020-07-14T17:53:52-04:00
[INFO] ------------------------------------------------------------------------
```