### PR TITLE
[JENKINS-58716] Replace AbstractMultiParentHook.getParentUrl with a processed pomData.connectionUrl

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -47,9 +47,11 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
                     scmTag = getParentProjectName() + "-" + currentPlugin.version;
                     System.out.println(String.format("POM did not provide an SCM tag. Inferring tag '%s'.", scmTag));
                 }
-                System.out.println("Checking out from SCM connection URL: " + getParentUrl() + " (" + getParentProjectName() + "-" + currentPlugin.version + ") at tag " + scmTag);
+                // Like PluginCompatTester.cloneFromSCM but with subdirectories trimmed:
+                String parentUrl = pomData.getConnectionUrl().replaceFirst("^(.+github[.]com/[^/]+/[^/]+)/.+", "$1");
+                System.out.println("Checking out from SCM connection URL: " + parentUrl + " (" + getParentProjectName() + "-" + currentPlugin.version + ") at tag " + scmTag);
                 ScmManager scmManager = SCMManagerFactory.getInstance().createScmManager();
-                ScmRepository repository = scmManager.makeScmRepository(getParentUrl());
+                ScmRepository repository = scmManager.makeScmRepository(parentUrl);
                 CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(parentPath), new ScmTag(scmTag));
 
                 if (!result.isSuccess()) {
@@ -84,11 +86,6 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
      * Returns the folder where the multimodule project parent will be checked out
      */
     protected abstract String getParentFolder();
-
-    /**
-     * Returns the Git URL to check out the multimodule project
-     */
-    protected abstract String getParentUrl();
 
     /**
      * Returns the parent project name. This will be used to form the checkout tag with the format

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -18,10 +18,6 @@ public class BlueOceanHook extends AbstractMultiParentHook {
         return "blueocean";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/blueocean-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
@@ -11,10 +11,6 @@ public class ConfigurationAsCodeHook extends AbstractMultiParentHook {
         return "configuration-as-code-plugin";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/configuration-as-code-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -17,10 +17,6 @@ public class DeclarativePipelineHook extends AbstractMultiParentHook {
         return "pipeline-model-definition";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/pipeline-model-definition-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
@@ -16,10 +16,6 @@ public class DeclarativePipelineMigrationHook extends AbstractMultiParentHook {
         return "declarative-pipeline-migration-assistant";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -11,10 +11,6 @@ public class PipelineStageViewHook extends AbstractMultiParentHook {
         return "pipeline-stage-view";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/pipeline-stage-view-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
@@ -16,10 +16,6 @@ public class StructsHook extends AbstractMultiParentHook {
         return "structs-plugin";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/structs-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
@@ -15,10 +15,6 @@ public class SwarmHook extends AbstractMultiParentHook {
         return "swarm";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/swarm-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -13,10 +13,6 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
         return "warnings-ng-plugin";
     }
 
-    @Override
-    protected String getParentUrl() {
-        return "scm:git:git://github.com/jenkinsci/warnings-ng-plugin.git";
-    }
 
     @Override
     protected String getParentProjectName() {


### PR DESCRIPTION
Follows up #181 for multimodule repos. For example, https://github.com/jenkinsci/blueocean-plugin/pull/2094 was deployed with

```xml
  <scm>
    <connection>scm:git:https://github.com/dwnusbaum/blueocean-plugin.git/blueocean-bitbucket-pipeline</connection>
    <developerConnection>scm:git:https://github.com/dwnusbaum/blueocean-plugin.git/blueocean-bitbucket-pipeline</developerConnection>
    <tag>e72b727f00ca3d0dd9325e4b9c46369b890af52d</tag>
    <url>https://github.com/dwnusbaum/blueocean-plugin/blueocean-bitbucket-pipeline</url>
  </scm>
```

We need to check out https://github.com/dwnusbaum/blueocean-plugin/commit/e72b727f00ca3d0dd9325e4b9c46369b890af52d as a result.