### PR TITLE
Correctly split Maven properties with equals signs

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -161,9 +161,9 @@ public class PluginCompatTesterCli {
             String[] split = options.getMavenProperties().split("\\s*:\\s*");
             Map<String, String> mavenProps = new HashMap<>(split.length);
             for (String expr : split) {
-                String[] split2 = expr.split("=");
+                String[] split2 = expr.split("=", 2);
                 String key = split2[0];
-                String value = split2.length >= 2 ? split2[1] : null;
+                String value = split2.length == 2 ? split2[1] : null;
                 mavenProps.put(key, value);
             }
             config.setMavenProperties(mavenProps);


### PR DESCRIPTION
### Steps to reproduce

Run PCT with e.g. `java -jar pct.jar -war jenkinsci/bom/target/local-test/megawar.war -includePlugins script-security -workDirectory jenkinsci/bom/target/local-test/pct-work -mavenProperties 'jth.jenkins-war.path=jenkinsci/bom/target/local-test/megawar.war:forkCount=.75C:surefire.excludesFile=jenkinsci/bom/target/local-test/excludes.txt:test=org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.GenericWhitelistTest:skipTests:argLine=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED' -reportFile jenkinsci/bom/target/local-test/pct-report.xml`.

### Expected results

**Note:** These are the _actual_ results when the `argList` property is passed via `-mavenPropertiesFile` rather than `-mavenProperties`.

PCT runs to completion.

### Actual results

Maven gets `argLine` set to `--add-opens java.base/java.lang` and later fails because this is not valid syntax.

### Evaluation

PCT is incorrectly splitting the string.

### Workaround

Rather than passing such a property with `-mavenProperties`, pass it in via `-mavenPropertiesFile`. This is inconvenient, but it avoids the parsing bug.

### Solution

Split the string first on colons, then on the first equals sign.

### Testing done

Reproduced the problem with the steps described above. Could no longer reproduce the problem after this PR.

Using the workaround, I successfully ran PCT against all plugins in the plugin BOM in jenkinsci/bom#935.

### Note

I am well aware that due to jenkinsci/bom#657, it will not be trivial to adopt this fix in `jenkinsci/bom`. I do not intend to resolve jenkinsci/bom#657 in order to deploy this fix; rather, I intend to implement the workaround described above until such a time that jenkinsci/bom#657 is resolved.