### PR TITLE
Remove dependency on Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,14 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.4</version>
       </dependency>
       <dependency>
-        <groupId>net.java.dev.jna</groupId>
-        <artifactId>jna</artifactId>
-        <version>5.13.0</version>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -57,14 +57,41 @@
       <version>1.82</version>
     </dependency>
     <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.20</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xpp3</groupId>
+          <artifactId>xpp3_min</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
       <version>1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>4.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -72,161 +99,23 @@
       <version>3.8.7</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>2.386</version>
+      <groupId>org.dom4j</groupId>
+      <artifactId>dom4j</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+      <version>1.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke.stapler</groupId>
+      <artifactId>json-lib</artifactId>
+      <version>2.4-jenkins-3</version>
       <exclusions>
-        <exclusion>
-          <groupId>args4j</groupId>
-          <artifactId>args4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.inject</groupId>
-          <artifactId>guice</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.infradna.tool</groupId>
-          <artifactId>bridge-method-annotation</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.solaris</groupId>
-          <artifactId>embedded_su4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.xml.txw2</groupId>
-          <artifactId>txw2</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-jelly</groupId>
-          <artifactId>commons-jelly-tags-fmt</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-jelly</groupId>
-          <artifactId>commons-jelly-tags-xml</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.jenkins.stapler</groupId>
-          <artifactId>jenkins-stapler-support</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jakarta.servlet.jsp.jstl</groupId>
-          <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jaxen</groupId>
-          <artifactId>jaxen</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jline</groupId>
-          <artifactId>jline</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.java.sezpoz</groupId>
-          <artifactId>sezpoz</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sf.kxml</groupId>
-          <artifactId>kxml2</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.antlr</groupId>
-          <artifactId>antlr4-runtime</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.ant</groupId>
-          <artifactId>ant</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-all</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.connectbot.jbcrypt</groupId>
-          <artifactId>jbcrypt</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.fusesource.jansi</groupId>
-          <artifactId>jansi</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>annotation-indexer</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>crypto-util</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>memory-monitor</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jenkins-ci.main</groupId>
-          <artifactId>cli</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jenkins-ci.main</groupId>
-          <artifactId>websocket-spi</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jfree</groupId>
-          <artifactId>jfreechart</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jvnet.hudson</groupId>
-          <artifactId>commons-jelly-tags-define</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jvnet.robust-http-client</groupId>
-          <artifactId>robust-http-client</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jvnet.winp</groupId>
-          <artifactId>winp</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>windows-package-checker</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.kohsuke.jinterop</groupId>
-          <artifactId>j-interop</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.kohsuke.stapler</groupId>
-          <artifactId>stapler-adjunct-codemirror</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.kohsuke.stapler</groupId>
-          <artifactId>stapler-adjunct-timeline</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-analysis</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-commons</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-tree</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-util</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -243,12 +132,32 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.3.25</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/model/UpdateSite.java
+++ b/src/main/java/hudson/model/UpdateSite.java
@@ -1,0 +1,105 @@
+package hudson.model;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import net.sf.json.JSONObject;
+
+public final class UpdateSite {
+
+    /**
+     * In-memory representation of the update center data.
+     */
+    public static final class Data {
+        /**
+         * The {@link UpdateSite} ID.
+         */
+        @NonNull public final String sourceId;
+
+        /**
+         * The latest jenkins.war.
+         */
+        @NonNull public final Entry core;
+
+        /**
+         * Plugins in the repository, keyed by their artifact IDs.
+         */
+        @NonNull
+        public final Map<String, Plugin> plugins = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        public Data(JSONObject o) {
+            this.sourceId = o.getString("id");
+            this.core = new Entry(sourceId, o.getJSONObject("core"));
+            for (Map.Entry<String, JSONObject> e : (Set<Map.Entry<String, JSONObject>>) o.getJSONObject("plugins").entrySet()) {
+                Plugin p = new Plugin(sourceId, e.getValue());
+                plugins.put(e.getKey(), p);
+            }
+        }
+    }
+
+    public static class Entry {
+        /**
+         * {@link UpdateSite} ID.
+         */
+        @NonNull public final String sourceId;
+
+        /**
+         * Artifact ID.
+         */
+        @NonNull public final String name;
+
+        /**
+         * The version.
+         */
+        @NonNull public final String version;
+
+        /**
+         * Download URL.
+         */
+        @NonNull public final String url;
+
+        public Entry(String sourceId, JSONObject o) {
+            this.sourceId = sourceId;
+            this.name = o.getString("name");
+            this.version = o.getString("version");
+            this.url = o.getString("url");
+        }
+    }
+
+    public static class Plugin extends Entry {
+        /**
+         * Human readable title of the plugin.
+         */
+        @CheckForNull public final String title;
+
+        /**
+         * Dependencies of this plugin, a name -&gt; version mapping.
+         */
+        @NonNull public final Map<String, String> dependencies = new HashMap<>();
+
+        /**
+         * Optional dependencies of this plugin.
+         */
+        @NonNull public final Map<String, String> optionalDependencies = new HashMap<>();
+
+        public Plugin(String sourceId, JSONObject o) {
+            super(sourceId, o);
+            this.title = o.optString("title", null);
+            for (Object jo : o.getJSONArray("dependencies")) {
+                JSONObject depObj = (JSONObject) jo;
+                if (Boolean.parseBoolean(depObj.getString("optional"))) {
+                    optionalDependencies.put(depObj.getString("name"), depObj.getString("version"));
+                } else {
+                    dependencies.put(depObj.getString("name"), depObj.getString("version"));
+                }
+            }
+        }
+
+        public final String getDisplayName() {
+            return title != null ? title : name;
+        }
+    }
+}

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -26,10 +26,7 @@
 package org.jenkins.tools.test;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.AbortException;
