### PR TITLE
Remove cache options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ demo: target/plugins-compat-tester-cli.jar $(WAR_PATH) print-java-home
 	     -reportFile $(CURDIR)/out/pct-report.xml \
 	     -failOnError \
 	     -workDirectory $(CURDIR)/work \
-	     -skipTestCache true \
 	     -mvn $(MVN_EXECUTABLE) \
 	     -war $(CURDIR)/$(WAR_PATH) \
 	     -testJDKHome "$(TEST_JDK_HOME)" \

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ java -jar target/plugins-compat-tester-cli.jar \
   -workDirectory $(pwd)/tmp/work \
   -includePlugins ${PLUGIN_ARTIFACT_ID} \
   -war jenkins.war -localCheckoutDir ${PLUGIN_SRC} \
-  -skipTestCache true \
   -failOnError \
   -mvn ${PATH_TO_MAVEN}
 ```
@@ -120,7 +119,6 @@ java -jar target/plugins-compat-tester-cli.jar \
   -workDirectory $(pwd)/tmp/work \
   -includePlugins ${PLUGIN_ARTIFACT_ID} \
   -bom ${BOM_FILE_LOCATION} \
-  -skipTestCache true \
   -failOnError \
   -mvn ${PATH_TO_MAVEN}
 ```

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -170,7 +170,6 @@ echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   -jar /pct/pct-cli.jar \
   -reportFile ${PCT_OUTPUT_DIR}/pct-report.xml \
   -workDirectory "${PCT_TMP}/work" ${WAR_PATH_OPT} \
-  -skipTestCache true \
   ${FAIL_ON_ERROR_ARG}\
   ${LOCAL_CHECKOUT_ARG} \
   -includePlugins "${ARTIFACT_ID}" \

--- a/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jenkins.tools.test.model.PCTPlugin;
-import org.jenkins.tools.test.model.TestStatus;
 
 import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.IStringConverter;
