### PR TITLE
Propagate Maven properties updated from any before execution hook

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -594,7 +594,9 @@ public class PluginCompatTester {
             pcth.runBeforeExecution(forExecutionHooks);
             args = (List<String>)forExecutionHooks.get("args");
             Set<String> types = new HashSet<>((List<String>) forExecutionHooks.get("types"));
-            userProperties.put("types", String.join(",", types));
+            PluginCompatTesterConfig afterHookExecution = ((PluginCompatTesterConfig) forExecutionHooks.get("config"));
+            mconfig.userProperties.putAll(afterHookExecution.retrieveMavenProperties());
+            mconfig.userProperties.put("types", String.join(",", types));
 
             // Execute with tests
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, args.toArray(new String[args.size()]));


### PR DESCRIPTION
Make it feasible to update any Maven properties via PluginCompatTesterBeforeExecution hook

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
