### PR TITLE
Use warnings-ng instead of deprecated findbugs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,8 @@ for (int i = 0; i < platforms.size(); ++i) {
                     junit '**/target/surefire-reports/TEST-*.xml'
 
                     if (publishing) {
-                      findBugs pattern: '**/target/findbugsXml.xml'
+                      def spotbugs = scanForIssues tool: spotBugs(pattern: '**/target/findbugsXml.xml')
+                      publishIssues issues: [spotbugs]
                       infra.prepareToPublishIncrementals()
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ for (int i = 0; i < platforms.size(); ++i) {
                     junit '**/target/surefire-reports/TEST-*.xml'
 
                     if (publishing) {
-                      findbugs pattern: '**/target/findbugsXml.xml'
+                      findBugs pattern: '**/target/findbugsXml.xml'
                       infra.prepareToPublishIncrementals()
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,8 +39,10 @@ for (int i = 0; i < platforms.size(); ++i) {
                     junit '**/target/surefire-reports/TEST-*.xml'
 
                     if (publishing) {
-                      def spotbugs = scanForIssues tool: spotBugs(pattern: '**/target/findbugsXml.xml')
-                      publishIssues issues: [spotbugs]
+                      recordIssues(
+                        enabledForFailure: true, aggregatingResults: true, 
+                        tools: [java(), spotBugs(pattern: '**/target/findbugsXml.xml')]
+                      )
                       infra.prepareToPublishIncrementals()
                     }
                 }


### PR DESCRIPTION
Recreates #259 per @bmunozm request so it can be tested by the PR Builder, I have already review the changes and look safe to run