### PR TITLE
Fix issue on checkout due to GH changes

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -597,6 +597,7 @@ public class PluginCompatTester {
         ScmRepository repository;
         ScmManager scmManager = SCMManagerFactory.getInstance().createScmManager();
         for (String connectionURL: connectionURLs){
+            connectionURL = connectionURL.replace("git://", "https://"); // See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
             System.out.println("Checking out from SCM connection URL : " + connectionURL + " (" + name + "-" + version + ") at tag " + scmTag);
             if (checkoutDirectory.isDirectory()) {
                 FileUtils.deleteDirectory(checkoutDirectory);


### PR DESCRIPTION
### Highlights
- Follow up of https://github.com/jenkinsci/plugin-compat-tester/pull/315
- Before this PR:
```
Checking out from SCM connection URL : scm:git:git://github.com/jenkinsci/bootstrap5-api-plugin.git (bootstrap5-api-5.1.3-3) at tag v5.1.3-3
[INFO] Executing: /bin/sh -c cd '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work' && 'git' 'clone' 'git://github.com/jenkinsci/bootstrap5-api-plugin.git' '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work/bootstrap5-api'
[INFO] Working directory: /jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work
Checking out from SCM connection URL : scm:git:git@github.com:jenkinsci-cert/bootstrap5-api-plugin.git (bootstrap5-api-5.1.3-3) at tag v5.1.3-3
[INFO] Executing: /bin/sh -c cd '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work' && 'git' 'clone' 'git@github.com:jenkinsci-cert/bootstrap5-api-plugin.git' '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work/bootstrap5-api'
[INFO] Working directory: /jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work
Checking out from SCM connection URL : scm:git:git://github.com/jenkinsci-cert/bootstrap5-api-plugin.git (bootstrap5-api-5.1.3-3) at tag v5.1.3-3
[INFO] Executing: /bin/sh -c cd '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work' && 'git' 'clone' 'git://github.com/jenkinsci-cert/bootstrap5-api-plugin.git' '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work/bootstrap5-api'
[INFO] Working directory: /jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work
Error : The git-clone command failed. || Cloning into '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work/bootstrap5-api'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Jan 11, 2022 2:39:53 AM org.jenkins.tools.test.PluginCompatTester testPlugins
SEVERE: Internal error while executing a test for core 2.319.2-cb-8 and plugin bootstrap5-api 5.1.3-3. Please submit a bug to plugin-compat-tester
org.jenkins.tools.test.exception.PluginSourcesUnavailableException: Problem while checking out plugin sources!
	at org.jenkins.tools.test.PluginCompatTester.testPluginAgainst(PluginCompatTester.java:500)
	at org.jenkins.tools.test.PluginCompatTester.testPlugins(PluginCompatTester.java:313)
	at org.jenkins.tools.test.PluginCompatTesterCli.main(PluginCompatTesterCli.java:178)

Caused by: java.lang.RuntimeException: The git-clone command failed. || Cloning into '/jenkins/workspace/builders_URR-pr-builder_master/output-bootstrap5-api/work/bootstrap5-api'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
	at org.jenkins.tools.test.PluginCompatTester.cloneFromSCM(PluginCompatTester.java:615)
	at org.jenkins.tools.test.PluginCompatTester.testPluginAgainst(PluginCompatTester.java:483)
	... 2 more
```
- After this PR:
```
Checking out from SCM connection URL : scm:git:https://github.com/jenkinsci/bootstrap5-api-plugin.git (bootstrap5-api-5.1.3-3) at tag v5.1.3-3
[INFO] Executing: /bin/sh -c cd '/home/imontero/sync/unified-release/output-bootstrap5-api/work' && 'git' 'clone' 'https://github.com/jenkinsci/bootstrap5-api-plugin.git' '/home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api'
[INFO] Working directory: /home/imontero/sync/unified-release/output-bootstrap5-api/work
[INFO] Executing: /bin/sh -c cd '/home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api' && 'git' 'fetch' 'https://github.com/jenkinsci/bootstrap5-api-plugin.git'
[INFO] Working directory: /home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api
[INFO] Executing: /bin/sh -c cd '/home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api' && 'git' 'checkout' 'v5.1.3-3'
[INFO] Working directory: /home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api
[INFO] Executing: /bin/sh -c cd '/home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api' && 'git' 'ls-files'
[INFO] Working directory: /home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api
Processing org.jenkins.tools.test.hook.NodeCleanupBeforeCompileHook
Hook not triggered. Continuing.
Processing org.jenkins.tools.test.hook.MultiParentCompileHook
ene. 11, 2022 10:01:56 A. M. org.jenkins.tools.test.hook.AwsJavaSdkHook isAwsJavaSdkPlugin
ADVERTENCIA: Artifact bootstrap5-api has no parent POM, likely it was incrementalified (JEP-305). Will guess the plugin by artifact ID. FTR JENKINS-55169
ene. 11, 2022 10:01:56 A. M. org.jenkins.tools.test.hook.DeclarativePipelineHook isDPPlugin
ADVERTENCIA: Artifact bootstrap5-api has no parent POM, likely it was incrementalified (JEP-305). Will guess the plugin by artifact ID. FTR JENKINS-55169
ene. 11, 2022 10:01:56 A. M. org.jenkins.tools.test.hook.BlueOceanHook isBOPlugin
ADVERTENCIA: Artifact bootstrap5-api has no parent POM, likely it was incrementalified (JEP-305). Will guess the plugin by artifact ID. FTR JENKINS-55169
Hook not triggered.  Continuing.
running [/usr/bin/mvn, --show-version, --batch-mode, -ntp, --define=failIfNoTests=false, --define=surefire.excludesFile=/home/imontero/sync/unified-release/src/test/resources/pct-surefire-exclusion-list, clean, process-test-classes, -Dmaven.javadoc.skip] in /home/imontero/sync/unified-release/output-bootstrap5-api/work/bootstrap5-api >> /home/imontero/sync/unified-release/output-bootstrap5-api/out/logs/bootstrap5-api/v5.1.3-3_against_org.jenkins-ci.plugins_plugin_2.319.2-cb-8.log
Apache Maven 3.8.2 (ea98e05a04480131370aa0c110b8c54cf726c06f)
Maven home: /opt/apache-maven-3.8.2
Java version: 1.8.0_191, vendor: Oracle Corporation, runtime: /usr/lib/jvm/java-8-oracle/jre
Default locale: es_ES, platform encoding: UTF-8
OS name: "linux", version: "4.15.0-166-generic", arch: "amd64", family: "unix"
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------< io.jenkins.plugins:bootstrap5-api >------------------
[INFO] Building Bootstrap 5 API Plugin 5.1.3-3
[INFO] --------------------------------[ hpi ]---------------------------------

```

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
