### PR TITLE
Remove `warningMessages`

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -276,7 +276,6 @@ public class PluginCompatTester {
                         continue; // Don't do anything : we are in the cached interval ! :-)
                     }
 
-                    List<String> warningMessages = new ArrayList<>();
                     Set<String> testDetails = new TreeSet<>();
                     if (errorMessage == null) {
                     try {
@@ -286,7 +285,6 @@ public class PluginCompatTester {
                         } else {
                             status = TestStatus.TEST_FAILURES;
                         }
-                        warningMessages.addAll(result.pomWarningMessages);
                         testDetails.addAll(config.isStoreAll() ? result.getTestDetails().getAll() : result.getTestDetails().hasFailures() ? result.getTestDetails().getFailed() : Collections.emptySet());
                     } catch (PomExecutionException e) {
                         if(!e.succeededPluginArtifactIds.contains("maven-compiler-plugin")){
@@ -299,7 +297,6 @@ public class PluginCompatTester {
                             status = TestStatus.INTERNAL_ERROR;
                         }
                         errorMessage = e.getErrorMessage();
-                        warningMessages.addAll(e.getPomWarningMessages());
                         testDetails.addAll(config.isStoreAll() ? e.getTestDetails().getAll() : e.getTestDetails().hasFailures() ? e.getTestDetails().getFailed() : Collections.emptySet());
                     } catch (Error e){
                         // Rethrow the error ... something is wrong !
@@ -323,7 +320,7 @@ public class PluginCompatTester {
                     	actualCoreCoordinates = new MavenCoordinates(actualCoreCoordinates.groupId, actualCoreCoordinates.artifactId, solveVersionFromModel(new MavenBom(config.getBom()).getModel()));
                     }
 
-                    PluginCompatResult result = new PluginCompatResult(actualCoreCoordinates, status, errorMessage, warningMessages, testDetails, buildLogFilePath);
+                    PluginCompatResult result = new PluginCompatResult(actualCoreCoordinates, status, errorMessage, testDetails, buildLogFilePath);
                     report.add(pluginInfos, result);
 
                     if(config.reportFile != null){
@@ -525,11 +522,10 @@ public class PluginCompatTester {
 
             // Execute with tests
             runner.run(mconfig, pluginCheckoutDir, buildLogFile, args.toArray(new String[0]));
-            return new TestExecutionResult(((PomData)forExecutionHooks.get("pomData")).getWarningMessages(), new ExecutedTestNamesSolver().solve(types, runner.getExecutedTests(), pluginCheckoutDir));
+            return new TestExecutionResult(new ExecutedTestNamesSolver().solve(types, runner.getExecutedTests(), pluginCheckoutDir));
         } catch (ExecutedTestNamesSolverException e) {
             throw new PomExecutionException(e);
         } catch (PomExecutionException e){
-            e.getPomWarningMessages().addAll(pomData.getWarningMessages());
             if (ranCompile) {
                 // So the status cannot be considered COMPILATION_ERROR
                 e.succeededPluginArtifactIds.add("maven-compiler-plugin");

--- a/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
@@ -42,22 +42,20 @@ import org.jenkins.tools.test.util.ExecutedTestNamesDetails;
 public class PomExecutionException extends Exception {
     private final List<Throwable> exceptionsThrown;
     public final List<String> succeededPluginArtifactIds;
-    private final List<String> pomWarningMessages;
     private final ExecutedTestNamesDetails testDetails;
 
     public PomExecutionException(Throwable cause) {
-        this(cause.toString(), Collections.emptyList(), List.of(cause), Collections.emptyList(), new ExecutedTestNamesDetails());
+        this(cause.toString(), Collections.emptyList(), List.of(cause), new ExecutedTestNamesDetails());
     }
 
     public PomExecutionException(PomExecutionException exceptionToCopy){
-        this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.pomWarningMessages, exceptionToCopy.testDetails);
+        this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.testDetails);
     }
 
-    public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, List<String> pomWarningMessages, ExecutedTestNamesDetails testDetails){
+    public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, ExecutedTestNamesDetails testDetails){
         super(message, exceptionsThrown.isEmpty() ? null : exceptionsThrown.iterator().next());
         this.exceptionsThrown = new ArrayList<>(exceptionsThrown);
         this.succeededPluginArtifactIds = new ArrayList<>(succeededPluginArtifactIds);
-        this.pomWarningMessages = new ArrayList<>(pomWarningMessages);
         this.testDetails = testDetails;
     }
 
@@ -74,10 +72,6 @@ public class PomExecutionException extends Exception {
         return strBldr.toString();
     }
 
-    public List<String> getPomWarningMessages() {
-        return pomWarningMessages;
-    }
-    
     public ExecutedTestNamesDetails getTestDetails() {
         return testDetails;
     }

--- a/src/main/java/org/jenkins/tools/test/hook/SkipUIHelperPlugins.java
+++ b/src/main/java/org/jenkins/tools/test/hook/SkipUIHelperPlugins.java
@@ -3,8 +3,11 @@ package org.jenkins.tools.test.hook;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jenkins.tools.test.model.TestExecutionResult;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.jenkins.tools.test.util.ExecutedTestNamesDetails;
 
 /**
  * Short circuit running any UI plugins that function as a helper methods. These are installed as
@@ -16,6 +19,9 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
  * @see <a href="js-libs">https://github.com/jenkinsci/js-libs</a>
  */
 public class SkipUIHelperPlugins extends PluginCompatTesterHookBeforeCheckout {
+
+    private static final Logger LOGGER = Logger.getLogger(SkipUIHelperPlugins.class.getName());
+
     private static List<String> allBundlePlugins = List.of(
         "ace-editor", "bootstrap", "handlebars", "jquery-detached",
         "js-module-base", "momentjs", "numeraljs");
@@ -33,8 +39,9 @@ public class SkipUIHelperPlugins extends PluginCompatTesterHookBeforeCheckout {
      */
     @Override
     public Map<String, Object> action(Map<String, Object> moreInfo) {
+        LOGGER.log(Level.WARNING, "Plugin unsupported at this time, skipping");
         moreInfo.put("executionResult", 
-            new TestExecutionResult(List.of("Plugin unsupported at this time, skipping")));
+            new TestExecutionResult(new ExecutedTestNamesDetails()));
         moreInfo.put("runCheckout", false);
         return moreInfo;
     }

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -110,7 +110,7 @@ public class ExternalMavenRunner implements MavenRunner {
             }
             if (p.waitFor() != 0) {
                 throw new PomExecutionException(cmd + " failed in " + baseDirectory, succeededPluginArtifactIds,
-                        /* TODO */Collections.emptyList(), Collections.emptyList(),
+                        /* TODO */Collections.emptyList(),
                         new ExecutedTestNamesSolver().solve(getTypes(config), getExecutedTests(), baseDirectory));
             }
         } catch (PomExecutionException x) {

--- a/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
@@ -83,15 +83,6 @@ public class MavenCoordinates implements Comparable<MavenCoordinates> {
         return "MavenCoordinates[groupId="+groupId+", artifactId="+artifactId+", version="+version+"]";
     }
 
-    public String toGAV(){
-        return groupId+":"+artifactId+":"+version;
-    }
-
-    public static MavenCoordinates fromGAV(String gav){
-        String[] chunks = gav.split(":");
-        return new MavenCoordinates(chunks[0], chunks[1], chunks[2]);
-    }
-
     @Override
     public int compareTo(MavenCoordinates o) {
         if((groupId+":"+artifactId).equals(o.groupId+":"+o.artifactId)){

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
@@ -43,27 +43,25 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
     public final Date compatTestExecutedOn;
 
     public final String errorMessage;
-    public final List<String> warningMessages;
 
     private final Set<String> testDetails;
 
     private String buildLogPath = "";
 
     public PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, List<String> warningMessages, Set<String> testDetails,
+                              String errorMessage, Set<String> testDetails,
                               String buildLogPath){
         // Create new result with current date
-        this(coreCoordinates, status, errorMessage, warningMessages, testDetails, buildLogPath, new Date());
+        this(coreCoordinates, status, errorMessage, testDetails, buildLogPath, new Date());
     }
     private PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, List<String> warningMessages, Set<String> testDetails,
+                              String errorMessage, Set<String> testDetails,
                               String buildLogPath, Date compatTestExecutedOn){
         this.coreCoordinates = coreCoordinates;
 
         this.status = status;
 
         this.errorMessage = errorMessage;
-        this.warningMessages = warningMessages;
 
         this.testDetails = testDetails;
         this.buildLogPath = buildLogPath;

--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -224,7 +224,7 @@ public class PluginRemoting {
         if(transformedConnectionUrl.isEmpty()){
             transformedConnectionUrl = "scm:git:git://github.com/jenkinsci/"+pomData.artifactId.replaceAll("jenkins", "")+"-plugin.git";
             if(!oldUrl.equals(transformedConnectionUrl)){
-                pomData.getWarningMessages().add("project.scm.connectionUrl is not present in plugin's pom .. isn't it residing somewhere on a parent pom ?");
+                LOGGER.log(Level.WARNING, "project.scm.connectionUrl is not present in plugin's pom .. isn't it residing somewhere on a parent pom ?");
             }
         }
 
@@ -232,7 +232,7 @@ public class PluginRemoting {
         oldUrl = transformedConnectionUrl;
         transformedConnectionUrl = transformedConnectionUrl.replaceAll("(svn|hudson)\\.dev\\.java\\.net/svn/hudson/", "svn.java.net/svn/hudson~svn/");
         if(!oldUrl.equals(transformedConnectionUrl)){
-            pomData.getWarningMessages().add("project.scm.connectionUrl is pointing to svn.dev.java.net/svn/hudson/ instead of svn.java.net/svn/hudson~svn/");
+            LOGGER.log(Level.WARNING, "project.scm.connectionUrl is pointing to svn.dev.java.net/svn/hudson/ instead of svn.java.net/svn/hudson~svn/");
         }
 
         // ${project.artifactId}
@@ -244,7 +244,7 @@ public class PluginRemoting {
         oldUrl = transformedConnectionUrl;
         transformedConnectionUrl = transformedConnectionUrl.replaceAll("(http(s)?://)?[^@:]+@github\\.com", "git://github.com");
         if(!oldUrl.equals(transformedConnectionUrl)){
-            pomData.getWarningMessages().add("project.scm.connectionUrl is using a github account instead of a read-only url git://github.com/...");
+            LOGGER.log(Level.WARNING, "project.scm.connectionUrl is using a github account instead of a read-only url git://github.com/...");
         }
         */
 
@@ -252,19 +252,19 @@ public class PluginRemoting {
         oldUrl = transformedConnectionUrl;
         transformedConnectionUrl = transformedConnectionUrl.replaceAll("scm:git:git://git@github\\.com:jenkinsci", "scm:git:git://github.com/jenkinsci");
         if(!oldUrl.equals(transformedConnectionUrl)){
-            pomData.getWarningMessages().add("project.scm.connectionUrl should should be accessed in read-only mode (with git:// protocol)");
+            LOGGER.log(Level.WARNING, "project.scm.connectionUrl should should be accessed in read-only mode (with git:// protocol)");
         }
 
         oldUrl = transformedConnectionUrl;
         transformedConnectionUrl = transformedConnectionUrl.replaceAll("://github\\.com[^/]", "://github.com/");
         if(!oldUrl.equals(transformedConnectionUrl)){
-            pomData.getWarningMessages().add("project.scm.connectionUrl should have a '/' after the github.com url");
+            LOGGER.log(Level.WARNING, "project.scm.connectionUrl should have a '/' after the github.com url");
         }
 
         oldUrl = transformedConnectionUrl;
         transformedConnectionUrl = transformedConnectionUrl.replaceAll("://github\\.com/hudson/", "://github.com/jenkinsci/");
         if(!oldUrl.equals(transformedConnectionUrl)){
-            pomData.getWarningMessages().add("project.scm.connectionUrl should not reference hudson project anymore (no plugin repository there))");
+            LOGGER.log(Level.WARNING, "project.scm.connectionUrl should not reference hudson project anymore (no plugin repository there))");
         }
 
 		// Just fixing some scm-sync-configuration issues...
@@ -274,7 +274,7 @@ public class PluginRemoting {
 			transformedConnectionUrl = transformedConnectionUrl.substring(0, transformedConnectionUrl.length()-4)+"-plugin.git";
         }
         if(!oldUrl.equals(transformedConnectionUrl)){
-            pomData.getWarningMessages().add("project.scm.connectionUrl should be ending with '-plugin.git'");
+            LOGGER.log(Level.WARNING, "project.scm.connectionUrl should be ending with '-plugin.git'");
         }
 
         pomData.setConnectionUrl(transformedConnectionUrl);

--- a/src/main/java/org/jenkins/tools/test/model/PomData.java
+++ b/src/main/java/org/jenkins/tools/test/model/PomData.java
@@ -46,7 +46,6 @@ public class PomData {
     public final MavenCoordinates parent;
     private String connectionUrl;
     private String scmTag;
-    private List<String> warningMessages = new ArrayList<>();
 
     public PomData(String artifactId, @CheckForNull String packaging, String connectionUrl, String scmTag, @CheckForNull MavenCoordinates parent, String groupId){
         this.artifactId = artifactId;
@@ -65,10 +64,6 @@ public class PomData {
         this.connectionUrl = connectionUrl;
     }
 
-    public List<String> getWarningMessages() {
-        return warningMessages;
-    }
-
     @NonNull
     public String getPackaging() {
         return packaging;
@@ -76,13 +71,5 @@ public class PomData {
 
     public String getScmTag() {
         return scmTag;
-    }
-
-    public boolean isPluginPOM() {
-        if (parent != null) {
-            return parent.matches("org.jenkins-ci.plugins", "plugin");
-        } else { // Interpolate by packaging
-            return "hpi".equalsIgnoreCase(packaging);
-        }
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
+++ b/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
@@ -39,14 +39,7 @@ public class TestExecutionResult {
 
     private final ExecutedTestNamesDetails testDetails;
 
-    public final List<String> pomWarningMessages;
-
-    public TestExecutionResult(List<String> pomWarningMessages){
-        this(pomWarningMessages, new ExecutedTestNamesDetails());
-    }
-
-    public TestExecutionResult(List<String> pomWarningMessages, ExecutedTestNamesDetails testDetails){
-        this.pomWarningMessages = Collections.unmodifiableList(pomWarningMessages);
+    public TestExecutionResult(ExecutedTestNamesDetails testDetails){
         this.testDetails = testDetails;
     }
 

--- a/src/main/resources/org/jenkins/tools/test/resultToReport.xsl
+++ b/src/main/resources/org/jenkins/tools/test/resultToReport.xsl
@@ -156,14 +156,6 @@
 		</xsl:choose>
                 </xsl:otherwise>
             </xsl:choose>
-            <xsl:if test="count($compatResult/warningMessages//string) &gt; 0">
-                <xsl:call-template name="display-img">
-                    <xsl:with-param name="id"><xsl:value-of select="$cellId"/>-warns</xsl:with-param>
-                    <xsl:with-param name="title">Warnings !</xsl:with-param>
-                    <xsl:with-param name="img">document.png</xsl:with-param>
-                    <xsl:with-param name="error"><xsl:value-of select="$compatResult/warningMessages//string" /></xsl:with-param>
-                </xsl:call-template>
-            </xsl:if>
             <xsl:if test="$compatResult/buildLogPath != ''">
                 <xsl:element name="a">
                     <xsl:attribute name="href"><xsl:value-of select="$compatResult/buildLogPath" /></xsl:attribute>


### PR DESCRIPTION
As a first step toward #407, get rid of `warningMessages`. These were passed around from one class to another and ultimately logged in an XML file that nobody ever looks at. In the handful of cases where we were actually trying to log a warning, I changed the warning to a log statement so that it now gets printed to the console where someone can actually see it. To test this I ran `jenkinsci/bom` tests with `ace-editor` (saw the warning) and `text-finder` (saw no warning), which seems sufficient for this low-risk change.