### PR TITLE
Bugfix on dealing with non-executed test phase due collateral issues

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -323,7 +323,7 @@ public class PluginCompatTester {
                             status = TestStatus.COMPILATION_ERROR;
                         } else if (!e.getTestDetails().hasBeenExecuted()) { // testing was not able to start properly (i.e: invalid exclusion list file format)
                             status = TestStatus.INTERNAL_ERROR;
-                        } else if (!e.getTestDetails().hasFailures()) { 
+                        } else if (e.getTestDetails().hasFailures()) { 
                             status = TestStatus.TEST_FAILURES;                            
                         } else { // Can this really happen ???
                             status = TestStatus.SUCCESS;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -45,6 +45,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -310,7 +311,7 @@ public class PluginCompatTester {
                     if (errorMessage == null) {
                     try {
                         TestExecutionResult result = testPluginAgainst(actualCoreCoordinates, plugin, mconfig, pomData, pluginsToCheck, pluginGroupIds, pcth, config.getOverridenPlugins());
-                        if (result.getTestDetails().getFailed().isEmpty()) {
+                        if (result.getTestDetails().isSuccess()) {
                             status = TestStatus.SUCCESS;
                         } else {
                             status = TestStatus.TEST_FAILURES;
@@ -320,14 +321,16 @@ public class PluginCompatTester {
                     } catch (PomExecutionException e) {
                         if(!e.succeededPluginArtifactIds.contains("maven-compiler-plugin")){
                             status = TestStatus.COMPILATION_ERROR;
-                        } else if (!e.getTestDetails().getFailed().isEmpty()) {
-                            status = TestStatus.TEST_FAILURES;
+                        } else if (!e.getTestDetails().hasBeenExecuted()) { // testing was not able to start properly (i.e: invalid exclusion list file format)
+                            status = TestStatus.INTERNAL_ERROR;
+                        } else if (!e.getTestDetails().hasFailures()) { 
+                            status = TestStatus.TEST_FAILURES;                            
                         } else { // Can this really happen ???
                             status = TestStatus.SUCCESS;
                         }
                         errorMessage = e.getErrorMessage();
                         warningMessages.addAll(e.getPomWarningMessages());
-                        testDetails.addAll(config.isStoreAll() ? e.getTestDetails().getAll() : e.getTestDetails().getFailed());
+                        testDetails.addAll(config.isStoreAll() ? e.getTestDetails().getAll() : e.getTestDetails().hasFailures() ? e.getTestDetails().getFailed() : Collections.emptySet());
                     } catch (Error e){
                         // Rethrow the error ... something is wrong !
                         throw e;
@@ -566,7 +569,7 @@ public class PluginCompatTester {
         } catch (PomExecutionException e){
             e.getPomWarningMessages().addAll(pomData.getWarningMessages());
             if (ranCompile) {
-                // So the status is considered to be TEST_FAILURES not COMPILATION_ERROR:
+                // So the status cannot be considered COMPILATION_ERROR
                 e.succeededPluginArtifactIds.add("maven-compiler-plugin");
             }
             throw e;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -317,7 +317,7 @@ public class PluginCompatTester {
                             status = TestStatus.TEST_FAILURES;
                         }
                         warningMessages.addAll(result.pomWarningMessages);
-                        testDetails.addAll(config.isStoreAll() ? result.getTestDetails().getAll() : result.getTestDetails().getFailed());
+                        testDetails.addAll(config.isStoreAll() ? result.getTestDetails().getAll() : result.getTestDetails().hasFailures() ? result.getTestDetails().getFailed() : Collections.emptySet());
                     } catch (PomExecutionException e) {
                         if(!e.succeededPluginArtifactIds.contains("maven-compiler-plugin")){
                             status = TestStatus.COMPILATION_ERROR;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesDetails.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesDetails.java
@@ -16,8 +16,6 @@ public class ExecutedTestNamesDetails {
     
     public ExecutedTestNamesDetails() {
         this.tests = new HashMap<>();
-        this.tests.put(FAILED, new TreeSet<String>());
-        this.tests.put(EXECUTED, new TreeSet<String>());
     }
     
     public void addFailedTest(String test) {
@@ -29,8 +27,13 @@ public class ExecutedTestNamesDetails {
     }
     
     public Set<String> getAll() {
-        Set<String> result = new TreeSet<>(this.tests.get(EXECUTED));
-        result.addAll(this.tests.get(FAILED));
+        Set<String> result = new TreeSet<>();
+        if (this.tests.containsKey(EXECUTED)) {
+            result.addAll(this.tests.get(EXECUTED));
+        }
+        if (this.tests.containsKey(FAILED)) {
+            result.addAll(this.tests.get(FAILED));
+        }
         return Collections.unmodifiableSet(result);
     }
     
@@ -43,13 +46,25 @@ public class ExecutedTestNamesDetails {
     }
     
     private Set<String> get(String key) {
-        return Collections.unmodifiableSet(new TreeSet<>(this.tests.get(key)));
+        return this.tests.containsKey(key) ? Collections.unmodifiableSet(new TreeSet<>(this.tests.get(key))) : null;
     }
     
     private void add(String key, String test) {
+        if (this.tests.get(key) == null) {
+            this.tests.put(key, new TreeSet<String>());
+        }
         this.tests.get(key).add(test);
     }
-    
-    
 
+    public boolean hasBeenExecuted() {
+        return getExecuted() != null || getFailed() != null;
+    }
+
+    public boolean isSuccess() {
+        return getExecuted() != null && getFailed() == null;
+    }
+
+    public boolean hasFailures() {
+        return getFailed() != null && !getFailed().isEmpty();
+    }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesSolver.java
@@ -101,18 +101,20 @@ public class ExecutedTestNamesSolver {
 
         System.out.println("[INFO] ");
         System.out.println("[INFO] Results:");
-        System.out.println("[INFO] ");
-        System.out.println(String.format("[INFO] Executed: %s", testNames.getExecuted().size()));
-        for (String testName : testNames.getExecuted()) {
-            System.out.println(String.format("[INFO] - %s", testName));
-        }
-        System.out.println("[INFO] ");
-        System.out.println(String.format("[INFO] Failed: %s", testNames.getFailed().size()));
-        for (String testName : testNames.getFailed()) {
-            System.out.println(String.format("[INFO] - %s", testName));
-        }
-
+        printDetails(testNames.getExecuted(), "Executed");
+        printDetails(testNames.getFailed(), "Failed");
         return testNames;
+    }
+
+    private void printDetails(Set<String> tests, String type) {
+        System.out.println("[INFO] ");
+        int size = tests != null ? tests.size() : 0;
+        System.out.println(String.format("[INFO] %s: %s", type, size));
+        if (size != 0) {
+            for (String testName : tests) {
+                System.out.println(String.format("[INFO] - %s", testName));
+            }
+        }
     }
 
     private List<String> getReportsDirectoryPaths(Set<String> types, File baseDirectory) throws ExecutedTestNamesSolverException {

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -213,6 +213,30 @@ public class PluginCompatTesterTest {
         PluginCompatTester tester = new PluginCompatTester(config);
         tester.testPlugins();
     }
+    
+    @Test
+    public void testWithInvalidExclusionList() throws Throwable {
+        File exclusionList = new ClassPathResource("bad-surefire-exclusion-list").getFile();
+        PluginCompatTesterConfig config = getConfig(ImmutableList.of("active-directory"));
+        Map<String, String> mavenProperties = new HashMap<>();
+        mavenProperties.put("surefire.excludesFile", exclusionList.getAbsolutePath());
+        config.setMavenProperties(mavenProperties);
+        
+        PluginCompatTester tester = new PluginCompatTester(config);
+        PluginCompatReport report = tester.testPlugins();
+        assertNotNull(report);
+        Map<PluginInfos, List<PluginCompatResult>> pluginCompatTests = report.getPluginCompatTests();
+        assertNotNull(pluginCompatTests);
+        for (Entry<PluginInfos, List<PluginCompatResult>> entry : pluginCompatTests.entrySet()) {
+            assertEquals("active-directory", entry.getKey().pluginName);
+            List<PluginCompatResult> results = entry.getValue();
+            assertEquals(1, results.size());
+            PluginCompatResult result = results.get(0);
+            assertNotNull(result);
+            assertNotNull(result.status);
+            assertEquals(TestStatus.INTERNAL_ERROR, result.status);
+        }
+    }
 
     private PluginCompatTesterConfig getConfig(List<String> includedPlugins) throws IOException {
         PluginCompatTesterConfig config = new PluginCompatTesterConfig(testFolder.getRoot(),

--- a/plugins-compat-tester/src/test/resources/bad-surefire-exclusion-list
+++ b/plugins-compat-tester/src/test/resources/bad-surefire-exclusion-list
@@ -1,0 +1,1 @@
+io.jenkins.plugins.FooBar#method


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Highlights
- Current code of PCT is not dealing and reporting properly the status on non-executed test phase situations
- If you provide a surefire exclusion list file via `mavenProperties` and this file has wrong syntax (i.e.: method filtering, which is not supported by surefire), then it will provide status as `SUCCESS` on its report
- Main root cause is that the `PomExecutionException` thrown by the runner, once the surefire plugin reports that the file syntax is invalid, is not properly managed by the caller, and hits on: https://github.com/jenkinsci/plugin-compat-tester/blob/master/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java#L325..L326
- So, although the log shows a `BUILD FAILURE` as follows:
```
[...]
[INFO] --- maven-surefire-plugin:3.0.0-M4:test (default-cli) @ active-directory ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.618 s
[INFO] Finished at: 2021-09-08T12:00:07+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test (default-cli) on project cloudbees-aborted-builds: Method filter prohibited in includes|excludes|includesFile|excludesFile parameter: Test#fooBar -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[...]
```
- Generated report before this PR looks like this:
```
[...]
<compatResult>
          <coreCoordinates>
            <groupId>org.jenkins-ci.plugins</groupId>
            <artifactId>plugin</artifactId>
            <version>2.303.1-cb-9</version>
          </coreCoordinates>
          <status>SUCCESS</status>
[...]
```
- After this PR, the generated report will reflect that an internal error has occurred and testing was not executed yet
```
[...]
<compatResult>
          <coreCoordinates>
            <groupId>org.jenkins-ci.plugins</groupId>
            <artifactId>plugin</artifactId>
            <version>2.303.1-cb-9</version>
          </coreCoordinates>
          <status>INTERNAL_ERROR</status>
[...]
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
