### PR TITLE
Use an appropriate charset for the xml-declared encoding when writing transformed POM

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
-
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.plexus.util.FileUtils;
 import org.dom4j.Document;
@@ -64,23 +63,23 @@ public class MavenPom {
     private final static String VERSION_ELEMENT = "version";
     private final static String CLASSIFIER_ELEMENT = "classifier";
 
-	private File rootDir;
-	private String pomFileName;
-	
-	public MavenPom(File rootDir){
-		this(rootDir, "pom.xml");
-	}
-	
-	private MavenPom(File rootDir, String pomFileName){
-		this.rootDir = rootDir;
-		this.pomFileName = pomFileName;
-	}
+    private File rootDir;
+    private String pomFileName;
 
-	public void transformPom(MavenCoordinates coreCoordinates) throws PomTransformationException{
-		File pom = new File(rootDir.getAbsolutePath()+"/"+pomFileName);
-		File backupPom = new File(rootDir.getAbsolutePath()+"/"+pomFileName+".backup");
-		try {
-			FileUtils.rename(pom, backupPom);
+    public MavenPom(File rootDir) {
+        this(rootDir, "pom.xml");
+    }
+
+    private MavenPom(File rootDir, String pomFileName) {
+        this.rootDir = rootDir;
+        this.pomFileName = pomFileName;
+    }
+
+    public void transformPom(MavenCoordinates coreCoordinates) throws PomTransformationException {
+        File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
+        File backupPom = new File(rootDir.getAbsolutePath() + "/" + pomFileName + ".backup");
+        try {
+            FileUtils.rename(pom, backupPom);
 
             Document doc;
             try {
@@ -108,15 +107,15 @@ public class MavenPom {
             }
 
             writeDocument(pom, doc);
-		} catch (Exception e) {
-			throw new PomTransformationException("Error while transforming pom : "+pom.getAbsolutePath(), e);
-		}
-	}
+        } catch (Exception e) {
+            throw new PomTransformationException("Error while transforming pom : " + pom.getAbsolutePath(), e);
+        }
+    }
 
     /**
      * Removes the dependency if it exists.
      */
-	public void removeDependency(@Nonnull String groupId, @Nonnull String artifactId) throws IOException {
+    public void removeDependency(@Nonnull String groupId, @Nonnull String artifactId) throws IOException {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
         try {
@@ -136,9 +135,9 @@ public class MavenPom {
             }
 
             Element groupIdElem = mavenDependency.element(GROUP_ID_ELEMENT);
-            if (groupIdElem != null && groupId.equalsIgnoreCase(groupIdElem.getText()) ) {
+            if (groupIdElem != null && groupId.equalsIgnoreCase(groupIdElem.getText())) {
                 LOGGER.log(Level.WARNING, "Removing dependency on {0}:{1}",
-                        new Object[] {groupId, artifactId});
+                        new Object[]{groupId, artifactId});
                 dependencies.remove(mavenDependency);
             }
         }
@@ -146,9 +145,8 @@ public class MavenPom {
         writeDocument(pom, doc);
     }
 
-    public void addDependencies(Map<String,VersionNumber> toAdd, Map<String,VersionNumber> toReplace, Map<String,VersionNumber> toAddTest, Map<String,VersionNumber> toReplaceTest, VersionNumber coreDep, Map<String,String> pluginGroupIds, List<String> toConvert) 
-        throws IOException 
-    {
+    public void addDependencies(Map<String, VersionNumber> toAdd, Map<String, VersionNumber> toReplace, Map<String, VersionNumber> toAddTest, Map<String, VersionNumber> toReplaceTest, VersionNumber coreDep, Map<String, String> pluginGroupIds, List<String> toConvert)
+            throws IOException {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
         try {
@@ -186,8 +184,8 @@ public class MavenPom {
         }
 
         Element properties = doc.getRootElement().element("properties");
-        Map<String,VersionNumber> toReplaceUsed = new LinkedHashMap<>();
-        Map<String,VersionNumber> toReplaceTestUsed = new LinkedHashMap<>();
+        Map<String, VersionNumber> toReplaceUsed = new LinkedHashMap<>();
+        Map<String, VersionNumber> toReplaceTestUsed = new LinkedHashMap<>();
         for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {
             Element artifactId = mavenDependency.element(ARTIFACT_ID_ELEMENT);
             Element groupId = mavenDependency.element(GROUP_ID_ELEMENT);
@@ -196,7 +194,7 @@ public class MavenPom {
             }
 
             String expectedGroupId = pluginGroupIds.get(artifactId.getTextTrim());
-            if(expectedGroupId == null || !groupId.getTextTrim().equals(expectedGroupId)) {
+            if (expectedGroupId == null || !groupId.getTextTrim().equals(expectedGroupId)) {
                 continue;
             }
 
@@ -215,8 +213,8 @@ public class MavenPom {
                     // Search property and update its value
                     String property = version.getTextTrim().replace("${", "").replace("}", "");
                     Element propertyToUpdate = null;
-                    for (Element mavenProperty: (List<Element>) properties.elements()) {
-                        if(StringUtils.equals(property, mavenProperty.getQName().getName())){
+                    for (Element mavenProperty : (List<Element>) properties.elements()) {
+                        if (StringUtils.equals(property, mavenProperty.getQName().getName())) {
                             propertyToUpdate = mavenProperty;
                             break;
                         }
@@ -262,10 +260,10 @@ public class MavenPom {
     }
 
     /**
-     * Add the given new plugins to the pom file. 
+     * Add the given new plugins to the pom file.
      */
-    private void addPlugins(Map<String,VersionNumber> adding, Map<String,String> pluginGroupIds, Element dependencies, String scope) {
-        for (Map.Entry<String,VersionNumber> dep : adding.entrySet()) {
+    private void addPlugins(Map<String, VersionNumber> adding, Map<String, String> pluginGroupIds, Element dependencies, String scope) {
+        for (Map.Entry<String, VersionNumber> dep : adding.entrySet()) {
             Element dependency = dependencies.addElement("dependency");
             String group = pluginGroupIds.get(dep.getKey());
 
@@ -280,14 +278,14 @@ public class MavenPom {
             dependency.addElement(VERSION_ELEMENT).addText(dep.getValue().toString());
 
             // Add required scope
-            if(scope != null) {
+            if (scope != null) {
                 dependency.addElement("scope").addText(scope);
             }
         }
     }
 
     private void writeDocument(final File target, final Document doc) throws IOException {
-        Writer w = Files.newBufferedWriter(target.toPath(), Charset.defaultCharset());
+        Writer w = Files.newBufferedWriter(target.toPath(), getSafeCharset(doc));
         OutputFormat format = OutputFormat.createPrettyPrint();
         XMLWriter writer = new XMLWriter(w, format);
         try {
@@ -295,6 +293,14 @@ public class MavenPom {
         } finally {
             writer.close();
             w.close();
+        }
+    }
+
+    private Charset getSafeCharset(final Document doc) {
+        try {
+            return Charset.forName(doc.getXMLEncoding());
+        } catch (Exception ex) {
+            return Charset.defaultCharset();
         }
     }
 

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
@@ -1,37 +1,40 @@
-
 package org.jenkins.tools.test.model;
 
 import com.google.common.collect.ImmutableMap;
 import hudson.util.VersionNumber;
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
 public class MavenPomTest {
 
-    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     @Issue("https://github.com/jenkinsci/bom/pull/301#issuecomment-694518923")
-    @Test public void addDependenciesWithTestsClassifier() throws Exception {
+    @Test
+    public void addDependenciesWithTestsClassifier() throws Exception {
         File prj = tmp.newFolder();
-        File pom = new File(prj, "pom.xml");
-        FileUtils.copyURLToFile(MavenPomTest.class.getResource("credentials-binding-pom-before.xml"), pom);
-        Map<String,VersionNumber> toAdd = new HashMap<>(Collections.singletonMap("trilead-api", new VersionNumber("1.0.8")));
-        Map<String,VersionNumber> toReplace = new HashMap<>(ImmutableMap.of("credentials", new VersionNumber("2.3.12"), "ssh-credentials", new VersionNumber("1.18.1"), "plain-credentials", new VersionNumber("1.7")));
-        Map<String,VersionNumber> toAddTest = new HashMap<>();
-        Map<String,VersionNumber> toReplaceTest = new HashMap<>(ImmutableMap.of("workflow-scm-step", new VersionNumber("2.11"), "workflow-durable-task-step", new VersionNumber("2.35"), "display-url-api", new VersionNumber("2.3.3"), "script-security", new VersionNumber("1.74"), "workflow-cps", new VersionNumber("2.83")));
+        File pom = createPomFileFromResource(prj, "credentials-binding-pom-before.xml");
+
+        Map<String, VersionNumber> toAdd = new HashMap<>(Collections.singletonMap("trilead-api", new VersionNumber("1.0.8")));
+        Map<String, VersionNumber> toReplace = new HashMap<>(ImmutableMap.of("credentials", new VersionNumber("2.3.12"), "ssh-credentials", new VersionNumber("1.18.1"), "plain-credentials", new VersionNumber("1.7")));
+        Map<String, VersionNumber> toAddTest = new HashMap<>();
+        Map<String, VersionNumber> toReplaceTest = new HashMap<>(ImmutableMap.of("workflow-scm-step", new VersionNumber("2.11"), "workflow-durable-task-step", new VersionNumber("2.35"), "display-url-api", new VersionNumber("2.3.3"), "script-security", new VersionNumber("1.74"), "workflow-cps", new VersionNumber("2.83")));
         toReplaceTest.putAll(ImmutableMap.of("workflow-support", new VersionNumber("3.5"), "workflow-job", new VersionNumber("2.39"), "workflow-basic-steps", new VersionNumber("2.20")));
         VersionNumber coreDep = new VersionNumber("2.164.3");
-        Map<String,String> pluginGroupIds = new HashMap<>(ImmutableMap.of("credentials-binding", "org.jenkins-ci.plugins", "pipeline-build-step", "org.jenkins-ci.plugins", "credentials", "org.jenkins-ci.plugins", "jdk-tool", "org.jenkins-ci.plugins", "snakeyaml-api", "io.jenkins.plugins"));
+        Map<String, String> pluginGroupIds = new HashMap<>(ImmutableMap.of("credentials-binding", "org.jenkins-ci.plugins", "pipeline-build-step", "org.jenkins-ci.plugins", "credentials", "org.jenkins-ci.plugins", "jdk-tool", "org.jenkins-ci.plugins", "snakeyaml-api", "io.jenkins.plugins"));
         pluginGroupIds.putAll(ImmutableMap.of("workflow-step-api", "org.jenkins-ci.plugins.workflow", "plain-credentials", "org.jenkins-ci.plugins", "trilead-api", "org.jenkins-ci.plugins", "command-launcher", "org.jenkins-ci.plugins", "jquery", "org.jenkins-ci.plugins"));
         pluginGroupIds.putAll(ImmutableMap.of("matrix-project", "org.jenkins-ci.plugins", "jquery-detached", "org.jenkins-ci.ui", "ace-editor", "org.jenkins-ci.ui", "git", "org.jenkins-ci.plugins", "workflow-durable-task-step", "org.jenkins-ci.plugins.workflow"));
         pluginGroupIds.putAll(ImmutableMap.of("git-client", "org.jenkins-ci.plugins", "ssh-credentials", "org.jenkins-ci.plugins", "variant", "org.jenkins-ci.plugins", "cloudbees-folder", "org.jenkins-ci.plugins", "scm-api", "org.jenkins-ci.plugins"));
@@ -43,7 +46,50 @@ public class MavenPomTest {
         pluginGroupIds.putAll(ImmutableMap.of("workflow-api", "org.jenkins-ci.plugins.workflow", "git-server", "org.jenkins-ci.plugins"));
         List<String> toConvert = Collections.emptyList();
         new MavenPom(prj).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, toConvert);
-        assertEquals(IOUtils.toString(MavenPomTest.class.getResource("credentials-binding-pom-after.xml")).replaceAll("(?m) +$", ""), FileUtils.readFileToString(pom).replaceAll("(?m) +$", ""));
+
+        assertResourceEqualsXmlFile("credentials-binding-pom-after.xml", pom);
     }
 
+    @Issue("https://github.com/jenkinsci/plugin-compat-tester/pull/287")
+    @Test
+    public void transformPOMwithSpecialCharacters() throws Exception {
+        File folder = tmp.newFolder();
+        File pomFile = createPomFileFromResource(folder, "demo-plugin-pom-before.xml");
+
+        MavenCoordinates coreCoordinates = new MavenCoordinates(
+                "org.jenkins-ci.plugins",
+                "plugin",
+                "2.235.1");
+
+        MavenPom mavenPom = new MavenPom(pomFile.getParentFile());
+        mavenPom.transformPom(coreCoordinates);
+
+        assertResourceEqualsXmlFile("demo-plugin-pom-after.xml", pomFile);
+    }
+
+    private void assertResourceEqualsXmlFile(String resource, File pom) throws IOException {
+        Charset charset = Charset.forName("UTF-8");
+        assertEquals(
+                normalizeXmlString(IOUtils.toString(MavenPomTest.class.getResource(resource), charset)),
+                normalizeXmlString(FileUtils.readFileToString(pom, charset))
+        );
+    }
+
+    private File createPomFileFromResource(File parentFolder, String resource) throws IOException {
+        File pom = new File(parentFolder, "pom.xml");
+        FileUtils.copyURLToFile(MavenPomTest.class.getResource(resource), pom);
+        return pom;
+    }
+
+    private static String normalizeXmlString(String source) {
+        return source
+                // remove leading and trailing spaces
+                .replaceAll("(?m)[ \t]+$", "").replaceAll("(?m)^[ \t] +", "")
+                // normalize new line characters
+                .replaceAll("\r\n", "\n")
+                // ensure new line at end of line
+                .concat("\n")
+                // remove extra new lines
+                .replaceAll("\n\n+", "\n");
+    }
 }

--- a/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-pom-after.xml
+++ b/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-pom-after.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <!--
+      Contains special characters so that we can mae sure they don't get lost
+        due to encoding errors:
+        - Spanish: ¡Esta transformación debería ser un éxito, niño!
+        - Japanese: このもう1つも機能するはずです
+        - Chinese: 这也应该有效
+    -->
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>2.235.1</version>
+        <relativePath/>
+    </parent>
+    <groupId>io.jenkins.plugins</groupId>
+    <artifactId>demo-plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+        <jenkins.version>2.164.1</jenkins.version>
+        <java.level>8</java.level>
+        <!-- Other properties you may want to use:
+             ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
+             ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
+             ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
+        -->
+    </properties>
+    <name>TODO Plugin</name>
+    <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.39</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.30</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>3.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1.39</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>scm-api</artifactId>
+                <version>2.2.6</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <developers>
+        <developer>
+            <id>bhacker</id>
+            <name>Bob Q. Hacker</name>
+            <email>bhacker@nowhere.net</email>
+        </developer>
+        <developer>
+            <id>somedev</id>
+            <name>Sômè Fántàstíc Dëvélóper</name>
+            <email>somedev@some.org</email>
+        </developer>
+    </developers>
+
+    <!-- Assuming you want to host on @jenkinsci:
+    <url>https://wiki.jenkins.io/display/JENKINS/TODO+Plugin</url>
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    </scm>
+    -->
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-pom-before.xml
+++ b/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-pom-before.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <!--
+      Contains special characters so that we can mae sure they don't get lost
+        due to encoding errors:
+        - Spanish: ¡Esta transformación debería ser un éxito, niño!
+        - Japanese: このもう1つも機能するはずです
+        - Chinese: 这也应该有效
+    -->
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.43</version>
+        <relativePath/>
+    </parent>
+    <groupId>io.jenkins.plugins</groupId>
+    <artifactId>demo-plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+        <jenkins.version>2.164.1</jenkins.version>
+        <java.level>8</java.level>
+        <!-- Other properties you may want to use:
+             ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
+             ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
+             ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
+        -->
+    </properties>
+    <name>TODO Plugin</name>
+    <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.39</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.30</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>3.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1.39</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>scm-api</artifactId>
+                <version>2.2.6</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <developers>
+        <developer>
+            <id>bhacker</id>
+            <name>Bob Q. Hacker</name>
+            <email>bhacker@nowhere.net</email>
+        </developer>
+        <developer>
+            <id>somedev</id>
+            <name>Sômè Fántàstíc Dëvélóper</name>
+            <email>somedev@some.org</email>
+        </developer>
+    </developers>
+
+    <!-- Assuming you want to host on @jenkinsci:
+    <url>https://wiki.jenkins.io/display/JENKINS/TODO+Plugin</url>
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    </scm>
+    -->
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>


### PR DESCRIPTION
Fixes [JENKINS-66173](https://issues.jenkins.io/browse/JENKINS-66173).

Prior code was keeping the original xml encoding declaration (for instance UTF-8) but using ANSI default charset while writing the transformed file. It now uses the appropriate charset for the encoding declared in the XML document.

Both the error and the fix may be tested by running PCT for genexus plugin, which POM contains accented characters in the developer name 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

