### PR TITLE
Bugfix on retrieving plugin test types

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,7 @@ itBranches['google-compute-engine:4.3.3 tests on retrieving the test report'] = 
         stage('Download Jenkins 2.263.3') {
             sh '''
             curl -sL http://mirrors.jenkins.io/war-stable/2.263.3/jenkins.war --output jenkins.war
-            echo "65543f5632ee54344f3351b34b305702df12393b3196a95c3771ddb3819b220b jenkins.war" | sha256sum --check
+            echo "a355f58c26afaf2ed08cedeacdbc0de85c821bb7a15edac8255f7a74c6aedf53 jenkins.war" | sha256sum --check
             '''
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,7 @@ itBranches['google-compute-engine:4.3.3 tests on retrieving the test report'] = 
             sh 'make docker'
         }
 
-        stage('Download Jenkins 2.164.1') {
+        stage('Download Jenkins 2.263.3') {
             sh '''
             curl -sL http://mirrors.jenkins.io/war-stable/2.263.3/jenkins.war --output jenkins.war
             echo "65543f5632ee54344f3351b34b305702df12393b3196a95c3771ddb3819b220b jenkins.war" | sha256sum --check

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ itBranches['google-compute-engine:4.3.3 tests on retrieving the test report'] = 
                          -v $(pwd)/jenkins.war:/pct/jenkins.war:ro \
                          -v $(pwd)/mvn-settings.xml:/pct/m2-settings.xml \
                          -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
-                         -e ARTIFACT_ID=google-compute-engine -e VERSION=google-compute-engine-4.3.3 \
+                         -e ARTIFACT_ID=google-compute-engine -e VERSION=google-compute-engine-4.3.3 -e FAIL_ON_ERROR=false\
                          jenkins/pct
             '''
             archiveArtifacts artifacts: "out/**"

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -25,6 +25,7 @@
  */
 package org.jenkins.tools.test;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import hudson.AbortException;
@@ -554,6 +555,7 @@ public class PluginCompatTester {
             pcth.runBeforeExecution(forExecutionHooks);
             args = (List<String>)forExecutionHooks.get("args");
             Set<String> types = new HashSet<>((List<String>) forExecutionHooks.get("types"));
+            mconfig.userProperties.put("types", String.join(",", types));
 
             // Execute with tests
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, args.toArray(new String[args.size()]));

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -25,7 +25,6 @@
  */
 package org.jenkins.tools.test;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import hudson.AbortException;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -114,15 +114,15 @@ public class ExternalMavenRunner implements MavenRunner {
     }
 
     private Set<String> getTypes(Config config) {
+        Set<String> result = new HashSet<>();
         if (config == null || config.userProperties == null || !config.userProperties.containsKey("types")) {
-            return null;
+            result.add("surefire");
+            return result;
         }
         String types = config.userProperties.get("types");
-        Set<String> result = new HashSet<>();
         for (String type : types.split(",")) {
             result.add(type);
         }
-        
         return result;
     }
 

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -102,7 +102,7 @@ public class ExternalMavenRunner implements MavenRunner {
             if (p.waitFor() != 0) {
                 throw new PomExecutionException(cmd + " failed in " + baseDirectory, succeededPluginArtifactIds,
                         /* TODO */Collections.emptyList(), Collections.emptyList(),
-                        new ExecutedTestNamesSolver().solve(null, getExecutedTests(), baseDirectory));
+                        new ExecutedTestNamesSolver().solve(getTypes(config), getExecutedTests(), baseDirectory));
             }
         } catch (PomExecutionException x) {
             x.printStackTrace();
@@ -112,5 +112,20 @@ public class ExternalMavenRunner implements MavenRunner {
             throw new PomExecutionException(x);
         }
     }
+
+    private Set<String> getTypes(Config config) {
+        if (config == null || config.userProperties == null || !config.userProperties.containsKey("types")) {
+            return null;
+        }
+        String types = config.userProperties.get("types");
+        Set<String> result = new HashSet<>();
+        for (String type : types.split(",")) {
+            result.add(type);
+        }
+        
+        return result;
+    }
+    
+    
 
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -125,7 +125,5 @@ public class ExternalMavenRunner implements MavenRunner {
         
         return result;
     }
-    
-    
 
 }


