### PR TITLE
Remove adhoc dependency replacement for maven-plugin

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -1020,7 +1020,7 @@ public class PluginCompatTester {
 
             if (!toAdd.isEmpty() || !toReplace.isEmpty() || !toAddTest.isEmpty() || !toReplaceTest.isEmpty()) {
                 System.out.println("Adding/replacing plugin dependencies for compatibility: " + toAdd + " " + toReplace + "\nFor test: " + toAddTest + " " + toReplaceTest);
-                pom.addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, convertFromTestDep);
+                pom.addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, convertFromTestDep);
             }
 
         // TODO(oleg_nenashev): This is a hack, logic above should be refactored somehow (JENKINS-55279)

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -145,7 +145,7 @@ public class MavenPom {
         writeDocument(pom, doc);
     }
 
-    public void addDependencies(Map<String, VersionNumber> toAdd, Map<String, VersionNumber> toReplace, Map<String, VersionNumber> toAddTest, Map<String, VersionNumber> toReplaceTest, VersionNumber coreDep, Map<String, String> pluginGroupIds, List<String> toConvert)
+    public void addDependencies(Map<String, VersionNumber> toAdd, Map<String, VersionNumber> toReplace, Map<String, VersionNumber> toAddTest, Map<String, VersionNumber> toReplaceTest, Map<String, String> pluginGroupIds, List<String> toConvert)
             throws IOException {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
@@ -157,22 +157,6 @@ public class MavenPom {
         Element dependencies = doc.getRootElement().element("dependencies");
         if (dependencies == null) {
             dependencies = doc.getRootElement().addElement("dependencies");
-        }
-
-        for (Element mavenDependency : (List<Element>) dependencies.elements("dependency")) {
-            Element artifactId = mavenDependency.element(ARTIFACT_ID_ELEMENT);
-            if (artifactId == null || !"maven-plugin".equals(artifactId.getTextTrim())) {
-                continue;
-            }
-            Element version = mavenDependency.element(VERSION_ELEMENT);
-            if (version == null || version.getTextTrim().startsWith("${")) {
-                // Prior to 1.532, plugins sometimes assumed they could pick up the Maven plugin version from their parent POM.
-                if (version != null) {
-                    mavenDependency.remove(version);
-                }
-                version = mavenDependency.addElement(VERSION_ELEMENT);
-                version.addText(coreDep.toString());
-            }
         }
 
         Set<String> depsWithoutClassifier = new HashSet<>();

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
@@ -33,7 +33,6 @@ public class MavenPomTest {
         Map<String, VersionNumber> toAddTest = new HashMap<>();
         Map<String, VersionNumber> toReplaceTest = new HashMap<>(ImmutableMap.of("workflow-scm-step", new VersionNumber("2.11"), "workflow-durable-task-step", new VersionNumber("2.35"), "display-url-api", new VersionNumber("2.3.3"), "script-security", new VersionNumber("1.74"), "workflow-cps", new VersionNumber("2.83")));
         toReplaceTest.putAll(ImmutableMap.of("workflow-support", new VersionNumber("3.5"), "workflow-job", new VersionNumber("2.39"), "workflow-basic-steps", new VersionNumber("2.20")));
-        VersionNumber coreDep = new VersionNumber("2.164.3");
         Map<String, String> pluginGroupIds = new HashMap<>(ImmutableMap.of("credentials-binding", "org.jenkins-ci.plugins", "pipeline-build-step", "org.jenkins-ci.plugins", "credentials", "org.jenkins-ci.plugins", "jdk-tool", "org.jenkins-ci.plugins", "snakeyaml-api", "io.jenkins.plugins"));
         pluginGroupIds.putAll(ImmutableMap.of("workflow-step-api", "org.jenkins-ci.plugins.workflow", "plain-credentials", "org.jenkins-ci.plugins", "trilead-api", "org.jenkins-ci.plugins", "command-launcher", "org.jenkins-ci.plugins", "jquery", "org.jenkins-ci.plugins"));
         pluginGroupIds.putAll(ImmutableMap.of("matrix-project", "org.jenkins-ci.plugins", "jquery-detached", "org.jenkins-ci.ui", "ace-editor", "org.jenkins-ci.ui", "git", "org.jenkins-ci.plugins", "workflow-durable-task-step", "org.jenkins-ci.plugins.workflow"));
@@ -45,7 +44,7 @@ public class MavenPomTest {
         pluginGroupIds.putAll(ImmutableMap.of("display-url-api", "org.jenkins-ci.plugins", "token-macro", "org.jenkins-ci.plugins", "script-security", "org.jenkins-ci.plugins", "pipeline-input-step", "org.jenkins-ci.plugins", "branch-api", "org.jenkins-ci.plugins"));
         pluginGroupIds.putAll(ImmutableMap.of("workflow-api", "org.jenkins-ci.plugins.workflow", "git-server", "org.jenkins-ci.plugins"));
         List<String> toConvert = Collections.emptyList();
-        new MavenPom(prj).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, toConvert);
+        new MavenPom(prj).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
 
         assertResourceEqualsXmlFile("credentials-binding-pom-after.xml", pom);
     }
@@ -76,11 +75,10 @@ public class MavenPomTest {
         toReplace.put("workflow-step-api", new VersionNumber("2.24"));
         Map<String, VersionNumber> toAddTest = new HashMap<>();
         Map<String, VersionNumber> toReplaceTest = new HashMap<>();
-        VersionNumber coreDep = new VersionNumber("2.303.1");
         Map<String, String> pluginGroupIds = new HashMap<>();
         pluginGroupIds.put("workflow-step-api", "org.jenkins-ci.plugins.workflow");
         List<String> toConvert = Collections.emptyList();
-        new MavenPom(folder).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, toConvert);
+        new MavenPom(folder).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
         assertResourceEqualsXmlFile("demo-plugin-properties-pom-after.xml", pomFile);
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Highlights
- It tries to remove adhoc dependency replacement for `maven-plugin` from: https://github.com/jenkinsci/plugin-compat-tester/commit/f6cc14065a41fcc1fdf08bafc68750d04e5e133b
- It seems not needed anymore and it is making some invalid dependency version replacement

### Tasks

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
