### PR TITLE
Remove no-longer-necessary SpotBugs suppressions

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -27,7 +27,6 @@ package org.jenkins.tools.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Functions;
 import hudson.model.UpdateSite;
@@ -135,7 +134,6 @@ public class PluginCompatTester {
     private List<String> splits;
     private Set<String> splitCycles;
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "not mutated after this point I hope")
     public PluginCompatTester(PluginCompatTesterConfig config){
         this.config = config;
         runner = new ExternalMavenRunner(config.getExternalMaven());

--- a/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
@@ -25,7 +25,6 @@
  */
 package org.jenkins.tools.test.exception;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -57,7 +56,6 @@ public class PomExecutionException extends Exception {
         this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.pomWarningMessages, exceptionToCopy.testDetails);
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "oh well")
     public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, List<String> pomWarningMessages, ExecutedTestNamesDetails testDetails){
         super(message, exceptionsThrown.isEmpty() ? null : exceptionsThrown.iterator().next());
         this.exceptionsThrown = new ArrayList<>(exceptionsThrown);
@@ -79,12 +77,10 @@ public class PomExecutionException extends Exception {
         return strBldr.toString();
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "deliberately mutable")
     public List<String> getPomWarningMessages() {
         return pomWarningMessages;
     }
     
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "oh well")
     public ExecutedTestNamesDetails getTestDetails() {
         return testDetails;
     }

--- a/src/main/java/org/jenkins/tools/test/logging/SystemIOLoggerFilter.java
+++ b/src/main/java/org/jenkins/tools/test/logging/SystemIOLoggerFilter.java
@@ -25,7 +25,6 @@
  */
 package org.jenkins.tools.test.logging;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -53,7 +52,6 @@ public class SystemIOLoggerFilter extends PrintStream {
         return currentPSFile;
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "as designed")
     public static class SystemIOWrapper extends PrintStream {
         private SystemIOLoggerFilter loggerFilter;
         private PrintStream systemIO;

--- a/src/main/java/org/jenkins/tools/test/model/MavenBom.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenBom.java
@@ -1,6 +1,5 @@
 package org.jenkins.tools.test.model;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,7 +29,6 @@ public class MavenBom {
         }
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "so be it")
     public Model getModel() {
         return contents;
     }

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -25,7 +25,6 @@
  */
 package org.jenkins.tools.test.model;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -46,7 +45,6 @@ import org.apache.commons.lang.StringUtils;
  *
  * @author Frederic Camblor
  */
-@SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"}, justification = "limited callers should know not to mutate")
 public class PluginCompatTesterConfig {
 
     private static final Logger LOGGER = Logger.getLogger(PluginCompatTesterConfig.class.getName());

--- a/src/main/java/org/jenkins/tools/test/model/PomData.java
+++ b/src/main/java/org/jenkins/tools/test/model/PomData.java
@@ -25,7 +25,6 @@
  */
 package org.jenkins.tools.test.model;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -66,7 +65,6 @@ public class PomData {
         this.connectionUrl = connectionUrl;
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Deliberately mutable")
     public List<String> getWarningMessages() {
         return warningMessages;
     }

--- a/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
+++ b/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
@@ -25,7 +25,6 @@
  */
 package org.jenkins.tools.test.model;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -47,13 +46,11 @@ public class TestExecutionResult {
         this(pomWarningMessages, new ExecutedTestNamesDetails());
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "oh well")
     public TestExecutionResult(List<String> pomWarningMessages, ExecutedTestNamesDetails testDetails){
         this.pomWarningMessages = Collections.unmodifiableList(pomWarningMessages);
         this.testDetails = testDetails;
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "oh well")
     public ExecutedTestNamesDetails getTestDetails() {
         return testDetails;
     }


### PR DESCRIPTION
These `EI_EXPOSE_REP` errors were suppressed project-wide in a recent parent POM update.