### PR TITLE
Fix unmodified pomfile

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -560,9 +560,7 @@ public class PluginCompatTester {
             // Much simpler to do use the parent POM to set up the test classpath.
             MavenPom pom = new MavenPom(pluginCheckoutDir);
             try {
-              if (config.getExcludeHooks() != null && !config.getExcludeHooks().contains(TransformPom.class.getName())) {
                 addSplitPluginDependencies(plugin.name, mconfig, pluginCheckoutDir, pom, otherPlugins, pluginGroupIds, coreCoordinates.version, overridenPlugins, parentFolder);
-              }
             } catch (PomTransformationException x) {
                 throw x;
             }


### PR DESCRIPTION
### Highlights
- This PR tries to fix a weird behavior detected on testing `junit` plugin
- If we launch the PCT CLI with a war file with some dependencies to update (for example: `boostrap5-api` - which is also a dependency of `junit` plugin) the PCT executes the testing without modifying its pomfile which seems wrong
- This is happening if we do not provide any `excludeHooks` and if we provide a `excludeHooks` pointing to `TransformPom`
- This behavior seems wrong and unrelated to the need of executing the `PluginCompatTester#addSplitPluginDependencies` method. Introduced in: https://github.com/jenkinsci/plugin-compat-tester/commit/23e2bcb7a8cb940d3427b16885e5390e28b1adb1#diff-56ea8384acb1f763e2f462f02781e29ee845b4901b11f30bef2bd83ee984d51eR565
- Once applied the change proposed in the PR, we obtain the expected modification in the pomfile:
```
Adding/replacing plugin dependencies for compatibility: { ... bootstrap5-api=5.2.0-1, ...}
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
