### PR TITLE
Create Hooks for Warnings NG

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -68,9 +68,16 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
             System.out.println("Child path for " + currentPlugin.getDisplayName() + " " + childPath);
             moreInfo.put("checkoutDir", childPath);
             moreInfo.put("pluginDir", childPath);
+        } else {
+            configureLocalCheckOut(currentPlugin, config.getLocalCheckoutDir(), moreInfo);
         }
 
         return moreInfo;
+    }
+
+    protected void configureLocalCheckOut(UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {
+        // Do nothing to keep compatibility with pre-existing Hooks
+        System.out.println("Ignoring localCheckoutDir for " + currentPlugin.getDisplayName());
     }
 
     /**

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PluginWithIntegrationTestsHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PluginWithIntegrationTestsHook.java
@@ -1,0 +1,24 @@
+package org.jenkins.tools.test.hook;
+
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Workaround for those plugins with integration tests since they need execute the failsafe:integration-test goal before execution.
+ */
+public abstract class PluginWithIntegrationTestsHook extends PluginCompatTesterHookBeforeExecution {
+
+    @Override
+    public Map<String, Object> action(Map<String, Object> info) throws Exception {
+        List<String> args = (List<String>) info.get("args");
+
+        if (args != null) {
+            args.add("failsafe:integration-test");
+        }
+
+        return info;
+    }
+
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -40,6 +40,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean isPipelineStageViewPlugin = PipelineStageViewHook.isPipelineStageViewPlugin(pomData);
         boolean isSwarm = SwarmHook.isSwarmPlugin(pomData);
         boolean isDeclarativePipelineMigration = DeclarativePipelineMigrationHook.isPlugin(pomData);
+        boolean isWarningsMG = WarningsNGCheckoutHook.isWarningsNG(pomData);
         boolean pluginPOM = pomData.isPluginPOM();
         if (parent != null) {
             isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
@@ -60,7 +61,7 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
         boolean coreRequiresNewParentPOM = coreCoordinates.compareVersionTo(CORE_NEW_PARENT_POM) >= 0;
         boolean coreRequiresPluginOver233 = coreCoordinates.compareVersionTo(CORE_WITHOUT_WAR_FOR_TEST) >= 0;
 
-        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || isPipelineStageViewPlugin || isSwarm || isDeclarativePipelineMigration || (pluginPOM && parentV2)) {
+        if (isDeclarativePipeline || isBO || isCB || isStructs || isCasC || isPipelineStageViewPlugin || isSwarm || isDeclarativePipelineMigration || (pluginPOM && parentV2) || isWarningsMG) {
             List<String> argsToMod = (List<String>)info.get("args");
             argsToMod.add("-Djenkins.version=" + coreCoordinates.version);
             // There are rules that avoid dependencies on a higher java level. Depending on the baselines and target cores

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -1,0 +1,62 @@
+package org.jenkins.tools.test.hook;
+
+import hudson.model.UpdateSite;
+import org.jenkins.tools.test.model.PomData;
+
+import java.io.File;
+import java.util.Map;
+
+public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
+
+    @Override
+    protected String getParentFolder() {
+        return "warnings-ng-plugin";
+    }
+
+    @Override
+    protected String getParentUrl() {
+        return "scm:git:git://github.com/jenkinsci/warnings-ng-plugin.git";
+    }
+
+    @Override
+    protected String getParentProjectName() {
+        return "warnings-ng";
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) {
+        return isWarningsNG(info);
+    }
+
+    @Override
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
+        return "plugin";
+    }
+
+    public static boolean isWarningsNG(Map<String, Object> moreInfo) {
+        PomData data = (PomData) moreInfo.get("pomData");
+        return isWarningsNG(data);
+    }
+
+    public static boolean isWarningsNG(PomData data) {
+        return "warnings-ng-parent".equals(data.artifactId) // localCheckoutDir
+                || "warnings-ng".equals(data.artifactId); // checkout
+    }
+
+    @Override
+    protected void configureLocalCheckOut(UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {
+        File pluginDir = new File(localCheckoutDir, getPluginFolderName(currentPlugin));
+        if (!pluginDir.exists() && !pluginDir.isDirectory()) {
+            throw new RuntimeException("Invalid localCheckoutDir for " + currentPlugin.getDisplayName());
+        }
+
+        // Checkout already happened, don't run through again
+        moreInfo.put("runCheckout", false);
+        firstRun = false;
+
+        // Change the "download"" directory; after download, it's simply used for reference
+        System.out.println("Child path for " + currentPlugin.getDisplayName() + " " + pluginDir);
+        moreInfo.put("checkoutDir", pluginDir);
+        moreInfo.put("pluginDir", pluginDir);
+    }
+}

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
@@ -1,0 +1,19 @@
+package org.jenkins.tools.test.hook;
+
+import org.jenkins.tools.test.model.PomData;
+
+import java.util.Map;
+
+/**
+ * Workaround for Warnings NG plugin since it needs execute integration tests.
+ */
+public class WarningsNGExecutionHook extends PluginWithIntegrationTestsHook {
+
+    @Override
+    public boolean check(Map<String, Object> info) {
+        PomData data = (PomData) info.get("pomData");
+        return "warnings-ng-parent".equals(data.artifactId) // localCheckoutDir
+                || "warnings-ng".equals(data.artifactId); // checkout
+    }
+
+}

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
@@ -1,0 +1,50 @@
+package org.jenkins.tools.test.hook;
+
+import com.google.common.collect.Lists;
+import org.jenkins.tools.test.model.MavenCoordinates;
+import org.jenkins.tools.test.model.PomData;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WarningsNGExecutionHookTest {
+
+    @Test
+    public void testCheckMethod() {
+        final WarningsNGExecutionHook hook = new WarningsNGExecutionHook();
+        final MavenCoordinates parent = new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.57");
+
+        PomData pomData = new PomData("warnings-ng", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        Map<String, Object> info = new HashMap<>();
+        info.put("pomData", pomData);
+        assertTrue(hook.check(info));
+
+        pomData = new PomData("other-plugin", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        info = new HashMap<>();
+        info.put("pomData", pomData);
+        assertFalse(hook.check(info));
+    }
+
+    @Test
+    public void testAction() throws Exception {
+        final WarningsNGExecutionHook hook = new WarningsNGExecutionHook();
+
+        Map<String, Object> info = new HashMap<>();
+        info.put("args", Lists.newArrayList(
+                "--define=forkCount=1",
+                "hpi:resolve-test-dependencies",
+                "hpi:test-hpl",
+                "surefire:test"));
+        Map<String, Object> afterAction = hook.action(info);
+        List<String> args = (List<String>) afterAction.get("args");
+        assertThat(args.size(), is(5));
+        assertTrue(args.contains("failsafe:integration-test"));
+    }
+}


### PR DESCRIPTION
PR to make Warnings NG Plugin executable on PCT:
- BeforeCheckoutHook since the plugin is multimodule
  - The Hook expects the same folder structure as in the repository
  - The plugin directory is the `plugin` folder
  - Hook allows the `localcheckoutDir` option
- BeforeExecutionHook since the plugin includes integration tests
  - New parent class for other plugins to be used
  - Hook for the Warnings NG Plugin itself

@bmunozm @raul-arabaolaza @imonteroperez 

CC @uhafner fyi as maintainer of the Warnings NG Plugin