### PR TITLE
Teach PCT about Mina SSHD API plugins

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MinaSshdApi.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MinaSshdApi.java
@@ -1,0 +1,37 @@
+package org.jenkins.tools.test.hook;
+
+import hudson.model.UpdateSite;
+import java.util.Map;
+import org.jenkins.tools.test.model.PomData;
+
+public class MinaSshdApi extends AbstractMultiParentHook {
+
+    @Override
+    protected String getParentFolder() {
+        return "mina-sshd-api-plugin";
+    }
+
+    @Override
+    protected String getParentProjectName() {
+        return "mina-sshd-api-parent";
+    }
+
+    @Override
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin){
+        return currentPlugin.getDisplayName();
+    }
+
+    @Override
+    public boolean check(Map<String, Object> info) {
+        return isMinaSshdApiPlugin(info);
+    }
+
+    private boolean isMinaSshdApiPlugin(Map<String, Object> moreInfo) {
+        PomData data = (PomData) moreInfo.get("pomData");
+        return isMinaSshdApiPlugin(data);
+    }
+
+    private boolean isMinaSshdApiPlugin(PomData data) {
+        return data.groupId.equals("io.jenkins.plugins.mina-sshd-api");
+    }
+}


### PR DESCRIPTION
Discovered when running BOM/PCT tests with recent PCT bits in https://github.com/jenkinsci/bom/pull/1059: although current BOM `master` builds appear fine with regard to the Mina SSHD API plugins, they are using an ancient and nonstandard version of PCT that fails to report many errors. Recent and unmodified PCT bits show errors like the ones from [this run](https://ci.jenkins.io/job/Tools/job/bom/job/PR-1059/55/) ([specific log](https://ci.jenkins.io/blue/rest/organizations/jenkins/pipelines/Tools/pipelines/bom/branches/PR-1059/runs/55/nodes/350/steps/6265/log/?start=0) for `mina-sshd-api-core`) and `pct-report.xml` contains `<status>INTERNAL_ERROR</status>`.

This PR corrects the specific problem shown above by teaching PCT about the Mina SSHD API plugins, and I tested it in [this run](https://ci.jenkins.io/job/Tools/job/bom/job/PR-1059/57/) (see the corresponding build log for `mina-sshd-api-core`). The build progresses further than before (as demonstrated by comparing the two build logs for `mina-sshd-api-core`), although ultimately the tests for `mina-sshd-api-core` still do not get executed: unlike e.g. `pipeline-stage-view` (which triggers [this code path](https://github.com/jenkinsci/plugin-compat-tester/blob/f035412416dd448b85b472c65202ac6a6b7c50ef/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java#L132%3D=), which works), the Mina SSHD API plugins are in a multi-module Maven project with JEP-229 enabled (which triggers [this code path](https://github.com/jenkinsci/plugin-compat-tester/blob/f035412416dd448b85b472c65202ac6a6b7c50ef/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java#L124-L130=), skipping all tests because they are apparently not supported in multimodule Maven projects with JEP-229 enabled). I filed any latent curiousity about this gap in feature parity between JEP-229 and non-JEP-229 plugins for another day and decided to proceed with the current PR which at least improves the status quo. Besides, this PR is completely risk-free for anything other than the Mina SSHD API plugins, so merging it cannot hurt. And most importantly, it is the last thing standing in my way to completing https://github.com/jenkinsci/bom/pull/1059.