### PR TITLE
Do not duplicate dependencies whose versions are specified using a property

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -223,6 +223,7 @@ public class MavenPom {
                         properties.remove(propertyToUpdate);
                         propertyToUpdate.setText(replacement.toString());
                         properties.add(propertyToUpdate);
+                        toReplaceUsed.put(trimmedArtifactId, replacement);
                         continue;
                     }
                 } else {

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
@@ -67,6 +67,23 @@ public class MavenPomTest {
         assertResourceEqualsXmlFile("demo-plugin-pom-after.xml", pomFile);
     }
 
+    @Test
+    public void doNotDuplicateDependenciesWhoseVersionsAreProperties() throws Exception {
+        File folder = tmp.newFolder();
+        File pomFile = createPomFileFromResource(folder, "demo-plugin-properties-pom-before.xml");
+        Map<String, VersionNumber> toAdd = new HashMap<>();
+        Map<String, VersionNumber> toReplace = new HashMap<>();
+        toReplace.put("workflow-step-api", new VersionNumber("2.24"));
+        Map<String, VersionNumber> toAddTest = new HashMap<>();
+        Map<String, VersionNumber> toReplaceTest = new HashMap<>();
+        VersionNumber coreDep = new VersionNumber("2.303.1");
+        Map<String, String> pluginGroupIds = new HashMap<>();
+        pluginGroupIds.put("workflow-step-api", "org.jenkins-ci.plugins.workflow");
+        List<String> toConvert = Collections.emptyList();
+        new MavenPom(folder).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, toConvert);
+        assertResourceEqualsXmlFile("demo-plugin-properties-pom-after.xml", pomFile);
+    }
+
     private void assertResourceEqualsXmlFile(String resource, File pom) throws IOException {
         Charset charset = Charset.forName("UTF-8");
         assertEquals(

--- a/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-properties-pom-after.xml
+++ b/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-properties-pom-after.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">    
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.43</version>
+        <relativePath/>
+    </parent>
+    <groupId>io.jenkins.plugins</groupId>
+    <artifactId>demo-plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <name>TODO Plugin</name>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <properties>
+        <jenkins.version>2.289.3</jenkins.version>
+        <java.level>8</java.level>
+        <workflow-step-api-plugin.version>2.24</workflow-step-api-plugin.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow-step-api-plugin.version}</version>
+            <scope>optional</scope>
+        </dependency>
+        <!--SYNTHETIC-->
+    </dependencies>
+</project>

--- a/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-properties-pom-before.xml
+++ b/plugins-compat-tester/src/test/resources/org/jenkins/tools/test/model/demo-plugin-properties-pom-before.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">    
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.43</version>
+        <relativePath/>
+    </parent>
+    <groupId>io.jenkins.plugins</groupId>
+    <artifactId>demo-plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <name>TODO Plugin</name>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <properties>
+        <jenkins.version>2.289.3</jenkins.version>
+        <java.level>8</java.level>
+        <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow-step-api-plugin.version}</version>
+            <scope>optional</scope>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
I ran into a PCT failure in a proprietary plugin that appears to be a bug in the PCT. The plugin has an optional dependency on another plugin, and the version of the optional dependency is specified using a property. When I test the plugin in the PCT against a newer version of the optional dependency, the PCT both updates the property that controls the dependency's version and inserts a duplicate non-optional version of the dependency after the PCT-specific `<!--SYNTHETIC-->` marker in the POM. This has the result of making the dependency non-optional in the PCT.

Normally this would not affect a plugin's tests because optional dependencies are always available in `JenkinsRule` tests, but my plugin uses `RealJenkinsRule` and specifically omits the optional dependency in one test, and that test fails because the plugin fails to load because the dependency that should be optional is not optional according to the PCT-modified POM.

I think this bug was introduced by https://github.com/jenkinsci/plugin-compat-tester/pull/239. My proposed fix is to count any property replacement as a use of the dependency, just like if we overwrote the version of the dependency directly.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
