### PR TITLE
Support running with Java 17

### DIFF
--- a/plugins-compat-tester-cli/pom.xml
+++ b/plugins-compat-tester-cli/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,6 +15,18 @@
   <build>
     <finalName>${project.artifactId}</finalName>
 	  <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.2.2</version>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Add-Opens>java.base/java.lang.reflect java.base/java.text java.base/java.util java.desktop/java.awt.font</Add-Opens>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
### Steps to reproduce

Run PCT with Java 17, for example: `java -jar pct.jar -war megawar.war -includePlugins workflow-job -workDirectory pct-work -reportFile pct-report.xml`

### Expected results

PCT runs to completion.

### Actual results

PCT fails with

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        at com.thoughtworks.xstream.XStream.setupConverters(XStream.java:811)
        at com.thoughtworks.xstream.XStream.<init>(XStream.java:574)
        at com.thoughtworks.xstream.XStream.<init>(XStream.java:496)
        at com.thoughtworks.xstream.XStream.<init>(XStream.java:465)
        at com.thoughtworks.xstream.XStream.<init>(XStream.java:411)
        at com.thoughtworks.xstream.XStream.<init>(XStream.java:378)
        at hudson.util.XStream2.<init>(XStream2.java:94)
        at org.jenkins.tools.test.model.PluginCompatReport.createXStream(PluginCompatReport.java:184)
        at org.jenkins.tools.test.model.PluginCompatReport.fromXml(PluginCompatReport.java:167)
        at org.jenkins.tools.test.PluginCompatTester.testPlugins(PluginCompatTester.java:233)
        at org.jenkins.tools.test.PluginCompatTesterCli.main(PluginCompatTesterCli.java:178)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible: module java.base does not "opens java.util" to unnamed module @53c4a559
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
        at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
        at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
        at com.thoughtworks.xstream.core.util.Fields.locate(Fields.java:39)
        at com.thoughtworks.xstream.converters.collections.TreeMapConverter.<clinit>(TreeMapConverter.java:50)
        ... 11 more
```

### Evaluation

PCT performs reflective operations that are not allowed with Java 17 modularity rules.

### Workaround

Rather than running `java -jar pct.jar`, run `java --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.desktop/java.awt.font=ALL-UNNAMED -jar pct.jar`.

The list of `--add-opens` directives was discovered iteratively by continuing to run PCT and adding new directives until it passed. Each one of these directives is necessary; if a single one is removed, failures begin to occur.

### Solution

Update the `MANIFEST.MF` file in the CLI to include the `--add-opens` directives that are needed to run PCT with Java 17. See [Breaking encapsulation](https://openjdk.java.net/jeps/261#Breaking-encapsulation) for more information.

### Testing done

Reproduced the problem with the steps described above. Could no longer reproduce the problem after this PR.

Using the workaround, I successfully ran PCT against all plugins in the plugin BOM in jenkinsci/bom#935.

### Note

I am well aware that due to jenkinsci/bom#657, it will not be trivial to adopt this fix in `jenkinsci/bom`. I do not intend to resolve jenkinsci/bom#657 in order to deploy this fix; rather, I intend to implement the workaround described above until such a time that jenkinsci/bom#657 is resolved.