-import hudson.Functions;
 import hudson.model.UpdateSite;
-import hudson.model.UpdateSite.Plugin;
 import hudson.util.VersionNumber;
 import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import java.io.BufferedReader;
@@ -38,13 +35,16 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
-import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -75,13 +75,12 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.io.RawInputStreamFacade;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
 import org.jenkins.tools.test.exception.PomExecutionException;
@@ -172,8 +171,11 @@ public class PluginCompatTester {
         // Providing XSL Stylesheet along xml report file
         if(config.reportFile != null){
             if(config.isProvideXslReport()){
+                Files.createDirectories(Paths.get(PluginCompatReport.getBaseFilepath(config.reportFile)));
                 File xslFilePath = PluginCompatReport.getXslFilepath(config.reportFile);
-                FileUtils.copyStreamToFile(new RawInputStreamFacade(getXslTransformerResource().getInputStream()), xslFilePath);
+                try (InputStream is = getXslTransformerResource().getInputStream()) {
+                    Files.copy(is, xslFilePath.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
             }
         }
 
@@ -204,7 +206,7 @@ public class PluginCompatTester {
             }
         }
 
-        final Map<String, Plugin> pluginsToCheck;
+        final Map<String, UpdateSite.Plugin> pluginsToCheck;
         final List<String> pluginsToInclude = config.getIncludePlugins();
         if (data.plugins.isEmpty() && pluginsToInclude != null && !pluginsToInclude.isEmpty()) {
             // Update Center returns empty info OR the "-war" option is specified for WAR without bundled plugins
@@ -231,7 +233,7 @@ public class PluginCompatTester {
         if (onlyOnePluginIncluded() && localCheckoutProvided() && !pluginsToCheck.containsKey(config.getIncludePlugins().get(0))) {
             String artifactId = config.getIncludePlugins().get(0);
             try {
-                Plugin extracted = extractFromLocalCheckout();
+                UpdateSite.Plugin extracted = extractFromLocalCheckout();
                 pluginsToCheck.put(artifactId, extracted);
             } catch (PluginSourcesUnavailableException e) {
                 LOGGER.log(Level.SEVERE, "Cannot test {0} because plugin sources are not available despite a local checkout being provided", artifactId);
@@ -251,7 +253,7 @@ public class PluginCompatTester {
         boolean failed = false;
         ROOT_CYCLE: for(MavenCoordinates coreCoordinates : testedCores){
             LOGGER.log(Level.INFO, "Starting plugin tests on core coordinates {0}", coreCoordinates);
-            for (Plugin plugin : pluginsToCheck.values()) {
+            for (UpdateSite.Plugin plugin : pluginsToCheck.values()) {
                 if(config.getIncludePlugins()==null || config.getIncludePlugins().contains(plugin.name.toLowerCase())){
                     PluginInfos pluginInfos = new PluginInfos(plugin.name, plugin.version, plugin.url);
 
@@ -363,7 +365,7 @@ public class PluginCompatTester {
 
                     if(config.reportFile != null){
                         if(!config.reportFile.exists()){
-                            FileUtils.fileWrite(config.reportFile.getAbsolutePath(), "");
+                            FileUtils.touch(config.reportFile);
                         }
                         report.save(config.reportFile);
                     }
@@ -388,20 +390,20 @@ public class PluginCompatTester {
         }
 
         if (failed && config.isFailOnError()) {
-            throw new AbortException("Execution was aborted due to the failure in a plugin test (-failOnError is set)");
+            throw new RuntimeException("Execution was aborted due to the failure in a plugin test (-failOnError is set)");
         }
 
         return report;
     }
 
-    private Plugin extractFromLocalCheckout() throws PluginSourcesUnavailableException {
+    private UpdateSite.Plugin extractFromLocalCheckout() throws PluginSourcesUnavailableException {
         PomData data = new PluginRemoting(new File(config.getLocalCheckoutDir(), "pom.xml")).retrievePomData();
         JSONObject o = new JSONObject();
         o.put("name", data.artifactId);
         o.put("version", ""); // version is not required
         o.put("url", data.getConnectionUrl());
         o.put("dependencies", new JSONArray());
-        return new UpdateSite(DEFAULT_SOURCE_ID, null).new Plugin(DEFAULT_SOURCE_ID, o);
+        return new UpdateSite.Plugin(DEFAULT_SOURCE_ID, o);
     }
 
     protected void generateHtmlReportFile() throws IOException {
@@ -438,7 +440,7 @@ public class PluginCompatTester {
         return String.format("logs/%s/v%s_against_%s_%s_%s.log", pluginName, pluginVersion, coreCoords.groupId, coreCoords.artifactId, coreCoords.version);
     }
 
-    private TestExecutionResult testPluginAgainst(MavenCoordinates coreCoordinates, Plugin plugin, MavenRunner.Config mconfig, PomData pomData, Map<String, Plugin> otherPlugins, Map<String, String> pluginGroupIds, PluginCompatTesterHooks pcth, List<PCTPlugin> overridenPlugins)
+    private TestExecutionResult testPluginAgainst(MavenCoordinates coreCoordinates, UpdateSite.Plugin plugin, MavenRunner.Config mconfig, PomData pomData, Map<String, UpdateSite.Plugin> otherPlugins, Map<String, String> pluginGroupIds, PluginCompatTesterHooks pcth, List<PCTPlugin> overridenPlugins)
             throws PluginSourcesUnavailableException, PomExecutionException, IOException, PomTransformationException {
         LOGGER.log(Level.INFO, "\n\n\n\n\n\n#############################################\n#############################################\n##\n## Starting to test {0} {1} against {2}\n##\n#############################################\n#############################################\n\n\n\n\n", new Object[]{plugin.name, plugin.version, coreCoordinates});
 
@@ -475,7 +477,7 @@ public class PluginCompatTester {
                         File pomLocalCheckoutPluginDir = new File(localCheckoutPluginDir, "pom.xml");
                         if(pomLocalCheckoutPluginDir.exists()) {
                             LOGGER.log(Level.INFO, "Copying plugin directory from {0}", localCheckoutPluginDir.getAbsolutePath());
-                            FileUtils.copyDirectoryStructure(localCheckoutPluginDir, pluginCheckoutDir);
+                            org.codehaus.plexus.util.FileUtils.copyDirectoryStructure(localCheckoutPluginDir, pluginCheckoutDir);
                         } else {
                             cloneFromSCM(pomData, plugin.name, plugin.version, pluginCheckoutDir, "");
                         }
@@ -484,7 +486,7 @@ public class PluginCompatTester {
                         // and even up-to-date versions of org.apache.commons.io.FileUtils seem to not handle links,
                         // so may need to use something like http://docs.oracle.com/javase/tutorial/displayCode.html?code=http://docs.oracle.com/javase/tutorial/essential/io/examples/Copy.java
                         LOGGER.log(Level.INFO, "Copy plugin directory from {0}", config.getLocalCheckoutDir().getAbsolutePath());
-                        FileUtils.copyDirectoryStructure(config.getLocalCheckoutDir(), pluginCheckoutDir);
+                        org.codehaus.plexus.util.FileUtils.copyDirectoryStructure(config.getLocalCheckoutDir(), pluginCheckoutDir);
                     }
                 } else {
                     // These hooks could redirect the SCM, skip checkout (if multiple plugins use the same preloaded repo)
@@ -507,7 +509,7 @@ public class PluginCompatTester {
 
         File buildLogFile = createBuildLogFile(config.reportFile, plugin.name, plugin.version, coreCoordinates);
         FileUtils.forceMkdir(buildLogFile.getParentFile()); // Creating log directory
-        FileUtils.fileWrite(buildLogFile.getAbsolutePath(), ""); // Creating log file
+        FileUtils.touch(buildLogFile); // Creating log file
 
         // Ran the BeforeCompileHooks
         Map<String, Object> beforeCompile = new HashMap<>();
@@ -549,7 +551,9 @@ public class PluginCompatTester {
             }
             catch (Exception x) {
                 LOGGER.log(Level.WARNING, "Failed to transform POM; continuing", x);
-                pomData.getWarningMessages().add(Functions.printThrowable(x));
+                StringWriter sw = new StringWriter();
+                x.printStackTrace(new PrintWriter(sw));
+                pomData.getWarningMessages().add(sw.toString());
                 // but continue
             }
 
@@ -663,7 +667,7 @@ public class PluginCompatTester {
          *     git checkout FETCH_HEAD
          */
         if (checkoutDirectory.isDirectory()) {
-            org.apache.commons.io.FileUtils.deleteDirectory(checkoutDirectory);
+            FileUtils.deleteDirectory(checkoutDirectory);
         }
         Files.createDirectories(checkoutDirectory.toPath());
 
@@ -784,10 +788,9 @@ public class PluginCompatTester {
         }
 
         String json = jsonp.substring(jsonp.indexOf('(')+1,jsonp.lastIndexOf(')'));
-        UpdateSite us = new UpdateSite(DEFAULT_SOURCE_ID, url.toExternalForm());
 
         JSONObject jsonObj = JSONObject.fromObject(json);
-        UpdateSite.Data site = newUpdateSiteData(us, jsonObj);
+        UpdateSite.Data site = new UpdateSite.Data(jsonObj);
 
         // UpdateSite.Plugin does not contain gav object, so we process the JSON object on our own here
         for(Map.Entry<String,JSONObject> e : (Set<Map.Entry<String,JSONObject>>)jsonObj.getJSONObject("plugins").entrySet()) {
@@ -870,7 +873,7 @@ public class PluginCompatTester {
     		top.put("core", new JSONObject().accumulate("name", "core").accumulate("version",core).accumulate("url", "https://foobar"));
     	}
         LOGGER.log(Level.INFO, "Read contents of {0}: {1}", new Object[]{config.getBom(), top});
-    	return newUpdateSiteData(new UpdateSite(DEFAULT_SOURCE_ID, null), top);
+        return new UpdateSite.Data(top);
     }
 
     private List<File> getBomEntries() throws IOException, XmlPullParserException, PomExecutionException {
@@ -881,10 +884,10 @@ public class PluginCompatTester {
 
     	File buildLogFile = new File(config.workDirectory
     			+ File.separator + "bom-download.log");
-    	FileUtils.fileWrite(buildLogFile.getAbsolutePath(), ""); // Creating log file
+    	FileUtils.touch(buildLogFile); // Creating log file
 
     	runner.run(mconfig, fullDepPom.getParentFile(), buildLogFile, "dependency:copy-dependencies", "-P consume-incrementals", "-N");
-    	return FileUtils.getFiles(new File(config.workDirectory, "bom" + File.separator + "target" + File.separator + "dependency"),null, null);
+    	return org.codehaus.plexus.util.FileUtils.getFiles(new File(config.workDirectory, "bom" + File.separator + "target" + File.separator + "dependency"),null, null);
     }
 
     /**
@@ -994,7 +997,7 @@ public class PluginCompatTester {
             throw new IOException("no jenkins-core.jar in " + war);
         }
         LOGGER.log(Level.INFO, "Scanned contents of {0} with {1} plugins", new Object[]{war, plugins.size()});
-        return newUpdateSiteData(new UpdateSite(DEFAULT_SOURCE_ID, null), top);
+        return new UpdateSite.Data(top);
     }
 
     private SortedSet<MavenCoordinates> coreVersionFromWAR(UpdateSite.Data data) {
@@ -1003,16 +1006,6 @@ public class PluginCompatTester {
         return result;
     }
 
-    private UpdateSite.Data newUpdateSiteData(UpdateSite us, JSONObject jsonO) throws RuntimeException {
-        try {
-            Constructor<UpdateSite.Data> dataConstructor = UpdateSite.Data.class.getDeclaredConstructor(UpdateSite.class, JSONObject.class);
-            dataConstructor.setAccessible(true);
-            return dataConstructor.newInstance(us, jsonO);
-        }catch(Exception e){
-            throw new RuntimeException("UpdateSite.Data instantiation problems", e);
-        }
-    }
-    
     /**
      * Provides the Maven module used for a plugin on a {@code mvn [...] -pl} operation in the parent path 
      */
@@ -1040,7 +1033,7 @@ public class PluginCompatTester {
         return null;
     }
 
-    private void addSplitPluginDependencies(String thisPlugin, MavenRunner.Config mconfig, File pluginCheckoutDir, MavenPom pom, Map<String, Plugin> otherPlugins, Map<String, String> pluginGroupIds, String coreVersion, List<PCTPlugin> overridenPlugins, String parentFolder) throws Exception {
+    private void addSplitPluginDependencies(String thisPlugin, MavenRunner.Config mconfig, File pluginCheckoutDir, MavenPom pom, Map<String, UpdateSite.Plugin> otherPlugins, Map<String, String> pluginGroupIds, String coreVersion, List<PCTPlugin> overridenPlugins, String parentFolder) throws Exception {
         File tmp = File.createTempFile("dependencies", ".log");
         VersionNumber coreDep = null;
         Map<String,VersionNumber> pluginDeps = new HashMap<>();
@@ -1145,7 +1138,7 @@ public class PluginCompatTester {
                 VersionNumber splitPoint = new VersionNumber(pieces[1]);
                 VersionNumber declaredMinimum = new VersionNumber(pieces[2]);
                 if (coreDep.compareTo(splitPoint) < 0 && new VersionNumber(coreVersion).compareTo(splitPoint) >=0 && !pluginDeps.containsKey(plugin)) {
-                    Plugin bundledP = otherPlugins.get(plugin);
+                    UpdateSite.Plugin bundledP = otherPlugins.get(plugin);
                     if (bundledP != null) {
                         VersionNumber bundledV;
                         try {
@@ -1187,13 +1180,13 @@ public class PluginCompatTester {
             throw new PomTransformationException("No jenkins core dependency found, aborting!", new Throwable());
         }
     }
-    private void checkDefinedDeps(Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,Plugin> otherPlugins) {
+    private void checkDefinedDeps(Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,UpdateSite.Plugin> otherPlugins) {
         checkDefinedDeps(pluginList, adding, replacing, otherPlugins, new ArrayList<>(), null);
     }
-    private void checkDefinedDeps(Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,Plugin> otherPlugins, List<String> inTest, List<String> toConvertFromTest) {
+    private void checkDefinedDeps(Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,UpdateSite.Plugin> otherPlugins, List<String> inTest, List<String> toConvertFromTest) {
         for (Map.Entry<String,VersionNumber> pluginDep : pluginList.entrySet()) {
             String plugin = pluginDep.getKey();
-            Plugin bundledP = otherPlugins.get(plugin);
+            UpdateSite.Plugin bundledP = otherPlugins.get(plugin);
             if (bundledP != null) {
                 VersionNumber bundledV = new VersionNumber(bundledP.version);
                 if (bundledV.isNewerThan(pluginDep.getValue())) {
@@ -1207,7 +1200,7 @@ public class PluginCompatTester {
                         continue; // already handled
                     }
                     // We ignore the declared dependency version and go with the bundled version:
-                    Plugin depBundledP = otherPlugins.get(depPlugin);
+                    UpdateSite.Plugin depBundledP = otherPlugins.get(depPlugin);
                     if (depBundledP != null) {
                         updateAllDependents(plugin, depBundledP, pluginList, adding, replacing, otherPlugins, inTest, toConvertFromTest);
                     }
@@ -1221,7 +1214,7 @@ public class PluginCompatTester {
      * This helps in cases where tests fail due to new insufficient versions as well as more
      * accurately representing the totality of upgraded plugins for provided war files.
      */
-    private void updateAllDependents(String parent, Plugin dependent, Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,Plugin> otherPlugins, List<String> inTest, List<String> toConvertFromTest) {
+    private void updateAllDependents(String parent, UpdateSite.Plugin dependent, Map<String,VersionNumber> pluginList, Map<String,VersionNumber> adding, Map<String,VersionNumber> replacing, Map<String,UpdateSite.Plugin> otherPlugins, List<String> inTest, List<String> toConvertFromTest) {
         // Check if this exists with an undesired scope
         String pluginName = dependent.name;
         if (inTest.contains(pluginName)) {
@@ -1241,7 +1234,7 @@ public class PluginCompatTester {
             }
 
             // We ignore the declared dependency version and go with the bundled version:
-            Plugin depBundledP = otherPlugins.get(depPlugin);
+            UpdateSite.Plugin depBundledP = otherPlugins.get(depPlugin);
             if (depBundledP != null) {
                 updateAllDependents(pluginName, depBundledP, pluginList, adding, replacing, otherPlugins, inTest, toConvertFromTest);
             }

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -1,7 +1,6 @@
 package org.jenkins.tools.test.maven;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import hudson.Functions;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -21,6 +20,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.SystemUtils;
 import org.jenkins.tools.test.exception.PomExecutionException;
 import org.jenkins.tools.test.util.ExecutedTestNamesSolver;
 
@@ -60,7 +60,7 @@ public class ExternalMavenRunner implements MavenRunner {
         if (mvn != null) {
             cmd.add(mvn.getAbsolutePath());
         } else {
-            cmd.add(Functions.isWindows() ? "mvn.cmd" : "mvn");
+            cmd.add(SystemUtils.IS_OS_WINDOWS ? "mvn.cmd" : "mvn");
         }
         cmd.add("--show-version");
         cmd.add("--batch-mode");

--- a/src/main/java/org/jenkins/tools/test/model/MavenBom.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenBom.java
@@ -11,11 +11,11 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
-import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 public class MavenBom {

--- a/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -44,7 +45,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.plexus.util.FileUtils;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
@@ -83,7 +83,7 @@ public class MavenPom {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         File backupPom = new File(rootDir.getAbsolutePath() + "/" + pomFileName + ".backup");
         try {
-            FileUtils.rename(pom, backupPom);
+            Files.move(pom.toPath(), backupPom.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
             Document doc;
             try {

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
@@ -26,9 +26,8 @@
 package org.jenkins.tools.test.model;
 
 import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.io.xml.Xpp3DomDriver;
+import com.thoughtworks.xstream.io.xml.MXParserDomDriver;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.util.XStream2;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -180,9 +179,10 @@ public class PluginCompatReport {
         return report;
     }
 
-    private static XStream2 createXStream(){
-        XStream2 xstream = new XStream2(new Xpp3DomDriver());
+    private static XStream createXStream(){
+        XStream xstream = new XStream(new MXParserDomDriver());
         xstream.setMode(XStream.NO_REFERENCES);
+        xstream.allowTypes(new Class[] {MavenCoordinates.class, PluginCompatReport.class, PluginCompatResult.class, PluginInfos.class});
         xstream.alias("pluginInfos", PluginInfos.class);
         xstream.alias("coord", MavenCoordinates.class);
         xstream.alias("compatResult", PluginCompatResult.class);

--- a/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/NonStandardTagHookTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.fail;
 
 import hudson.model.UpdateSite;
 import java.io.File;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +47,7 @@ public class NonStandardTagHookTest {
         pluginData.put("version", "1.1.8");
         pluginData.put("url", "example.com");
         pluginData.put("dependencies", new JSONArray());
-        UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source", pluginData);
+        UpdateSite.Plugin plugin = new UpdateSite.Plugin("NO Source", pluginData);
         info.put("plugin", plugin);
         try {
             assertTrue("Check should be true", hook.check(info));
@@ -66,7 +65,7 @@ public class NonStandardTagHookTest {
         pluginData.put("version", "1.1.7");
         pluginData.put("url", "example.com");
         pluginData.put("dependencies", new JSONArray());
-        UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source", pluginData);
+        UpdateSite.Plugin plugin = new UpdateSite.Plugin("NO Source", pluginData);
         info.put("plugin", plugin);
         try {
             assertFalse("Check should be false", hook.check(info));
@@ -97,7 +96,7 @@ public class NonStandardTagHookTest {
             pluginData.put("version", "1.1.8");
             pluginData.put("url", "example.com");
             pluginData.put("dependencies", new JSONArray());
-            UpdateSite.Plugin plugin = new UpdateSite("fake", "fake").new Plugin("NO Source", pluginData);
+            UpdateSite.Plugin plugin = new UpdateSite.Plugin("NO Source", pluginData);
             info.put("plugin", plugin);
             info.put("config", config);
 


### PR DESCRIPTION
The dependency on Jenkins core adds significant complexity to the build and maintenance of this component but seems to exist only for `UpdateSite.Plugin`, a class which can trivially be reimplemented in this component in about 100 lines. Doing so makes the dependency tree much smaller and will hopefully allow us to simplify the implementation even further in the future. I found that some proprietary code was importing `hudson.IOUtils` but that can be trivially switched to Apache Commons. Other than that this should be a drop-in replacement. Before removing the Jenkins core dependency I ran `mvn dependency:analyze` and promoted to direct dependencies any dependencies that we were consuming directly in Java but getting through Jenkins core in Maven. I tested this in https://github.com/jenkinsci/bom/pull/1694.