### PR TITLE
adapt  warnings-ng plugin to new versioning tagging

### DIFF
--- a/plugins-compat-tester/src/main/resources/nonstandardtagplugins.properties
+++ b/plugins-compat-tester/src/main/resources/nonstandardtagplugins.properties
@@ -1,3 +1,5 @@
 electricflow=cloudbees-flow-%s
 electricflow-minimumVersion=1.1.8
 github=v%s
+warnings-ng=v%s
+warnings-ng-minimumVersion=8.4.1.1

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
@@ -46,8 +46,8 @@ public class NonStandardTagHookTest {
         NonStandardTagHook hook = new NonStandardTagHook();
         List<String> transformedPlugins = hook.transformedPlugins();
         assertNotNull("The list of transformed plugins must be non null", transformedPlugins);
-        assertEquals("List of affected plugins must be of size 3", 3, transformedPlugins.size());
-        assertEquals("The element in transformedPlugins must be 'artifactID'", "artifactID", transformedPlugins.get(0));
+        assertEquals("List of affected plugins must be of size 4", 4, transformedPlugins.size());
+        assertTrue("One element in transformedPlugins must be 'artifactID'", transformedPlugins.contains("artifactID"));
     }
 
     @Test

--- a/plugins-compat-tester/src/test/resources/nonstandardtagplugins.properties
+++ b/plugins-compat-tester/src/test/resources/nonstandardtagplugins.properties
@@ -2,3 +2,5 @@ artifactID=artifactId-%s
 electricflow=cloudbees-flow-%s
 electricflow-minimumVersion=1.1.8
 github=v%s
+warnings-ng=v%s
+warnings-ng-minimumVersion=8.4.1.1


### PR DESCRIPTION
Until version 8.4.1 the versioning of the plugin is `warnings-ng-${version}`, and after it, it is used  `v${version}`

This PR is making the warnings-ng plugin PCT will be able to launch against all versions