### PR TITLE
Do not force Windows users to set a Maven installation

### DIFF
--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -1,7 +1,7 @@
 package org.jenkins.tools.test.maven;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-
+import hudson.Functions;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -57,7 +57,11 @@ public class ExternalMavenRunner implements MavenRunner {
     public void run(Config config, File baseDirectory, File buildLogFile, String... goals)
             throws PomExecutionException {
         List<String> cmd = new ArrayList<>();
-        cmd.add(mvn != null ? mvn.getAbsolutePath() : "mvn");
+        if (mvn != null) {
+            cmd.add(mvn.getAbsolutePath());
+        } else {
+            cmd.add(Functions.isWindows() ? "mvn.cmd" : "mvn");
+        }
         cmd.add("--show-version");
         cmd.add("--batch-mode");
         cmd.add("--errors");

--- a/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -75,8 +75,6 @@ import hudson.util.VersionNumber;
  */
 public class PluginCompatTesterTest {
 
-    private static final String MAVEN_INSTALLATION_WINDOWS = "C:\\Jenkins\\tools\\hudson.tasks.Maven_MavenInstallation\\mvn\\bin\\mvn.cmd";
-
     private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml",
             System.getProperty("java.io.tmpdir"), File.separator, File.separator);
 
@@ -250,12 +248,6 @@ public class PluginCompatTesterTest {
         config.setParentVersion("1.410");
         config.setGenerateHtmlReport(true);
         config.setHookPrefixes(Collections.emptyList());
-
-        File ciJenkinsIoWinMvn = Paths.get(MAVEN_INSTALLATION_WINDOWS).toFile();
-        if (ciJenkinsIoWinMvn.exists()) {
-            System.out.println(String.format("Using mvn: %s", MAVEN_INSTALLATION_WINDOWS));
-            config.setExternalMaven(ciJenkinsIoWinMvn);
-        }
 
         return config;
     }


### PR DESCRIPTION
With this change windows users are no longer forced to specify a maven location when maven is on their path.

Also make the test portable by not relying on the location of maven in the ci container image.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
