### PR TITLE
chore(Jenkinsfile) switch WAR download to https://get.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ itBranches['buildtriggerbadge:2.11 tests success on JDK11'] = {
 
         stage('Download Jenkins 2.164.1') {
             sh '''
-            curl -sL http://mirrors.jenkins.io/war-stable/2.164.1/jenkins.war --output jenkins.war
+            curl --silent --show-error --location https://get.jenkins.io/war-stable/2.164.1/jenkins.war --output jenkins.war
             echo "65543f5632ee54344f3351b34b305702df12393b3196a95c3771ddb3819b220b jenkins.war" | sha256sum --check
             '''
         }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2888

This change also uses long flags for `curl` and shows if an error happens during the download (easier to diagnose)

Checked locally that it keeps the same behavior:

```bash
➜ curl --silent --show-error --location https://get.jenkins.io/war-stable/2.164.1/jenkins.war --output jenkins.war
➜ echo "65543f5632ee54344f3351b34b305702df12393b3196a95c3771ddb3819b220b jenkins.war" | sha256sum --check
jenkins.war: OK
➜ date
Thu May  5 12:20:52 CEST 2022
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
~- [ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
