### PR TITLE
update findBugs spelling 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ for (int i = 0; i < platforms.size(); ++i) {
                     junit '**/target/surefire-reports/TEST-*.xml'
 
                     if (publishing) {
-                      findbugs pattern: '**/target/findbugsXml.xml'
+                      findBugs pattern: '**/target/findbugsXml.xml'
                       infra.prepareToPublishIncrementals()
                     }
                 }


### PR DESCRIPTION
The CI is failing with the following error:
```
Recording test results

No such DSL method 'findbugs' found among steps [addEmbeddableBadgeConfiguration, ansiColor, archive, bat, build, catchError, checkout, compareVersions, datadog, deleteDir, dir, dockerFingerprintFrom, dockerFingerprintRun, ec2, echo, ecsTaskTemplate, envVarsForTool, error, fileExists, findFiles, getContext, git, githubNotify, input, isUnix, jiraComment, jiraIssueSelector, jiraSearch, junit, library, libraryResource, load, lock, mail, milestone, node, nodesByLabel, parallel, powershell, properties, publishChecks, publishHTML, publishIssues, pwd, pwsh, readCSV, readFile, readJSON, readManifest, readMavenPom, readProperties, readTrusted, readYaml, realtimeJUnit, recordIssues, resolveScm, retry, scanForIssues, script, sh, sha1, sleep, splitTests, sshagent, stage, stash, step, svn, tee, throttle, timeout, timestamps, tm, tool, touch, unarchive, unstable, unstash, unzip, validateDeclarativePipeline, waitUntil, warnError, withContext, withCredentials, withDockerContainer, withDockerRegistry, withDockerServer, withEnv, wrap, writeCSV, writeFile, writeJSON, writeMavenPom, writeYaml, ws, zip] or symbols [PVSStudio, abstractItemDirectoryComponent, acuCobol, agentDumpExportTableComponent, agentJVMProcessSystemMetricsComponent, agentSystemConfigurationComponent, agentsConfigFileComponent, ajc, all, allBranchesSame, allOf, always, androidLintParser, anonymizeSupportBundle, ansibleLint, ant, antFromApache, antOutcome, antPath, antTarget, any, anyOf, apiToken, architecture, archiveArtifacts, armCc, artifactManager, authorizationMatrix, axivion, axivionSuite, azureDownload, azureServicePrincipal, azureStorage, azureUpload, azureVMCloudRetentionStrategy, batchFile, bitbucket, bitbucketBranchDiscovery, bitbucketForkDiscovery, bitbucketPublicRepoPullRequestFilter, bitbucketPullRequestDiscovery, bitbucketSshCheckout, bitbucketTagDiscovery, bitbucketTrustEveryone, bitbucketTrustNobody, bitbucketTrustProject, bitbucketTrustTeam, bitbucketWebhookConfiguration, bitbucketWebhookRegistration, booleanParam, branch, buckminster, buildAllBranches, buildAnyBranches, buildButton, buildChangeRequests, buildDiscarder, buildDiscarders, buildNamedBranches, buildNoneBranches, buildParameter, buildRegularBranches, buildRetention, buildSelector, buildTags, buildingTag, cadence, cargo, caseInsensitive, caseSensitive, ccm, certificate, changeRequest, changelog, changeset, checkStyle, checkoutToSubdirectory, choice, choiceParam, clair, clang, clangAnalyzer, clangTidy, clock, cmake, codeAnalysis, codeNarc, command, coolflux, copyArtifactPermission, copyArtifacts, copyartifact, count, cpd, cppCheck, cppLint, credentials, cron, crumb, cssLint, defaultFolderConfiguration, defaultView, demand, detekt, diabC, disableConcurrentBuilds, disableResume, docFx, docker, dockerCert, dockerLint, dockerServer, dockerTool, dockerfile, downstream, doxygen, drMemory, dscanner, dumb, dupFinder, durabilityHint, eclipse, ecs, envVars, envVarsFilter, environment, equals, erlc, errorProne, esLint, exact, excludeCategory, excludeFile, excludeMessage, excludeModule, excludeNamespace, excludePackage, excludeType, expression, file, fileParam, filePath, findBugs, fingerprint, fingerprints, flake8, flawfinder, flexSdk, frameOptions, freeStyle, freeStyleJob, fromDocker, fromScm, fromSource, fxcop, gcc, gcc3, gcc4, gendarme, ghsMulti, git, gitBranchDiscovery, gitHubBranchDiscovery, gitHubBranchHeadAuthority, gitHubExcludeArchivedRepositories, gitHubExcludePublicRepositories, gitHubForkDiscovery, gitHubPullRequestDiscovery, gitHubSshCheckout, gitHubTagDiscovery, gitHubTopicsFilter, gitHubTrustContributors, gitHubTrustEveryone, gitHubTrustNobody, gitHubTrustPermissions, gitTagDiscovery, github, githubPush, gnat, gnuFortran, goLint, goVet, groovyScript, hadoLint, headRegexFilter, headWildcardFilter, hyperlink, hyperlinkToModels, iar, iarCstat, ibLinter, ideaInspection, includeCategory, includeFile, includeMessage, includeModule, includeNamespace, includePackage, includeType, infer, inheriting, inheritingGlobal, installSource, intel, invalids, isRestartedRun, issues, istanbulCobertura, istanbulCoberturaAdapter, jacoco, jacocoAdapter, java, javaDoc, javadoc, jcReport, jdk, jdkInstaller, jgit, jgitapache, jnlp, jobBuildDiscarder, jobName, jsHint, jsLint, junitParser, klocWork, kotlin, ktLint, label, lastCompleted, lastDuration, lastFailure, lastGrantedAuthorities, lastStable, lastSuccess, lastSuccessful, lastWithArtifacts, latestSavedBuild, legacy, legacySCM, list, local, location, logRotator, loggedInUsersCanDoAnything, mailer, masterBuild, masterJVMProcessSystemMetricsComponent, masterSystemConfigurationComponent, maven, maven3Mojos, mavenConsole, mavenErrors, mavenMojos, mavenWarnings, metrowerksCodeWarrior, mineRepository, modelsim, modernSCM, msBuild, myPy, myView, nagFortran, namedBranchesDifferent, newContainerPerStage, node, nodeProperties, nodeRemoteDirectoryComponent, nonInheriting, none, not, overrideIndexTriggers, paneStatus, parallelsAlwaysFailFast, parameters, password, pattern, pcLint, pep8, perforce, perlCritic, permalink, permanent, php, phpCodeSniffer, phpStan, pipeline-model, pipeline-model-docker, pipelineTriggers, pit, plainText, plugin, pmdParser, pollSCM, prefast, preserveStashes, projectNamingStrategy, protoLint, proxy, pruneTags, publishCoverage, puppetLint, pyDocStyle, pyLint, qacSourceCodeAnalyser, queueItemAuthenticator, quietPeriod, rateLimit, rateLimitBuilds, realTimeJUnitReports, recordIssues, regex, resharperInspectCode, resourceRoot, retainOnlyVariables, rfLint, robocopy, ruboCop, run, runDirectoryComponent, runParam, sSHLauncher, scala, schedule, scmRetryCount, scriptApproval, scriptApprovalLink, search, security, shell, simian, simpleBuildDiscarder, skipDefaultCheckout, skipStagesAfterUnstable, slave, sonarQube, sourceFiles, sourceRegexFilter, sourceWildcardFilter, specific, sphinxBuild, spotBugs, ssh, sshPublicKey, sshUserPrivateKey, standard, status, string, stringParam, styleCop, sunC, suppressAutomaticTriggering, swapSpace, swiftLint, tag, tagList, taskScanner, taskingVx, teamSlugFilter, text, textParam, threadDumpsComponent, throttleJobProperty, tiCss, time, timestamper, timestamperConfig, timezone, tmpSpace, tnsdl, toolLocation, triggeredBy, tsLint, unsecured, untrusted, upstream, userSeed, usernameColonPassword, usernamePassword, viewsTabBar, warningsParsers, warningsPlugin, weather, wildcards, withAnt, workspace, x509ClientCert, xlc, xmlLint, yamlLint, yuiCompressor, zfs, zip, zptLint] or globals [buildDockerAndPublishImage, buildPlugin, buildPluginWithGradle, currentBuild, customWARPackager, docker, env, essentialsTest, infra, params, pipeline, publishReports, runATH, runBenchmarks, runPCT, scm]
```

Try to fix updating findBugs used