### PR TITLE
Also consider `operations-center-parent-server` a CloudBees parent POM

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java
@@ -41,7 +41,8 @@ public class TransformPom extends PluginCompatTesterHookBeforeExecution {
             isCB = parent.matches("com.cloudbees.jenkins.plugins", "jenkins-plugins") ||
                     // TODO ought to analyze the chain of parent POMs, which would lead to com.cloudbees.jenkins.plugins:jenkins-plugins in this case:
                     parent.matches("com.cloudbees.operations-center.common", "operations-center-parent") ||
-                    parent.matches("com.cloudbees.operations-center.client", "operations-center-parent-client");
+                    parent.matches("com.cloudbees.operations-center.client", "operations-center-parent-client") ||
+                    parent.matches("com.cloudbees.operations-center.server", "operations-center-parent-server");
             parentV2 = parent.compareVersionTo("2.0") >= 0;
             parentUnder233 = parentV2 && parent.compareVersionTo(PLUGINS_PARENT_POM_FOR_CORE_WITHOUT_WAR_TEST) < 0;
         } else {


### PR DESCRIPTION
No idea how CloudBees ran PCT for years without it.

```
[FATAL] Non-resolvable parent POM for org.jenkins-ci.plugins:operations-center-server:2.346.0.6-SNAPSHOT: org.jenkins-ci.plugins:plugin:pom:2.357.1-cb-1 was not found in … and 'parent.relativePath' points at wrong local POM @ line 9, column 11
```

after `TransformPom` rewrote the `<parent>` to point to OSS `plugin-pom` in a crazy way. :shrug:
