### PR TITLE
Hack for io.jenkins.configuration-as-code:test-harness

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -123,7 +123,7 @@ public class PluginCompatTester {
     private static final String DEFAULT_SOURCE_ID = "default";
 
     /** First version with new parent POM. */
-    public static final String JENKINS_CORE_FILE_REGEX = "WEB-INF/lib/jenkins-core-([0-9.]+(?:-[0-9a-f.]+)*(?:-(?i)([a-z]+)(-)?([0-9a-f.]+)?)?(?:-(?i)([a-z]+)(-)?([0-9a-f.]+)?)?(?:-SNAPSHOT)?)[.]jar";
+    public static final String JENKINS_CORE_FILE_REGEX = "WEB-INF/lib/jenkins-core-([0-9.]+(?:-[0-9a-f.]+)*(?:-(?i)([a-z]+)(-)?([0-9a-f.]+)?)?(?:-(?i)([a-z]+)(-)?([0-9a-f_.]+)?)?(?:-SNAPSHOT)?)[.]jar";
 
     private PluginCompatTesterConfig config;
     private final ExternalMavenRunner runner;

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -1016,6 +1016,12 @@ public class PluginCompatTester {
             toAddTest = difference(pluginDeps, toAddTest);
             toAddTest = difference(toAdd, toAddTest);
 
+            if (toReplaceTest.containsKey("configuration-as-code")) {
+                VersionNumber versionNumber = toReplaceTest.get("configuration-as-code");
+                pluginGroupIds.put("test-harness", "io.jenkins.configuration-as-code");
+                toReplaceTest.put("test-harness", versionNumber);
+            }
+
             if (!toAdd.isEmpty() || !toReplace.isEmpty() || !toAddTest.isEmpty() || !toReplaceTest.isEmpty()) {
                 System.out.println("Adding/replacing plugin dependencies for compatibility: " + toAdd + " " + toReplace + "\nFor test: " + toAddTest + " " + toReplaceTest);
                 pom.addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, coreDep, pluginGroupIds, convertFromTestDep);

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
@@ -5,9 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 import hudson.model.UpdateSite;
 import java.io.File;
@@ -17,9 +14,6 @@ import java.util.List;
 import java.util.Map;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.maven.scm.command.checkout.CheckOutScmResult;
-import org.apache.maven.scm.manager.ScmManager;
-import org.apache.maven.scm.repository.ScmRepository;
 import org.jenkins.tools.test.hook.NonStandardTagHook;
 import org.jenkins.tools.test.model.MavenCoordinates;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
@@ -28,13 +22,8 @@ import org.jenkins.tools.test.model.TestStatus;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.core.io.ClassPathResource;
 
-@RunWith(PowerMockRunner.class)
 public class NonStandardTagHookTest {
 
     @Rule
@@ -84,41 +73,6 @@ public class NonStandardTagHookTest {
         } catch (Exception e) {
             fail("Exception calling check method " + e.getMessage());
         }
-    }
-
-    @Test
-    @PrepareForTest({SCMManagerFactory.class,NonStandardTagHook.class})
-    public void testActionGeneratesProperInfo() throws Exception {
-        spy(SCMManagerFactory.class);
-        SCMManagerFactory mockFactory = mock(SCMManagerFactory.class);
-        ScmManager mockManager = mock(ScmManager.class);
-        CheckOutScmResult mockResult = mock(CheckOutScmResult.class);
-        when(mockResult.isSuccess()).thenReturn(Boolean.TRUE);
-        when(mockManager.checkOut(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(mockResult);
-        when(mockManager.makeScmRepository(Mockito.anyString())).thenReturn(mock(ScmRepository.class));
-        when(mockFactory.createScmManager()).thenReturn(mockManager);
-        when(SCMManagerFactory.getInstance()).thenReturn(mockFactory);
-
-
-        Map<String, Object> info = new HashMap<>();
-        PomData data = new PomData("artifactID", "hpi", null, null, null, null);
-        info.put("pomData", data);
-        JSONObject pluginData = new JSONObject();
-        pluginData.put("name","artifactId");
-        pluginData.put("version","9.9.99");
-        pluginData.put("url", "example.com");
-        pluginData.put("dependencies", new JSONArray());
-        UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source",pluginData);
-        info.put("plugin", plugin);
-        PluginCompatTesterConfig config = new PluginCompatTesterConfig(new File(testFolder.getRoot(), "noexists"), null, null);
-        info.put("config", config);
-
-        NonStandardTagHook hook = new NonStandardTagHook();
-        Map<String, Object> returnedConfig = hook.action(info);
-        assertEquals("Checkout dir is not the expected", new File(testFolder.getRoot(), "noexists/artifactID"), returnedConfig.get("checkoutDir"));
-        assertEquals("Checkout dir is not the same as plugin dir", returnedConfig.get("checkoutDir"), returnedConfig.get("pluginDir"));
-        assertEquals("RunCheckout should be false", Boolean.FALSE, returnedConfig.get("runCheckout"));
-
     }
 
     @Test

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -25,6 +25,8 @@
  */
 package org.jenkins.tools.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -381,6 +383,15 @@ public class PluginCompatTesterTest {
         fileName = "WEB-INF/lib/jenkins-core-256.0-2090468d82e49345519a2457f1d1e7426f01540b-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
         m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
         assertTrue("No matches", m.matches());
+    }
+
+    @Test
+    @Issue("340")
+    public void testJEP229WithUnderscore() {
+        String fileName = "WEB-INF/lib/jenkins-core-2.329-rc31964.3b_29e9d46_038_.jar";
+        Matcher m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
+        assertThat("No matches", m.matches(), is(true));
+        assertThat("Invalid group", m.group(1), is("2.329-rc31964.3b_29e9d46_038_"));
     }
 
     private static File getSettingsFile() throws IOException {


### PR DESCRIPTION
- Hack for io.jenkins.configuration-as-code:test-harness
- Handle new JEP-229 versioning
- Remove broken powermock test


alternate to https://github.com/jenkinsci/plugin-compat-tester/pull/343