### PR TITLE
Decoupled adhoc static plugin method invocations on hooks management

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -25,16 +25,21 @@
  */
 package org.jenkins.tools.test;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+
+import org.jenkins.tools.test.model.PCTPlugin;
+import org.jenkins.tools.test.model.TestStatus;
+
 import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
+
 import hudson.util.VersionNumber;
-import java.io.File;
-import java.util.List;
-import javax.annotation.CheckForNull;
-import org.jenkins.tools.test.model.PCTPlugin;
-import org.jenkins.tools.test.model.TestStatus;
 
 /**
  * POJO containing CLI arguments &amp; help.
@@ -129,8 +134,8 @@ public class CliOptions {
     @Parameter(names="-hookPrefixes", description = "Prefixes of the extra hooks' classes")
     private String hookPrefixes;
     
-    @Parameter(names="-externalHooksJars", description = "Comma-separated list of external hooks jar file locations")
-    private String externalHooksJars;
+    @Parameter(names="-externalHooksJars", description = "Comma-separated list of external hooks jar file locations", listConverter = FileListConverter.class)
+    private List<File> externalHooksJars;
 
     @Parameter(names="-localCheckoutDir", description = "Folder containing either a local (possibly modified) clone of a plugin repository or a set of local clone of different plugins")
     private String localCheckoutDir;
@@ -221,7 +226,7 @@ public class CliOptions {
         return hookPrefixes;
     }
     
-    public String getExternalHooksJars() {
+    public List<File> getExternalHooksJars() {
         return externalHooksJars;
     }
 
@@ -268,6 +273,18 @@ public class CliOptions {
             String name = details[0];
             int colon = name.indexOf(':');
             return new PCTPlugin(colon == -1 ? name : name.substring(colon + 1), colon == -1 ? null : name.substring(0, colon), new VersionNumber(details[1]));
+        }
+    }
+    
+    public static class FileListConverter implements IStringConverter<List<File>> {
+        @Override
+        public List<File> convert(String files) {
+            String [] paths = files.split(",");
+            List<File> fileList = new ArrayList<>();
+            for(String path : paths){
+                fileList.add(new File(path));
+            }
+            return fileList;
         }
     }
 

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -128,6 +128,9 @@ public class CliOptions {
 
     @Parameter(names="-hookPrefixes", description = "Prefixes of the extra hooks' classes")
     private String hookPrefixes;
+    
+    @Parameter(names="-externalHooksJars", description = "Comma-separated list of external hooks jar file locations")
+    private String externalHooksJars;
 
     @Parameter(names="-localCheckoutDir", description = "Folder containing either a local (possibly modified) clone of a plugin repository or a set of local clone of different plugins")
     private String localCheckoutDir;
@@ -216,6 +219,10 @@ public class CliOptions {
 
     public String getHookPrefixes() {
         return hookPrefixes;
+    }
+    
+    public String getExternalHooksJars() {
+        return externalHooksJars;
     }
 
     public String getLocalCheckoutDir() {

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -134,7 +134,7 @@ public class CliOptions {
     @Parameter(names="-hookPrefixes", description = "Prefixes of the extra hooks' classes")
     private String hookPrefixes;
     
-    @Parameter(names="-externalHooksJars", description = "Comma-separated list of external hooks jar file locations", listConverter = FileListConverter.class)
+    @Parameter(names="-externalHooksJars", description = "Comma-separated list of external hooks jar file locations", listConverter = FileListConverter.class, validateWith = FileValidator.class)
     private List<File> externalHooksJars;
 
     @Parameter(names="-localCheckoutDir", description = "Folder containing either a local (possibly modified) clone of a plugin repository or a set of local clone of different plugins")
@@ -285,6 +285,18 @@ public class CliOptions {
                 fileList.add(new File(path));
             }
             return fileList;
+        }
+    }
+    
+    public static class FileValidator implements IParameterValidator {
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            for (String path : value.split(",")) {
+                File jar = new File(path);
+                if (!jar.exists() || !jar.isFile()) {
+                    throw new ParameterException(path + " must exists and be a normal file (not a directory)");
+                }
+            }
         }
     }
 

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -126,6 +126,9 @@ public class PluginCompatTesterCli {
         if(options.getHookPrefixes() != null && !options.getHookPrefixes().isEmpty()){
             config.setHookPrefixes(Arrays.asList(options.getHookPrefixes().split(",")));
         }
+        if(options.getExternalHooksJars() != null && !options.getExternalHooksJars().isEmpty()){
+            config.setExternalHooksJars(Arrays.asList(options.getExternalHooksJars().split(",")));
+        }
         if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());
         }

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -127,7 +127,7 @@ public class PluginCompatTesterCli {
             config.setHookPrefixes(Arrays.asList(options.getHookPrefixes().split(",")));
         }
         if(options.getExternalHooksJars() != null && !options.getExternalHooksJars().isEmpty()){
-            config.setExternalHooksJars(Arrays.asList(options.getExternalHooksJars().split(",")));
+            config.setExternalHooksJars(options.getExternalHooksJars());
         }
         if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());

--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.12</version>
+      <version>0.9.10</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.11</version> <!-- Downgrade due to: https://github.com/ronmamo/reflections/issues/273 -->
+      <version>0.9.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.12</version>
+      <version>0.9.11</version> <!-- Downgrade due to: https://github.com/ronmamo/reflections/issues/273 -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/plugins-compat-tester-model/pom.xml
+++ b/plugins-compat-tester-model/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.10</version>
+      <version>0.9.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -129,7 +129,7 @@ public class PluginCompatTesterConfig {
     private List<String> hookPrefixes = new ArrayList<>(Collections.singletonList("org.jenkins"));
     
     // External hooks jar files path locations
-    private List<String> externalHooksJars = new ArrayList<>();
+    private List<File> externalHooksJars = new ArrayList<>();
 
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
     private File localCheckoutDir;
@@ -411,7 +411,7 @@ public class PluginCompatTesterConfig {
         return hookPrefixes;
     }
     
-    public List<String> getExternalHooksJars() {
+    public List<File> getExternalHooksJars() {
         return externalHooksJars;
     }
 
@@ -420,7 +420,7 @@ public class PluginCompatTesterConfig {
         this.hookPrefixes.addAll(hookPrefixes);
     }
     
-    public void setExternalHooksJars(List<String> externalHooksJars) {
+    public void setExternalHooksJars(List<File> externalHooksJars) {
         this.externalHooksJars = externalHooksJars;
     }
 

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -127,6 +127,9 @@ public class PluginCompatTesterConfig {
  
     // Classpath prefixes of the extra hooks
     private List<String> hookPrefixes = new ArrayList<>(Collections.singletonList("org.jenkins"));
+    
+    // External hooks jar files path locations
+    private List<String> externalHooksJars = new ArrayList<>();
 
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
     private File localCheckoutDir;
@@ -407,10 +410,18 @@ public class PluginCompatTesterConfig {
     public List<String> getHookPrefixes() {
         return hookPrefixes;
     }
+    
+    public List<String> getExternalHooksJars() {
+        return externalHooksJars;
+    }
 
     public void setHookPrefixes(List<String> hookPrefixes) {
         // Want to also process the default
         this.hookPrefixes.addAll(hookPrefixes);
+    }
+    
+    public void setExternalHooksJars(List<String> externalHooksJars) {
+        this.externalHooksJars = externalHooksJars;
     }
 
     /**

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -65,9 +65,7 @@ public class PluginCompatTesterHooks {
             return;
         }
         for (File jar : externalJars) {
-            if (jar.exists() && jar.isFile()) {
-                classLoaders.add(new URLClassLoader(new URL[] { jar.toURI().toURL() }, PluginCompatTesterHooks.class.getClassLoader()));
-            }
+            classLoaders.add(new URLClassLoader(new URL[] { jar.toURI().toURL() }, PluginCompatTesterHooks.class.getClassLoader()));
         }
     }
     public Map<String, Object> runBeforeCheckout(Map<String, Object> elements) {

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -43,7 +43,7 @@ public class PluginCompatTesterHooks {
         setupHooksByType();
     }
 
-    public PluginCompatTesterHooks(List<String> extraPrefixes, List<String> externalJars) throws MalformedURLException {
+    public PluginCompatTesterHooks(List<String> extraPrefixes, List<File> externalJars) throws MalformedURLException {
         setupPrefixes(extraPrefixes);
         setupExternalClassLoaders(externalJars);
         setupHooksByType();
@@ -60,14 +60,13 @@ public class PluginCompatTesterHooks {
         }
     }
 
-    private void setupExternalClassLoaders(List<String> externalJars) throws MalformedURLException {
+    private void setupExternalClassLoaders(List<File> externalJars) throws MalformedURLException {
         if (externalJars == null) {
             return;
         }
-        for (String jar : externalJars) {
-            File file = new File(jar);
-            if (file.exists() && file.isFile()) {
-                classLoaders.add(new URLClassLoader(new URL[] { file.toURI().toURL() }, PluginCompatTesterHooks.class.getClassLoader()));
+        for (File jar : externalJars) {
+            if (jar.exists() && jar.isFile()) {
+                classLoaders.add(new URLClassLoader(new URL[] { jar.toURI().toURL() }, PluginCompatTesterHooks.class.getClassLoader()));
             }
         }
     }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
 
 /**
  * Loads and executes hooks for modifying the state of Plugin Compatibility Tester at different
@@ -107,7 +109,7 @@ public class PluginCompatTesterHooks {
         
         // Search for all hooks defined within the given classpath prefix
         for(String prefix : hookPrefixes) {
-            Reflections reflections = new Reflections(prefix);
+            Reflections reflections = new Reflections(prefix, PluginCompatTesterHooks.class.getClassLoader());
             Set<Class<? extends PluginCompatTesterHook>> subTypes;
             
             // Find all steps for a given stage. Long due to casting

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -107,7 +107,7 @@ public class PluginCompatTesterHooks {
         
         // Search for all hooks defined within the given classpath prefix
         for(String prefix : hookPrefixes) {
-            Reflections reflections = new Reflections(prefix, new SubTypesScanner());
+            Reflections reflections = new Reflections(prefix);
             Set<Class<? extends PluginCompatTesterHook>> subTypes;
             
             // Find all steps for a given stage. Long due to casting

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -12,6 +12,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
 
 /**
  * Loads and executes hooks for modifying the state of Plugin Compatibility Tester at different
@@ -106,7 +107,7 @@ public class PluginCompatTesterHooks {
         
         // Search for all hooks defined within the given classpath prefix
         for(String prefix : hookPrefixes) {
-            Reflections reflections = new Reflections(prefix);
+            Reflections reflections = new Reflections(prefix, new SubTypesScanner());
             Set<Class<? extends PluginCompatTesterHook>> subTypes;
             
             // Find all steps for a given stage. Long due to casting

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -172,7 +172,7 @@ public class PluginCompatTester {
             splitCycles = HISTORICAL_SPLIT_CYCLES;
         }
 
-        PluginCompatTesterHooks pcth = new PluginCompatTesterHooks(config.getHookPrefixes());
+        PluginCompatTesterHooks pcth = new PluginCompatTesterHooks(config.getHookPrefixes(), config.getExternalHooksJars());
         // Providing XSL Stylesheet along xml report file
         if(config.reportFile != null){
             if(config.isProvideXslReport()){

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -19,6 +19,8 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
 public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBeforeCheckout {
 
     protected boolean firstRun = true;
+    
+    private PomData pomData;
 
     @Override
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
@@ -38,7 +40,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
                 // Checkout to the parent directory. All other processes will be on the child directory
                 File parentPath = new File(config.workDirectory.getAbsolutePath() + "/" + getParentFolder());
 
-                PomData pomData = (PomData) moreInfo.get("pomData");
+                pomData = (PomData) moreInfo.get("pomData");
                 String scmTag;
                 if (pomData.getScmTag() != null) {
                     scmTag = pomData.getScmTag();
@@ -48,7 +50,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
                     System.out.println(String.format("POM did not provide an SCM tag. Inferring tag '%s'.", scmTag));
                 }
                 // Like PluginCompatTester.cloneFromSCM but with subdirectories trimmed:
-                String parentUrl = pomData.getConnectionUrl().replaceFirst("^(.+github[.]com/[^/]+/[^/]+)/.+", "$1");
+                String parentUrl = getUrl(pomData);
                 System.out.println("Checking out from SCM connection URL: " + parentUrl + " (" + getParentProjectName() + "-" + currentPlugin.version + ") at tag " + scmTag);
                 ScmManager scmManager = SCMManagerFactory.getInstance().createScmManager();
                 ScmRepository repository = scmManager.makeScmRepository(parentUrl);
@@ -75,6 +77,10 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
         }
 
         return moreInfo;
+    }
+
+    public String getUrl() {
+        return pomData.getConnectionUrl().replaceFirst("^(.+github[.]com/[^/]+/[^/]+)/.+", "$1");
     }
 
     protected void configureLocalCheckOut(UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -29,12 +29,12 @@ public class BlueOceanHook extends AbstractMultiParentHook {
         return isBOPlugin(info);
     }
 
-    public static boolean isBOPlugin(Map<String, Object> moreInfo) {
+    private boolean isBOPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isBOPlugin(data);
     }
 
-    public static boolean isBOPlugin(PomData data) {
+    private boolean isBOPlugin(PomData data) {
         if (data.parent != null) {
             return data.parent.artifactId.equalsIgnoreCase("blueocean-parent");
         } else {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
@@ -27,12 +27,12 @@ public class ConfigurationAsCodeHook extends AbstractMultiParentHook {
         return "plugin";
     }
 
-    public static boolean isCascPlugin(Map<String, Object> moreInfo) {
+    private boolean isCascPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isCascPlugin(data);
     }
 
-    public static boolean isCascPlugin(PomData data) {
+    private boolean isCascPlugin(PomData data) {
         if (data.parent != null) {
             // Non-incrementals
             return data.parent.groupId.equalsIgnoreCase("io.jenkins.configuration-as-code");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -28,12 +28,12 @@ public class DeclarativePipelineHook extends AbstractMultiParentHook {
         return isDPPlugin(info);
     }
 
-    public static boolean isDPPlugin(Map<String, Object> moreInfo) {
+    private boolean isDPPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isDPPlugin(data);
     }
 
-    public static boolean isDPPlugin(PomData data) {
+    private boolean isDPPlugin(PomData data) {
         if (data.parent != null) {
             return data.parent.artifactId.equalsIgnoreCase("pipeline-model-parent");
         } else {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
@@ -32,12 +32,12 @@ public class DeclarativePipelineMigrationHook extends AbstractMultiParentHook {
         return isPlugin(info);
     }
 
-    public static boolean isPlugin(Map<String, Object> moreInfo) {
+    private boolean isPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isPlugin(data);
     }
 
-    public static boolean isPlugin(PomData data) {
+    private boolean isPlugin(PomData data) {
         if (data.parent != null) {
             return data.parent.artifactId.equalsIgnoreCase("declarative-pipeline-migration-assistant-parent");
         }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -1,5 +1,7 @@
 package org.jenkins.tools.test.hook;
 
+import static org.jenkins.tools.test.model.hook.PluginCompatTesterHooks.getHooksFromStage;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +15,7 @@ import org.jenkins.tools.test.exception.PomExecutionException;
 import org.jenkins.tools.test.maven.ExternalMavenRunner;
 import org.jenkins.tools.test.maven.MavenRunner;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHook;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 
 public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile {
@@ -80,9 +83,12 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
 
     @Override
     public boolean check(Map<String, Object> info) {
-        return BlueOceanHook.isBOPlugin(info) || DeclarativePipelineHook.isDPPlugin(info) || StructsHook.isStructsPlugin(info) ||
-        SwarmHook.isSwarmPlugin(info) || ConfigurationAsCodeHook.isCascPlugin(info) || PipelineStageViewHook.isPipelineStageViewPlugin(info) ||
-        DeclarativePipelineMigrationHook.isPlugin(info) ;
+        for (PluginCompatTesterHook hook : getHooksFromStage("checkout", info)) {
+            if (hook instanceof AbstractMultiParentHook && hook.check(info)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isEslintFile(Path file) {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -27,12 +27,12 @@ public class PipelineStageViewHook extends AbstractMultiParentHook {
         return isPipelineStageViewPlugin(info);
     }
 
-    public static boolean isPipelineStageViewPlugin(Map<String, Object> moreInfo) {
+    private boolean isPipelineStageViewPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isPipelineStageViewPlugin(data);
     }
 
-    public static boolean isPipelineStageViewPlugin(PomData data) {
+    private boolean isPipelineStageViewPlugin(PomData data) {
         return data.groupId.equals("org.jenkins-ci.plugins.pipeline-stage-view") || data.artifactId.contains("pipeline-rest-api");
     }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
@@ -32,12 +32,12 @@ public class StructsHook extends AbstractMultiParentHook {
         return "plugin";
     }
 
-    public static boolean isStructsPlugin(Map<String, Object> moreInfo) {
+    private boolean isStructsPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isStructsPlugin(data);
     }
 
-    public static boolean isStructsPlugin(PomData data) {
+    private boolean isStructsPlugin(PomData data) {
         if (data.parent != null) {
             // Non-incrementals
             return data.parent.artifactId.equalsIgnoreCase("structs-parent");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
@@ -31,12 +31,12 @@ public class SwarmHook extends AbstractMultiParentHook {
         return isSwarmPlugin(info);
     }
 
-    public static boolean isSwarmPlugin(Map<String, Object> moreInfo) {
+    private boolean isSwarmPlugin(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isSwarmPlugin(data);
     }
 
-    public static boolean isSwarmPlugin(PomData data) {
+    private boolean isSwarmPlugin(PomData data) {
         if (data.parent != null) {
             // Non-incrementals
             return data.parent.artifactId.equalsIgnoreCase("swarm-plugin");

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -29,12 +29,12 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
         return "plugin";
     }
 
-    public static boolean isWarningsNG(Map<String, Object> moreInfo) {
+    private boolean isWarningsNG(Map<String, Object> moreInfo) {
         PomData data = (PomData) moreInfo.get("pomData");
         return isWarningsNG(data);
     }
 
-    public static boolean isWarningsNG(PomData data) {
+    private boolean isWarningsNG(PomData data) {
         return "warnings-ng-parent".equals(data.artifactId) // localCheckoutDir
                 || "warnings-ng".equals(data.artifactId); // checkout
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Highlights
- Current code of PCT on `TransformPom` and `MultiParentCompileHook` hooks is highly coupled to some `AbstractMultiParentHook` instances (like `StructsHook`, `BlueOceanHook`, etc.) 
- Current proposal remove the need to explicitly mention each hook involved in as a bad smell design
- In addition, with the current code, if we want to fork the PCT and include new hooks, every time we sync with upstream we will have to deal with including our additional hooks on these two ones (`TransformPom` and `MultiParentCompileHook`)
- What is proposed here is to provide a public method on `PluginCompatTesterHooks` to dynamically retrieve the registered hooks for a given stage, and to use that method on the affected ones to be refactored
- Also it provides a new option arg named `-externalHooksJars` to specify a comma-separated list of external hooks jar file locations

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
