### PR TITLE
Fix the declarative-pipeline migrator hook

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
@@ -28,11 +28,6 @@ public class DeclarativePipelineMigrationHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin){
-        return currentPlugin.getDisplayName();
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return "org.jenkins-ci.plugins.to-declarative".equals(data.groupId)


### PR DESCRIPTION
the folder name is not the display name.

Fixes attempting to run in a non existant folder (with spaces in the name)

```
2023-01-31 12:12:43.429+0000 [id=1]	INFO	o.j.t.t.h.MultiParentCompileHook#setupCompileResources: Cleaning up node modules if necessary
2023-01-31 12:12:43.429+0000 [id=1]	INFO	o.j.t.t.h.MultiParentCompileHook#setupCompileResources: Plugin compilation log directory: /jenkins/workspace/builders_URR-pr-builder_PR-8390/output-declarative-pipeline-migration-assistant/work/declarative-pipeline-migration-assistant-plugin/Declarative Pipeline Migration Assistant
2023-01-31 12:12:43.429+0000 [id=1]	INFO	o.j.t.t.m.ExternalMavenRunner#run: Running /usr/bin/mvn --show-version --batch-mode --errors -ntp --settings=/jenkins/workspace/builders_URR-pr-builder_PR-8390@tmp/config10447835059945445462tmp --define=enforcer.skip=true --define=failIfNoTests=false --define=forkCount=.75C --define=hpi-plugin.version=3.34 --define=jenkins.version=2.375.3-cb-1 --define=overrideWar=/jenkins/workspace/builders_URR-pr-builder_PR-8390/core-cm.war --define=reuseForks=false --define=surefire.excludesFile=/jenkins/workspace/builders_URR-pr-builder_PR-8390/src/test/resources/pct-surefire-exclusion-list --define=surefire.rerunFailingTestsCount=0 --define=upperBoundsExcludes=javax.servlet:servlet-api --define=useUpperBounds=true clean process-test-classes -Dmaven.javadoc.skip in /jenkins/workspace/builders_URR-pr-builder_PR-8390/output-declarative-pipeline-migration-assistant/work/declarative-pipeline-migration-assistant-plugin/Declarative Pipeline Migration Assistant >> /jenkins/workspace/builders_URR-pr-builder_PR-8390/output-declarative-pipeline-migration-assistant/work/declarative-pipeline-migration-assistant-plugin/Declarative Pipeline Migration Assistant/compilePluginLog.log
2023-01-31 12:12:43.430+0000 [id=1]	WARNING	o.j.t.t.m.ExternalMavenRunner#run: Failed to run Maven
java.io.IOException: error=2, No such file or directory
	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:340)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:271)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
Caused: java.io.IOException: Cannot run program "/usr/bin/mvn" (in directory "/jenkins/workspace/builders_URR-pr-builder_PR-8390/output-declarative-pipeline-migration-assistant/work/declarative-pipeline-migration-assistant-plugin/Declarative Pipeline Migration Assistant"): error=2, No such file or directory

```

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
