### PR TITLE
Fix dependency resolution when using java 11

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -1100,6 +1100,10 @@ public class PluginCompatTester {
             // Remove the self-dependency if any
             pom.removeDependency(pluginGroupIds.get(thisPlugin), thisPlugin);
         }
+        else {
+            // bad, we should always find a core dependency!
+            throw new PomTransformationException("No jenkins core dependency found, aborting!", new Throwable());
+        }
     }
     private void checkDefinedDeps(Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,Plugin> otherPlugins) {
         checkDefinedDeps(pluginList, adding, replacing, otherPlugins, new ArrayList<>(), null);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
newer versions of maven (3.8.x) produce slightly different output format when doing `mvn dependency:tree` which broke the existing regexes used to  determine what `jenkins-core` is used, as well as determining dependencies in test scope.  As a result, when using JDK11 pct tests were using the dependencies from the plugin being tested instead of the plugins contained in the .war file.

ex. 
JDK11
` [INFO]org.jenkins-ci.main:jenkins-core:jar:2.332.1-cb-1:provided--modulejenkins.core(auto)`

JDK8
`[INFO]org.jenkins-ci.main:jenkins-core:jar:2.332.1-cb-1:provided`

This PR fixes that by making the regex more robust (ie. don't care if there is some trailing text) and also adds a conditional to throw an exception if no jenkins core-dependency was found.  This should hopefully help us catch this earlier if it happens again.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
