### PR TITLE
Clean out local repo before checking out from a different URL

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -2,6 +2,7 @@ package org.jenkins.tools.test.hook;
 
 import hudson.model.UpdateSite;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import org.apache.maven.scm.manager.ScmManager;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.repository.ScmRepositoryException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.FileUtils;
 import org.jenkins.tools.test.PluginCompatTester;
 import org.jenkins.tools.test.SCMManagerFactory;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
@@ -80,7 +82,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
     }
 
     private void cloneFromSCM(UpdateSite.Plugin currentPlugin, File parentPath, String scmTag, String url, String fallbackGitHubOrganization)
-            throws ComponentLookupException, ScmRepositoryException, NoSuchScmProviderException, ScmException {
+            throws ComponentLookupException, ScmRepositoryException, NoSuchScmProviderException, ScmException, IOException {
         
         List<String> connectionURLs = new ArrayList<String>();
         connectionURLs.add(url);
@@ -97,6 +99,9 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
                 connectionURL = connectionURL.replace("git://", "https://"); // See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
             }
             System.out.println("Checking out from SCM connection URL: " + connectionURL + " (" + getParentProjectName() + "-" + currentPlugin.version + ") at tag " + scmTag);
+            if (parentPath.isDirectory()) {
+                FileUtils.deleteDirectory(parentPath);
+            }
             repository = scmManager.makeScmRepository(connectionURL);
             CheckOutScmResult result = scmManager.checkOut(repository, new ScmFileSet(parentPath), new ScmTag(scmTag));
             if(result.isSuccess()){


### PR DESCRIPTION
Follow-up to #338.

An issue was found when using fallback org with multi-parent hook.

Consider the following scenario
- the connection URL for the blueocean plugins is `scm:git:https://github.com/jenkinsci/blueocean-plugin.git`
- the fallback org is `myOrg`
- the target tag `myTag` only exists in `myOrg`

Expected behavior:
- process the repo with the default connection URL (`scm:git:git@github.com:jenkinsci/blueocean-plugin.git`) by cloning repo with URL, fetching tags, checking out `myTag`
- if/when that fails, process the fallback connection URL (`scm:git:git@github.com:myOrg/blueocean-plugin.git`) by cloning repo with that URL, fetching tags, checking out `myTag`

Actual behavior:
- process the repo with the default connection URL (`scm:git:git@github.com:jenkinsci/blueocean-plugin.git`) by cloning repo with that URL, fetching tags, checking out `myTag`
- when that fails,  process the fallback connection URL (`scm:git:git@github.com:myOrg/blueocean-plugin.git`). However, the repo was not cloned from with the respective URL. Instead, the existing clone was re-used. Naturally, checkout of the target tag would still fail, even though the tag exists on the fallback org. Consequently, the `fallbackGitHubOrganization` parameter has no actual effect.
 
The cause appears to be that the multi-parent hook implementation is missing this respective step in the standard execution, where the repo directory is cleared before a subsequent connection URL is processed: https://github.com/jenkinsci/plugin-compat-tester/blob/460dafbc42af5819decf9d9c599e301a0664d031/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java#L604-L606


<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
