### PR TITLE
Test a non-bundled plugin using localCheckout

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -231,6 +231,19 @@ public class PluginCompatTester {
             throw new IOException("List of plugins to check is empty, it is not possible to run PCT");
         }
 
+        // if there is only one plugin and it's not already resolved (not in the war, not in a bom and not in an update center)
+        // and there is a local checkout available then it needs to be added to the plugins to check
+        if (onlyOnePluginIncluded() && localCheckoutProvided() && !pluginsToCheck.containsKey(config.getIncludePlugins().get(0))) {
+            String artifactId = config.getIncludePlugins().get(0);
+            try {
+                Plugin extracted = extractFromLocalCheckout();
+                pluginsToCheck.put(artifactId, extracted);
+            } catch (PluginSourcesUnavailableException e) {
+                LOGGER.log(Level.SEVERE, String.format("Local checkout provided by plugin sources are not available. Cannot test plugin [%s]", artifactId));
+            }
+        }
+
+
         PluginCompatReport report = PluginCompatReport.fromXml(config.reportFile);
 
         SortedSet<MavenCoordinates> testedCores = config.getWar() == null ? generateCoreCoordinatesToTest(data, report) : coreVersionFromWAR(data);
@@ -387,6 +400,16 @@ public class PluginCompatTester {
         }
 
         return report;
+    }
+
+    private Plugin extractFromLocalCheckout() throws PluginSourcesUnavailableException {
+        PomData data = new PluginRemoting(new File(config.getLocalCheckoutDir(), "pom.xml")).retrievePomData();
+        JSONObject o = new JSONObject();
+        o.put("name", data.artifactId);
+        o.put("version", ""); // TODO retrieve version
+        o.put("url", data.getConnectionUrl());
+        o.put("dependencies", new JSONArray());
+        return new UpdateSite(DEFAULT_SOURCE_ID, null).new Plugin(DEFAULT_SOURCE_ID, o);
     }
 
     protected void generateHtmlReportFile() throws IOException {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -406,7 +406,7 @@ public class PluginCompatTester {
         PomData data = new PluginRemoting(new File(config.getLocalCheckoutDir(), "pom.xml")).retrievePomData();
         JSONObject o = new JSONObject();
         o.put("name", data.artifactId);
-        o.put("version", ""); // TODO retrieve version
+        o.put("version", ""); // version is not required
         o.put("url", data.getConnectionUrl());
         o.put("dependencies", new JSONArray());
         return new UpdateSite(DEFAULT_SOURCE_ID, null).new Plugin(DEFAULT_SOURCE_ID, o);

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -239,7 +239,7 @@ public class PluginCompatTester {
                 Plugin extracted = extractFromLocalCheckout();
                 pluginsToCheck.put(artifactId, extracted);
             } catch (PluginSourcesUnavailableException e) {
-                LOGGER.log(Level.SEVERE, String.format("Local checkout provided by plugin sources are not available. Cannot test plugin [%s]", artifactId));
+                LOGGER.log(Level.SEVERE, String.format("Local checkout provided but plugin sources are not available. Cannot test plugin [%s]", artifactId));
             }
         }
 


### PR DESCRIPTION
This allows to run the PCT on a plugin which is not bundled in the
war, not in an Update Center and not coming from a BOM (those are the 3
possible cases implemented until now).

There are 2 uses cases for this:
1. Run the PCT on a plugin which is still under development
2. Run the PCT on a plugin which is released but not bundled in the war
and not in the UC (because its code is not open source)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