### PR DESCRIPTION
This PR provides a bugfix on generating the report of failed tests based on its type

### Context
- On https://github.com/jenkinsci/plugin-compat-tester/pull/258 support for evaluating additional test goals was introduced. It provides to the PCT the capabilities to evaluate not only `surefire` based tests, also others like `failsafe`

### Problem statement
- Once used this new support, detected that PCT plugin report was not properly showing all the test failures
- @bmunozm did a preliminary analysis and detected this via bisect that reason was about mentioned PR
- Example of invalid result with `google-compute-engine` plugin:
```
[...]
executed classname tests: [com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest, com.google.jenkins.plugins.computeengine.AcceleratorConfigurationTest, com.google.jenkins.plugins.computeengine.GoogleKeyPairTest, com.google.jenkins.plugins.computeengine.ConfigAsCodeTest, com.google.jenkins.plugins.computeengine.InstanceConfigurationTest, com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest, com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest, com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest]
[INFO] -------------------------------------------------------
[INFO] Solving test names
[INFO] -------------------------------------------------------
[WARNING] No test reports found!
[...]
```
![before](https://user-images.githubusercontent.com/595347/107213339-8777f380-6a08-11eb-830c-dd3371862deb.jpeg)
- Example of expected result for `google-compute-engine` plugin:
```
[...]
executed classname tests: [com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest, com.google.jenkins.plugins.computeengine.AcceleratorConfigurationTest, com.google.jenkins.plugins.computeengine.GoogleKeyPairTest, com.google.jenkins.plugins.computeengine.ConfigAsCodeTest, com.google.jenkins.plugins.computeengine.InstanceConfigurationTest, com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest, com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest, com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest]
[INFO] -------------------------------------------------------
[INFO] Solving test names
[INFO] -------------------------------------------------------
[INFO] Reading /pct/tmp/work/google-compute-engine/target/surefire-reports
[INFO] Extracted 4 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.xml
[INFO] Extracted 2 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.AcceleratorConfigurationTest.xml
[INFO] Extracted 1 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.GoogleKeyPairTest.xml
[INFO] Extracted 2 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.ConfigAsCodeTest.xml
[INFO] Extracted 6 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.xml
[INFO] Extracted 9 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.xml
[INFO] Extracted 5 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.xml
[INFO] Extracted 6 testnames from /pct/tmp/work/google-compute-engine/target/surefire-reports/TEST-com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.xml
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Executed: 34
[INFO] - com.google.jenkins.plugins.computeengine.AcceleratorConfigurationTest.clientCalls
[INFO] - com.google.jenkins.plugins.computeengine.AcceleratorConfigurationTest.construction
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testConstructor
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckNetworkItemsEmpty
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckNetworkItemsValid
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckSubnetworkItemsEmpty
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckSubnetworkItemsValid
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillNetworkItems
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsEmptyRegion
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsNoSubnetworks
[INFO] - com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsValid
[INFO] - com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldCleanLostInstance
[INFO] - com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldNotCleanAnyInstance
[INFO] - com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldNotCleanStoppingInstance
[INFO] - com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldRegisterCleanNodeWorker
[INFO] - com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldRunWithoutClouds
[INFO] - com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.construction
[INFO] - com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.descriptorFillCredentials
[INFO] - com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.descriptorProjectValidation
[INFO] - com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.getConfigurationsByLabelMulti
[INFO] - com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.getConfigurationsByLabelSimple
[INFO] - com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.instanceIdWasGenerated
[INFO] - com.google.jenkins.plugins.computeengine.ConfigAsCodeTest.shouldCreateCloudInstanceFromCode
[INFO] - com.google.jenkins.plugins.computeengine.ConfigAsCodeTest.shouldCreateGCEClientFromCode
[INFO] - com.google.jenkins.plugins.computeengine.GoogleKeyPairTest.KeyPairGeneration
[INFO] - com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.descriptorBootDiskSizeValidation
[INFO] - com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testClient
[INFO] - com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testConfigRoundtrip
[INFO] - com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testInstanceMetadata
[INFO] - com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testInstanceModel
[INFO] - com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.construction
[INFO] - com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.descriptorProjectId
[INFO] - com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.descriptorRegion
[INFO] - com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.descriptorSubnetwork
[INFO] 
[INFO] Failed: 1
[INFO] - com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.unnecessary Mockito stubbings
[...]
```

### Solution and implementation details
- Detected wrongly null injection of types values to the solver
- Injected types as part of the `userProperties` map inside the config provided to the runner
- Results obtained as expected
- Example of generated report: 
```
<entry>
  <pluginInfos>
    <pluginName>google-compute-engine</pluginName>
    <pluginVersion>4.3.3</pluginVersion>
    <pluginUrl>jar:file:/pct/tmp/jenkins.war!/WEB-INF/plugins/google-compute-engine.hpi</pluginUrl>
  </pluginInfos>
  <list>
    <compatResult>
      [...]
      <status>TEST_FAILURES</status>
      [...]
      <testDetails class="sorted-set">
        <string>com.google.jenkins.plugins.computeengine.AcceleratorConfigurationTest.clientCalls</string>
        <string>com.google.jenkins.plugins.computeengine.AcceleratorConfigurationTest.construction</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testConstructor</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckNetworkItemsEmpty</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckNetworkItemsValid</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckSubnetworkItemsEmpty</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoCheckSubnetworkItemsValid</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillNetworkItems</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsEmptyRegion</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsNoSubnetworks</string>
        <string>com.google.jenkins.plugins.computeengine.AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsValid</string>
        <string>com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldCleanLostInstance</string>
        <string>com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldNotCleanAnyInstance</string>
        <string>com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldNotCleanStoppingInstance</string>
        <string>com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldRegisterCleanNodeWorker</string>
        <string>com.google.jenkins.plugins.computeengine.CleanLostNodesWorkTest.shouldRunWithoutClouds</string>
        <string>com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.construction</string>
        <string>com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.descriptorFillCredentials</string>
        <string>com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.descriptorProjectValidation</string>
        <string>com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.getConfigurationsByLabelMulti</string>
        <string>com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.getConfigurationsByLabelSimple</string>
        <string>com.google.jenkins.plugins.computeengine.ComputeEngineCloudTest.instanceIdWasGenerated</string>
        <string>com.google.jenkins.plugins.computeengine.ConfigAsCodeTest.shouldCreateCloudInstanceFromCode</string>
        <string>com.google.jenkins.plugins.computeengine.ConfigAsCodeTest.shouldCreateGCEClientFromCode</string>
        <string>com.google.jenkins.plugins.computeengine.GoogleKeyPairTest.KeyPairGeneration</string>
        <string>com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.descriptorBootDiskSizeValidation</string>
        <string>com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testClient</string>
        <string>com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testConfigRoundtrip</string>
        <string>com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testInstanceMetadata</string>
        <string>com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.testInstanceModel</string>
        <string>com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.unnecessary Mockito stubbings</string>
        <string>com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.construction</string>
        <string>com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.descriptorProjectId</string>
        <string>com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.descriptorRegion</string>
        <string>com.google.jenkins.plugins.computeengine.SharedVpcNetworkConfigurationTest.descriptorSubnetwork</string>
      </testDetails>
      [...]
    </compatResult>
  </list>
</entry>
```
![after](https://user-images.githubusercontent.com/595347/107213168-4e3f8380-6a08-11eb-9684-97d6e8b04c6a.jpeg)
@raul-arabaolaza @bmunozm @batmat 