### PR TITLE
Add some new configuration key called "compilerArgs" to be able to pass extra Maven arguments to the PCT compile phase

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -46,6 +46,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -548,7 +549,12 @@ public class PluginCompatTester {
             // and ensures that we are testing a plugin binary as close as possible to what was actually released.
             // We also skip potential javadoc execution to avoid general test failure.
             if (!ranCompile) {
-                runner.run(mconfig, pluginCheckoutDir, buildLogFile, "clean", "process-test-classes", "-Dmaven.javadoc.skip");
+                List<String> goals = new ArrayList<>(Arrays.asList("clean", "process-test-classes", "-Dmaven.javadoc.skip"));
+                List<String> compileArgs = (List<String>) beforeCompile.get("compileArgs");
+                if (compileArgs!=null) {
+                    goals.addAll(compileArgs);
+                }
+                runner.run(mconfig, pluginCheckoutDir, buildLogFile, goals.toArray(new String[0]));
             }
             ranCompile = true;
 


### PR DESCRIPTION
Use case is a multi module plugin such:
- shaded-jar
- jenkins-plugin

As the jenkins-plugin is using a shaded jar produced by the shaded jar module, Maven need at least `package` phase to be executed otherwise the jenkins-plugin will not see the shaded jar the compilation error.
The issue happens when using the option -localCheckoutDir (which trigger this test https://github.com/jenkinsci/plugin-compat-tester/blob/13ed8c2365960064dbc164a7bb59af347b0ee16a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java#L138) (I have no idea about the reason of this test).
so there is no way to reach Maven `install` phase here.
This change just introduce a new parameter `compileArgs` which can carry a list of Maven (goals/options)
