### PR TITLE
Pass `--errors` to Maven invocations

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -57,6 +57,7 @@ public class ExternalMavenRunner implements MavenRunner {
         cmd.add(mvn != null ? mvn.getAbsolutePath() : "mvn");
         cmd.add("--show-version");
         cmd.add("--batch-mode");
+        cmd.add("--errors");
         cmd.add(DISABLE_DOWNLOAD_LOGS);
         if (config.userSettingsFile != null) {
             cmd.add("--settings=" + config.userSettingsFile);


### PR DESCRIPTION
https://github.com/jenkinsci/bom/issues/895#issuecomment-1048034314

Without this patch, you just get a cryptic

```
java.lang.NoClassDefFoundError: com/google/common/io/NullOutputStream: com.google.common.io.NullOutputStream
```

With it, the problem can be tracked down to Surefire introspection:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test (default-cli) on project script-security: Execution default-cli of goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test failed: java.lang.NoClassDefFoundError: com/google/common/io/NullOutputStream: com.google.common.io.NullOutputStream -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test (default-cli) on project script-security: Execution default-cli of goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test failed: java.lang.NoClassDefFoundError: com/google/common/io/NullOutputStream
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at …
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at …
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test failed: java.lang.NoClassDefFoundError: com/google/common/io/NullOutputStream
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
    at …
Caused by: org.apache.maven.surefire.util.SurefireReflectionException: java.lang.NoClassDefFoundError: com/google/common/io/NullOutputStream
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray (ReflectionUtils.java:177)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeGetter (ReflectionUtils.java:76)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeGetter (ReflectionUtils.java:70)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.getSuites (ProviderFactory.java:145)
    at org.apache.maven.plugin.surefire.booterclient.ForkStarter.getSuitesIterator (ForkStarter.java:718)
    at org.apache.maven.plugin.surefire.booterclient.ForkStarter.runSuitesForkPerTestSet (ForkStarter.java:420)
    at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run (ForkStarter.java:301)
    at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run (ForkStarter.java:249)
    at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider (AbstractSurefireMojo.java:1217)
    at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked (AbstractSurefireMojo.java:1063)
    at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute (AbstractSurefireMojo.java:889)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at …
Caused by: java.lang.NoClassDefFoundError: com/google/common/io/NullOutputStream
    at java.lang.Class.getDeclaredMethods0 (Native Method)
    at java.lang.Class.privateGetDeclaredMethods (Class.java:2701)
    at java.lang.Class.privateGetMethodRecursive (Class.java:3048)
    at java.lang.Class.getMethod0 (Class.java:3018)
    at java.lang.Class.getMethod (Class.java:1784)
    at org.apache.maven.surefire.util.ReflectionUtils.tryGetMethod (ReflectionUtils.java:60)
    at org.apache.maven.surefire.common.junit3.JUnit3TestChecker.isSuiteOnly (JUnit3TestChecker.java:66)
    at org.apache.maven.surefire.common.junit3.JUnit3TestChecker.isValidJUnit3Test (JUnit3TestChecker.java:61)
    at org.apache.maven.surefire.common.junit3.JUnit3TestChecker.accept (JUnit3TestChecker.java:56)
    at org.apache.maven.surefire.common.junit4.JUnit4TestChecker.accept (JUnit4TestChecker.java:53)
    at org.apache.maven.surefire.util.DefaultScanResult.applyFilter (DefaultScanResult.java:102)
    at org.apache.maven.surefire.junit4.JUnit4Provider.scanClassPath (JUnit4Provider.java:309)
    at org.apache.maven.surefire.junit4.JUnit4Provider.getSuites (JUnit4Provider.java:303)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray (ReflectionUtils.java:169)
    at …
Caused by: java.lang.ClassNotFoundException: com.google.common.io.NullOutputStream
    at java.net.URLClassLoader.findClass (URLClassLoader.java:387)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:418)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:351)
    at org.apache.maven.surefire.booter.IsolatedClassLoader.loadClass (IsolatedClassLoader.java:100)
    at java.lang.Class.getDeclaredMethods0 (Native Method)
    at java.lang.Class.privateGetDeclaredMethods (Class.java:2701)
    at java.lang.Class.privateGetMethodRecursive (Class.java:3048)
    at java.lang.Class.getMethod0 (Class.java:3018)
    at java.lang.Class.getMethod (Class.java:1784)
    at org.apache.maven.surefire.util.ReflectionUtils.tryGetMethod (ReflectionUtils.java:60)
    at …
```
