### PR TITLE
Fix `master` branch IT related with `buildtriggerbadge`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM maven:3.6.3-jdk-8 as builder
+FROM maven:3.8.1-jdk-8 as builder
 
 # Warmup to avoid downloading the world each time
 RUN git clone https://github.com/jenkinsci/plugin-compat-tester &&\
@@ -37,7 +37,7 @@ COPY LICENSE.txt /pct/src/LICENSE.txt
 WORKDIR /pct/src/
 RUN mvn clean package -Dmaven.test.skip=true
 
-FROM maven:3.6.3-jdk-8
+FROM maven:3.8.1-jdk-8
 LABEL Maintainer="Oleg Nenashev <o.v.nenashev@gmail.com>"
 LABEL Description="Base image for running Jenkins Plugin Compat Tester (PCT) against custom plugins and Jenkins cores" Vendor="Jenkins project"
 ENV JENKINS_WAR_PATH=/pct/jenkins.war

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ parallel(branches)
 def itBranches = [:]
 
 
-itBranches['buildtriggerbadge:2.10 tests success on JDK11'] = {
+itBranches['buildtriggerbadge:2.11 tests success on JDK11'] = {
     node('docker') {
         checkout scm
         def settingsXML="mvn-settings.xml"
@@ -79,7 +79,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK11'] = {
                          -v $(pwd)/jenkins.war:/pct/jenkins.war:ro \
                          -v $(pwd)/out:/pct/out -e JDK_VERSION=11 \
                          -v $(pwd)/mvn-settings.xml:/pct/m2-settings.xml \
-                         -e ARTIFACT_ID=buildtriggerbadge -e VERSION=buildtriggerbadge-2.10 \
+                         -e ARTIFACT_ID=buildtriggerbadge -e VERSION=buildtriggerbadge-2.11 \
                          jenkins/pct
             '''
             archiveArtifacts artifacts: "out/**"
@@ -89,7 +89,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK11'] = {
     }
 }
 
-itBranches['buildtriggerbadge:2.10 tests success on JDK8'] = {
+itBranches['buildtriggerbadge:2.11 tests success on JDK8'] = {
     node('docker') {
         checkout scm
         def settingsXML="mvn-settings.xml"
@@ -113,7 +113,7 @@ itBranches['buildtriggerbadge:2.10 tests success on JDK8'] = {
                          -v $(pwd)/jenkins.war:/pct/jenkins.war:ro \
                          -v $(pwd)/mvn-settings.xml:/pct/m2-settings.xml \
                          -v $(pwd)/out:/pct/out -e JDK_VERSION=8 \
-                         -e ARTIFACT_ID=buildtriggerbadge -e VERSION=buildtriggerbadge-2.10 \
+                         -e ARTIFACT_ID=buildtriggerbadge -e VERSION=buildtriggerbadge-2.11 \
                          jenkins/pct
             '''
             archiveArtifacts artifacts: "out/**"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,6 @@ parallel(branches)
 // Integration testing, using a locally built Docker image
 def itBranches = [:]
 
-
 itBranches['buildtriggerbadge:2.11 tests success on JDK11'] = {
     node('docker') {
         checkout scm


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Current `master` branch was not working as expected due to some failures on `buildtriggerbadge` related ITs. Main reason was we are hitting:
```
Non-resolvable parent POM for org.jenkins-ci.plugins:buildtriggerbadge:2.10: Could not transfer artifact org.jenkins-ci.plugins:plugin:pom:3.28 from/to repo.jenkins-ci.org (http://repo.jenkins-ci.org/public/): Transfer failed for http://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/plugin/3.28/plugin-3.28.pom 308 Permanent Redirect and 'parent.relativePath' points at wrong local POM @ line 3, column 10 -> [Help 2]
```
New version 2.11 was using HTTPS to setup the repo URL, so it should fix the issue.

Now everything is ok: https://ci.jenkins.io/blue/organizations/jenkins/jenkinsci-libraries%2Fplugin-compat-tester/detail/PR-303/4/pipeline/

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