@@ -111,24 +110,6 @@ public class CliOptions {
     @CheckForNull
     private File externalMaven;
 
-    @Parameter(names = "-skipTestCache",
-            description = "Allows to skip compatibility test cache (by default, to 100 days)\n" +
-                    "If set to true, every plugin will be tested, no matter the cache is.")
-    private String skipTestCache = null;
-
-    @Parameter(names = "-testCacheTimeout",
-            description = "Allows to override the test cache timeout.\n" +
-                    "Test cache timeout allows to not perform compatibility test over\n" +
-                    "some plugins if compatibility test was performed recently.\n" +
-                    "Cache timeout is given in milliseconds")
-    private Long testCacheTimeout = null;
-
-    @Parameter(names = "-cacheThresholdStatus",
-            description = "Allows to define a minimal cache threshold for test status.\n" +
-                    "That is to say, every results lower than this threshold won't be considered\n" +
-                    "as part of the cache")
-    private String cacheThresholdStatus = TestStatus.COMPILATION_ERROR.toString();
-
     @Parameter(names="-mavenProperties", description = "Define extra properties to be passed to the build." +
           "Format: 'KEY1=VALUE1:KEY2=VALUE2'. These options will be used a la -D.\n" +
             "If your property values contain ':' you must use the 'mavenPropertiesFile' option instead.")
@@ -202,14 +183,6 @@ public class CliOptions {
         return externalMaven;
     }
 
-    public String getSkipTestCache() {
-        return skipTestCache;
-    }
-
-    public Long getTestCacheTimeout() {
-        return testCacheTimeout;
-    }
-
     public String getExcludePlugins() {
         return excludePlugins;
     }
@@ -235,10 +208,6 @@ public class CliOptions {
     @NonNull
     public List<String> getMavenOptions() {
         return mavenOptions != null ? Collections.unmodifiableList(mavenOptions) : Collections.emptyList();
-    }
-
-    public String getCacheThresholdStatus() {
-        return cacheThresholdStatus;
     }
 
     public String getHookPrefixes() {

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -271,11 +271,6 @@ public class PluginCompatTester {
                         pomData = null;
                     }
 
-                    if(!config.isSkipTestCache() && report.isCompatTestResultAlreadyInCache(pluginInfos, actualCoreCoordinates, config.getTestCacheTimeout(), config.getCacheThresholdStatus())){
-                        LOGGER.log(Level.INFO, "Cache activated for plugin {0} => test skipped", pluginInfos.pluginName);
-                        continue; // Don't do anything : we are in the cached interval ! :-)
-                    }
-
                     List<String> warningMessages = new ArrayList<>();
                     Set<String> testDetails = new TreeSet<>();
                     if (errorMessage == null) {

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import org.jenkins.tools.test.logging.LoggingConfiguration;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.exception.PomExecutionException;
-import org.jenkins.tools.test.model.TestStatus;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
@@ -133,15 +132,6 @@ public class PluginCompatTesterCli {
         }
         if(options.getExcludeHooks() != null && !options.getExcludeHooks().isEmpty()){
             config.setExcludeHooks(List.of(options.getExcludeHooks().split(",")));
-        }
-        if(options.getSkipTestCache() != null){
-            config.setSkipTestCache(Boolean.parseBoolean(options.getSkipTestCache()));
-        }
-        if(options.getTestCacheTimeout() != null){
-            config.setTestCacheTimeout(options.getTestCacheTimeout());
-        }
-        if(options.getCacheThresholdStatus() != null){
-            config.setCacheThresholdStatus(TestStatus.valueOf(options.getCacheThresholdStatus()));
         }
         if(options.getHookPrefixes() != null && !options.getHookPrefixes().isEmpty()){
             config.setHookPrefixes(List.of(options.getHookPrefixes().split(",")));

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
@@ -38,7 +38,6 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -119,36 +118,6 @@ public class PluginCompatReport {
 
     public static String getBaseFilename(File reportPath){
         return reportPath.getName().split("\\.")[0];
-    }
-
-    public boolean isCompatTestResultAlreadyInCache(PluginInfos pluginInfos, MavenCoordinates coreCoord, long cacheTimeout, TestStatus cacheThresholdStatus){
-        // Retrieving plugin compatibility results corresponding to pluginsInfos + coreCoord
-        if(!pluginCompatTests.containsKey(pluginInfos)){
-            // No data for this plugin version ? => no cache !
-            return false;
-        }
-
-        List<PluginCompatResult> results = pluginCompatTests.get(pluginInfos);
-        PluginCompatResult resultCorrespondingToGivenCoreCoords = null;
-        for(PluginCompatResult r : results){
-            if(r.coreCoordinates.equals(coreCoord)){
-                resultCorrespondingToGivenCoreCoords = r;
-                break;
-            }
-        }
-        if(resultCorrespondingToGivenCoreCoords == null){
-            // No data for this core coordinates ? => no cache !
-            return false;
-        }
-
-        // Is the latest execution on this plugin compliant with the given cache timeout ?
-        // If so, then cache will be activated !
-        if(new Date().before(new Date(resultCorrespondingToGivenCoreCoords.compatTestExecutedOn.getTime() + cacheTimeout))){
-            return true;
-        }
-
-        // Status was lower than cacheThresholdStatus ? => no cache !
-        return (!resultCorrespondingToGivenCoreCoords.status.isLowerThan(cacheThresholdStatus));
     }
 
     /**

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -106,16 +106,6 @@ public class PluginCompatTesterConfig {
     // organtizations, like your own fork
     private String fallbackGitHubOrganization = null;
 
-    // Allows to skip a plugin test if this plugin test has already been performed
-    // within testCacheTimeout ms
-    private long testCacheTimeout = 1000L * 60 * 60 * 24 * 100;
-    // Skips test cache : plugin will be tested, no matter the test cache is
-    private boolean skipTestCache = false;
-    // Allows to define a minimal cache threshold for TestStatus
-    // That is to say, every results lower than this threshold won't be put
-    // into the cache
-    private TestStatus cacheThresholdStatus = TestStatus.COMPILATION_ERROR;
-
     // Allows to provide XSL report file near XML report file
     // Only if reportFile is not null
     private boolean provideXslReport = true;
@@ -203,22 +193,6 @@ public class PluginCompatTesterConfig {
 
     public File getM2SettingsFile() {
         return m2SettingsFile;
-    }
-
-    public long getTestCacheTimeout() {
-        return testCacheTimeout;
-    }
-
-    public void setTestCacheTimeout(long testCacheTimeout) {
-        this.testCacheTimeout = testCacheTimeout;
-    }
-
-    public boolean isSkipTestCache() {
-        return skipTestCache;
-    }
-
-    public void setSkipTestCache(boolean skipTestCache) {
-        this.skipTestCache = skipTestCache;
     }
 
     public boolean isProvideXslReport() {
@@ -436,14 +410,6 @@ public class PluginCompatTesterConfig {
         return javaVersionOutput2.
                 replace(" full version ", " ").
                 replaceAll("\"", "");
-    }
-
-    public TestStatus getCacheThresholdStatus() {
-        return cacheThresholdStatus;
-    }
-
-    public void setCacheThresholdStatus(TestStatus cacheThresholdStatus) {
-        this.cacheThresholdStatus = cacheThresholdStatus;
     }
 
     public File getWar() {

--- a/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -210,9 +210,6 @@ public class PluginCompatTesterTest {
         config.setIncludePlugins(includedPlugins);
         config.setExcludePlugins(Collections.emptyList());
         config.setExcludeHooks(Collections.emptyList());
-        config.setSkipTestCache(true);
-        config.setCacheThresholdStatus(TestStatus.TEST_FAILURES);
-        config.setTestCacheTimeout(345600000);
         config.setParentVersion("1.410");
         config.setGenerateHtmlReport(true);
         config.setHookPrefixes(Collections.emptyList());


### PR DESCRIPTION
This functionality seems pointless, as evidenced by the fact that every known consumer passes `-skipTestCache true` to disable it. Rather than force consumers to do this, seems more straightforward to rip out this functionality so that the default actually makes sense. I did some light testing of this locally with `jenkinsci/bom` and (other than having to delete the `-skipTestCache true` option from the command-lin invocation) everything works fine without it. I did not think more testing was needed beyond that.