### PR TITLE
Support for excluding hooks

### DIFF
--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -89,6 +89,11 @@ public class CliOptions {
                     "If not set, see includePlugins behaviour.")
     private String excludePlugins = null;
 
+    @Parameter(names = "-excludeHooks",
+            description = "Comma separated list of hooks to NOT execute.\n" +
+                    "If not set, all hooks will be executed.")
+    private String excludeHooks = null;
+
     @Parameter(names = "-fallbackGitHubOrganization",
             description = "Include an alternative organization to use as a fallback to download the plugin.\n" +
                     "It is useful to use your own fork releases for an specific plugin if the " +
@@ -203,6 +208,10 @@ public class CliOptions {
 
     public String getExcludePlugins() {
         return excludePlugins;
+    }
+
+    public String getExcludeHooks() {
+        return excludeHooks;
     }
 
     public String getFallbackGitHubOrganization() {

--- a/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/plugins-compat-tester-cli/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -114,6 +114,9 @@ public class PluginCompatTesterCli {
         if(options.getExcludePlugins() != null && !options.getExcludePlugins().isEmpty()){
             config.setExcludePlugins(Arrays.asList(options.getExcludePlugins().toLowerCase().split(",")));
         }
+        if(options.getExcludeHooks() != null && !options.getExcludeHooks().isEmpty()){
+            config.setExcludeHooks(Arrays.asList(options.getExcludeHooks().split(",")));
+        }
         if(options.getSkipTestCache() != null){
             config.setSkipTestCache(Boolean.parseBoolean(options.getSkipTestCache()));
         }

--- a/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/plugins-compat-tester-model/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -102,6 +102,10 @@ public class PluginCompatTesterConfig {
     // If null, tests will be performed on every includePlugins found
     private List<String> excludePlugins = null;
 
+    // List of hooks that will not be executed
+    // If null, all hooks will be executed
+    private List<String> excludeHooks = null;
+
     // URL to be used as an alternative to download plugin source from fallback
     // organtizations, like your own fork
     private String fallbackGitHubOrganization = null;
@@ -245,6 +249,14 @@ public class PluginCompatTesterConfig {
 
     public void setExcludePlugins(List<String> excludePlugins) {
         this.excludePlugins = excludePlugins;
+    }
+
+    public List<String> getExcludeHooks() {
+        return excludeHooks;
+    }
+
+    public void setExcludeHooks(List<String> excludeHooks) {
+        this.excludeHooks = excludeHooks;
     }
 
     public String getFallbackGitHubOrganization() {

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -95,6 +95,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
 import org.jenkins.tools.test.exception.PomExecutionException;
 import org.jenkins.tools.test.exception.ExecutedTestNamesSolverException;
+import org.jenkins.tools.test.hook.TransformPom;
 import org.jenkins.tools.test.maven.ExternalMavenRunner;
 import org.jenkins.tools.test.model.MavenBom;
 import org.jenkins.tools.test.maven.MavenRunner;
@@ -176,7 +177,7 @@ public class PluginCompatTester {
             splitCycles = HISTORICAL_SPLIT_CYCLES;
         }
 
-        PluginCompatTesterHooks pcth = new PluginCompatTesterHooks(config.getHookPrefixes(), config.getExternalHooksJars());
+        PluginCompatTesterHooks pcth = new PluginCompatTesterHooks(config.getHookPrefixes(), config.getExternalHooksJars(), config.getExcludeHooks());
         // Providing XSL Stylesheet along xml report file
         if(config.reportFile != null){
             if(config.isProvideXslReport()){
@@ -561,7 +562,9 @@ public class PluginCompatTester {
             // Much simpler to do use the parent POM to set up the test classpath.
             MavenPom pom = new MavenPom(pluginCheckoutDir);
             try {
+              if (config.getExcludeHooks() != null && !config.getExcludeHooks().contains(TransformPom.class.getName())) {
                 addSplitPluginDependencies(plugin.name, mconfig, pluginCheckoutDir, pom, otherPlugins, pluginGroupIds, coreCoordinates.version, overridenPlugins, parentFolder);
+              }
             } catch (PomTransformationException x) {
                 throw x;
             }

--- a/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/plugins-compat-tester/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -246,6 +246,7 @@ public class PluginCompatTesterTest {
 
         config.setIncludePlugins(includedPlugins);
         config.setExcludePlugins(Collections.emptyList());
+        config.setExcludeHooks(Collections.emptyList());
         config.setSkipTestCache(true);
         config.setCacheThresholdStatus(TestStatus.TEST_FAILURES);
         config.setTestCacheTimeout(345600000);


### PR DESCRIPTION
This PR adds an `-excludeHooks` option, which can be used to exclude any specific hooks from running. My immediate use case is to exclude the `org.jenkins.tools.test.hook.TransformPom` hook to test JENKINS-45047, but I think this generic change has independent value for a number of possible future use cases. For example, one could use this to exclude unnecessary hooks while testing changes to improve the speed of local testing.

### Testing done

I have been running this code successfully for a while now while testing JENKINS-45047.