### PR TITLE
Support for crashed tests

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -318,6 +318,10 @@ public class PluginCompatTester {
                         warningMessages.addAll(result.pomWarningMessages);
                         testDetails.addAll(config.isStoreAll() ? result.getTestDetails().getAll() : result.getTestDetails().getFailed());
                     } catch (PomExecutionException e) {
+                        if (e.failedOnTestExecution()) {
+                            // Test execution failed (i.e.: crashed tests)
+                            throw e;
+                        }
                         if(!e.succeededPluginArtifactIds.contains("maven-compiler-plugin")){
                             status = TestStatus.COMPILATION_ERROR;
                         } else if (!e.getTestDetails().getFailed().isEmpty()) {
@@ -560,7 +564,7 @@ public class PluginCompatTester {
 
             // Execute with tests
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, args.toArray(new String[args.size()]));
-            return new TestExecutionResult(((PomData)forExecutionHooks.get("pomData")).getWarningMessages(), new ExecutedTestNamesSolver().solve(types, runner.getExecutedTests(), pluginCheckoutDir));
+            return new TestExecutionResult(((PomData)forExecutionHooks.get("pomData")).getWarningMessages(), new ExecutedTestNamesSolver().solve(types, runner.getExecutedTests(), runner.getCrashedTests(), pluginCheckoutDir));
         } catch (ExecutedTestNamesSolverException e) {
             throw new PomExecutionException(e);
         } catch (PomExecutionException e){

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
@@ -84,4 +84,13 @@ public class PomExecutionException extends Exception {
     public ExecutedTestNamesDetails getTestDetails() {
         return testDetails;
     }
+    
+    public boolean failedOnTestExecution() {
+        for (Throwable throwable : exceptionsThrown) {
+            if (throwable instanceof ExecutedTestNamesSolverException) {
+                return true;
+            }
+        } 
+        return false;
+    }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
@@ -27,7 +27,7 @@ public class ExecutedTestNamesSolver {
     
     private static final String TEST_PLACEHOLDER = "TEST-%s.xml";
     
-    public ExecutedTestNamesDetails solve(Set<String> types, Set<String> executedTests, File baseDirectory) throws ExecutedTestNamesSolverException {
+    public ExecutedTestNamesDetails solve(Set<String> types, Set<String> executedTests, Set<String> crashedTests, File baseDirectory) throws ExecutedTestNamesSolverException {
 
         System.out.println("[INFO] -------------------------------------------------------");
         System.out.println("[INFO] Solving test names");
@@ -58,6 +58,9 @@ public class ExecutedTestNamesSolver {
                     File testReport = Paths.get(testReportPath).toFile();
                     if (!testReport.exists()) {
                         System.out.println(String.format(WARNING_MSG, testReportPath));
+                        if (crashedTests.contains(testName)) {
+                            throw new ExecutedTestNamesSolverException(String.format("Crashed tests!: %s", crashedTests));
+                        }
                         continue;
                     }
                     


### PR DESCRIPTION
### Highlights
- Current PCT is not able to deal properly with crashed tests
- Consider a test that is generating a `SIGTERM` signal (i.e. exit status code 143)
- PCT is not dealing with this situation and is providing all the info about executed tests before reaching that signal
- Example before this PR (hacked by adding a `System.exit(143)` to a single test
```
[...]
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:39 min
[INFO] Finished at: 2021-06-22T15:04:14+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test (default-cli) on project nectar-rbac: There are test failures.
[ERROR] 
[ERROR] Please refer to /tmp/pct/work/nectar-rbac/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /tmp/pct/work/nectar-rbac && /usr/lib/jvm/java-8-oracle/jre/bin/java -Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -jar /tmp/pct/work/nectar-rbac/target/surefire/surefirebooter3225579000931510500.jar /tmp/pct/work/nectar-rbac/target/surefire 2021-06-22T14-59-37_328-jvmRun1 surefire1456255374072318391tmp surefire_03684692952981871857tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 143
[ERROR] Crashed tests:
[ERROR] nectar.plugins.rbac.roles.RoleAPITest
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /tmp/pct/work/nectar-rbac && /usr/lib/jvm/java-8-oracle/jre/bin/java -Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -jar /tmp/pct/work/nectar-rbac/target/surefire/surefirebooter3225579000931510500.jar /tmp/pct/work/nectar-rbac/target/surefire 2021-06-22T14-59-37_328-jvmRun1 surefire1456255374072318391tmp surefire_03684692952981871857tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 143
[ERROR] Crashed tests:
[ERROR] Crashed tests:
[ERROR] nectar.plugins.rbac.roles.RoleAPITest
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:690)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:285)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:248)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1217)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1063)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:889)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:957)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:289)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:193)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.lang.reflect.Method.invoke(Method.java:498)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
[...]
succeeded artifactIds: [maven-hpi-plugin, maven-hpi-plugin]
executed classname tests: [nectar.plugins.rbac.groups.ReadOnlyGroupTest, nectar.plugins.rbac.groups.SerializationTest, nectar.plugins.rbac.groups.GroupRoleAssignmentsCommandTest, nectar.plugins.rbac.assignees.InvalidAssigneeTest, nectar.plugins.rbac.PerformanceTest, nectar.plugins.rbac.groups.GroupCommandTest, nectar.plugins.rbac.groups.GroupContainerLocatorTest, nectar.plugins.rbac.groups.RootProxyGroupContainerTest, nectar.plugins.rbac.groups.GroupSealTest, nectar.plugins.rbac.assignees.UserAssigneeTest, nectar.plugins.rbac.permissions.PermissionListerTest, nectar.plugins.rbac.groups.GroupMembershipCommandTest, nectar.plugins.rbac.assignees.GroupAssigneeTest, nectar.plugins.rbac.groups.NodeProxyGroupContainerTest, nectar.plugins.rbac.assignees.UnknownAssigneeTest, nectar.plugins.rbac.groups.GroupTest, nectar.plugins.rbac.permissions.PermissionProxyTest, nectar.plugins.rbac.groups.GroupContainerACLTest, nectar.plugins.rbac.groups.ViewProxyGroupContainerTest, nectar.plugins.rbac.assignees.BuiltInAssigneesRootActionTest, nectar.plugins.rbac.importers.TypicalSetupRestartTest, nectar.plugins.rbac.importers.TypicalSetupTest, nectar.plugins.rbac.groups.GroupContainerActionTest, nectar.plugins.rbac.assignees.ExternalGroupRootActionTest, nectar.plugins.rbac.groups.JobProxyGroupContainerTest, nectar.plugins.rbac.groups.DangerousPermissionTests, nectar.plugins.rbac.assignees.ExternalGroupAssigneeTest, nectar.plugins.rbac.assignees.BuiltInAssigneeTest, nectar.plugins.rbac.groups.ContextGroupContainerTest, nectar.plugins.rbac.groups.NoPermissionsACLTest, nectar.plugins.rbac.roles.RoleAPITest]
[INFO] -------------------------------------------------------
[INFO] Solving test names
[INFO] -------------------------------------------------------
[INFO] Reading /tmp/pct/work/nectar-rbac/target/surefire-reports
[...]
[WARNING] Unable to retrieve info from: /tmp/pct/work/nectar-rbac/target/surefire-reports/TEST-nectar.plugins.rbac.roles.RoleAPITest.xml
[...]
Plugin workflow-cps-global-lib not in included plugins => test skipped !
Plugin workflow-durable-task-step not in included plugins => test skipped !
Plugin workflow-job not in included plugins => test skipped !
Plugin workflow-multibranch not in included plugins => test skipped !
Plugin workflow-scm-step not in included plugins => test skipped !
Plugin workflow-step-api not in included plugins => test skipped !
Plugin workflow-support not in included plugins => test skipped !
```
- This ^ PCT execution finished with status 0 from the PCT-CLI. So if we have a pipeline step `sh` evaluating the status of the PCT invokation via `java -jar pct-cli` we could reach an invalid zero status. 
- Also note the `WARNING` message from the log about the crashed test, but no consequence related with.
- After this PR, and given `surefire` is able to detect and deal with a forked VM that crashed for whatever reason (See: https://github.com/apache/maven-surefire/blob/master/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java#L740), I decided to introduce support on the PCT to deal with this and throwing an exception once a test execution crashes
```
[...]
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:39 min
[INFO] Finished at: 2021-06-22T15:04:14+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test (default-cli) on project nectar-rbac: There are test failures.
[ERROR] 
[ERROR] Please refer to /tmp/pct/work/nectar-rbac/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /tmp/pct/work/nectar-rbac && /usr/lib/jvm/java-8-oracle/jre/bin/java -Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -jar /tmp/pct/work/nectar-rbac/target/surefire/surefirebooter3225579000931510500.jar /tmp/pct/work/nectar-rbac/target/surefire 2021-06-22T14-59-37_328-jvmRun1 surefire1456255374072318391tmp surefire_03684692952981871857tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 143
[ERROR] Crashed tests:
[ERROR] nectar.plugins.rbac.roles.RoleAPITest
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /tmp/pct/work/nectar-rbac && /usr/lib/jvm/java-8-oracle/jre/bin/java -Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -jar /tmp/pct/work/nectar-rbac/target/surefire/surefirebooter3225579000931510500.jar /tmp/pct/work/nectar-rbac/target/surefire 2021-06-22T14-59-37_328-jvmRun1 surefire1456255374072318391tmp surefire_03684692952981871857tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 143
[ERROR] Crashed tests:
[ERROR] Crashed tests:
[ERROR] nectar.plugins.rbac.roles.RoleAPITest
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:690)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:285)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:248)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1217)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1063)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:889)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:957)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:289)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:193)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.lang.reflect.Method.invoke(Method.java:498)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
[...]
[INFO] Extracted 2 testnames from /tmp/pct/work/nectar-rbac/target/surefire-reports/TEST-nectar.plugins.rbac.groups.NoPermissionsACLTest.xml
[WARNING] Unable to retrieve info from: /tmp/pct/work/nectar-rbac/target/surefire-reports/TEST-nectar.plugins.rbac.roles.RoleAPITest.xml
org.jenkins.tools.test.exception.ExecutedTestNamesSolverException: Crashed tests!: [nectar.plugins.rbac.roles.RoleAPITest]
	at org.jenkins.tools.test.util.ExecutedTestNamesSolver.solve(ExecutedTestNamesSolver.java:63)
	at org.jenkins.tools.test.maven.ExternalMavenRunner.run(ExternalMavenRunner.java:120)
	at org.jenkins.tools.test.PluginCompatTester.testPluginAgainst(PluginCompatTester.java:566)
	at org.jenkins.tools.test.PluginCompatTester.testPlugins(PluginCompatTester.java:312)
	at org.jenkins.tools.test.PluginCompatTesterCli.main(PluginCompatTesterCli.java:175)
Exception in thread "main" org.jenkins.tools.test.exception.PomExecutionException: org.jenkins.tools.test.exception.ExecutedTestNamesSolverException: Crashed tests!: [nectar.plugins.rbac.roles.RoleAPITest]
	at org.jenkins.tools.test.maven.ExternalMavenRunner.run(ExternalMavenRunner.java:127)
	at org.jenkins.tools.test.PluginCompatTester.testPluginAgainst(PluginCompatTester.java:566)
	at org.jenkins.tools.test.PluginCompatTester.testPlugins(PluginCompatTester.java:312)
	at org.jenkins.tools.test.PluginCompatTesterCli.main(PluginCompatTesterCli.java:175)
Caused by: org.jenkins.tools.test.exception.ExecutedTestNamesSolverException: Crashed tests!: [nectar.plugins.rbac.roles.RoleAPITest]
	at org.jenkins.tools.test.util.ExecutedTestNamesSolver.solve(ExecutedTestNamesSolver.java:63)
	at org.jenkins.tools.test.maven.ExternalMavenRunner.run(ExternalMavenRunner.java:120)
	... 3 more
```
- With this PR this ^ new PCT execution finished with status different than zero from the PCT-CLI POV, so in the previous example of a pipeline step `sh` evaluating the status, now it will detect the issue and will not consider this a false positive (zero value) on evaluating a successful execution of the PCT.