### PR TITLE
Bump Maven to 3.6.3 as builder for PCT Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get -y update && apt-get install -y groovy apt-transport-https ca-certif
 RUN curl -L --show-error https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz --output openjdk.tar.gz && \
     echo "7a6bb980b9c91c478421f865087ad2d69086a0583aeeb9e69204785e8e97dcfd  openjdk.tar.gz" | sha256sum -c && \
     tar xvzf openjdk.tar.gz && \
-    mv jdk-11.0.1/ /usr/lib/jvm/java-11-openjdk-amd64 && \
+    mv jdk-11.0.1/ /usr/local/openjdk-11 && \
     rm openjdk.tar.gz
 
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM maven:3.6.0-jdk-8 as builder
+FROM maven:3.6.3-jdk-8 as builder
 
 # Warmup to avoid downloading the world each time
 RUN git clone https://github.com/jenkinsci/plugin-compat-tester &&\
@@ -37,7 +37,7 @@ COPY LICENSE.txt /pct/src/LICENSE.txt
 WORKDIR /pct/src/
 RUN mvn clean package -Dmaven.test.skip=true
 
-FROM maven:3.6.0-jdk-8
+FROM maven:3.6.3-jdk-8
 LABEL Maintainer="Oleg Nenashev <o.v.nenashev@gmail.com>"
 LABEL Description="Base image for running Jenkins Plugin Compat Tester (PCT) against custom plugins and Jenkins cores" Vendor="Jenkins project"
 ENV JENKINS_WAR_PATH=/pct/jenkins.war

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -28,7 +28,7 @@ import org.jenkins.tools.test.util.ExecutedTestNamesSolver;
  */
 public class ExternalMavenRunner implements MavenRunner {
 
-    private static final String DISABLE_DOWNLOAD_LOGS = "-ntp;
+    private static final String DISABLE_DOWNLOAD_LOGS = "-ntp";
 
     @CheckForNull
     private File mvn;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -28,7 +28,7 @@ import org.jenkins.tools.test.util.ExecutedTestNamesSolver;
  */
 public class ExternalMavenRunner implements MavenRunner {
 
-    private static final String DISABLE_DOWNLOAD_LOGS = "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn";
+    private static final String DISABLE_DOWNLOAD_LOGS = "-ntp;
 
     @CheckForNull
     private File mvn;

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -157,7 +157,7 @@ mkdir -p "${PCT_OUTPUT_DIR}"
 ###
 # Determine if we test the plugin against another JDK
 ###
-TEST_JDK_HOME=${TEST_JAVA_ARGS:-"/usr/lib/jvm/java-${JDK_VERSION:-8}-openjdk-amd64"}
+TEST_JDK_HOME=${TEST_JAVA_ARGS:-"/usr/local/openjdk-${JDK_VERSION:-8}"}
 TEST_JAVA_ARGS="'${TEST_JAVA_ARGS:-} -Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true'"
 
 # The image always uses external Maven due to https://issues.jenkins-ci.org/browse/JENKINS-48710


### PR DESCRIPTION
- Let's update the Maven version for PCT Dockerfile
- Previous to this change some plugins are not tested properly, such as `artifact-manager-s3` using Maven 3.6.0
```
09:22:00  Failed while enforcing RequireUpperBoundDeps. The error(s) are [
09:22:00  Require upper bound dependencies error for org.slf4j:slf4j-api:1.7.26 paths to dependency are:
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-org.testcontainers:testcontainers:1.15.2
09:22:00      +-org.slf4j:slf4j-api:1.7.26
09:22:00  and
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-io.findify:s3mock_2.12:0.2.5
09:22:00      +-com.typesafe.scala-logging:scala-logging_2.12:3.8.0
09:22:00        +-org.slf4j:slf4j-api:1.7.26 (managed) <-- org.slf4j:slf4j-api:1.7.30
09:22:00  and
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-org.testcontainers:testcontainers:1.15.2
09:22:00      +-com.github.docker-java:docker-java-api:3.2.7
09:22:00        +-org.slf4j:slf4j-api:1.7.26 (managed) <-- org.slf4j:slf4j-api:1.7.30
09:22:00  and
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-org.testcontainers:testcontainers:1.15.2
09:22:00      +-com.github.docker-java:docker-java-transport-zerodep:3.2.7
09:22:00        +-org.slf4j:slf4j-api:1.7.26 (managed) <-- org.slf4j:slf4j-api:1.7.25
09:22:00  and
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-org.jenkins-ci.main:jenkins-core:2.235.2
09:22:00      +-org.slf4j:jcl-over-slf4j:1.7.26
09:22:00        +-org.slf4j:slf4j-api:1.7.26 (managed) <-- org.slf4j:slf4j-api:1.7.25
09:22:00  and
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-org.jenkins-ci.main:jenkins-core:2.235.2
09:22:00      +-org.slf4j:log4j-over-slf4j:1.7.26
09:22:00        +-org.slf4j:slf4j-api:1.7.26 (managed) <-- org.slf4j:slf4j-api:1.7.25
09:22:00  and
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-org.jenkins-ci.main:jenkins-war:2.235.2
09:22:00      +-org.slf4j:slf4j-jdk14:1.7.26
09:22:00        +-org.slf4j:slf4j-api:1.7.26 (managed) <-- org.slf4j:slf4j-api:1.7.25
09:22:00  and
09:22:00  +-io.jenkins.plugins:artifact-manager-s3:1.13
09:22:00    +-org.jenkins-ci.main:jenkins-war:2.235.2
09:22:00      +-org.jenkins-ci.modules:sshd:2.6
09:22:00        +-org.apache.sshd:sshd-core:1.7.0
09:22:00          +-org.slf4j:slf4j-api:1.7.26 (managed) <-- org.slf4j:slf4j-api:1.7.25
```
- After this PR, plugins are properly evaluated/tested by the PCT as expected (tested with Maven 3.6.2 and Maven 3.6.3)