### PR TITLE
Format code with Google Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,9 @@
         <configuration>
           <java>
             <endWithNewline />
+            <googleJavaFormat>
+              <style>AOSP</style>
+            </googleJavaFormat>
             <importOrder />
             <indent>
               <spaces>true</spaces>

--- a/src/main/java/hudson/model/UpdateSite.java
+++ b/src/main/java/hudson/model/UpdateSite.java
@@ -10,30 +10,23 @@ import net.sf.json.JSONObject;
 
 public final class UpdateSite {
 
-    /**
-     * In-memory representation of the update center data.
-     */
+    /** In-memory representation of the update center data. */
     public static final class Data {
-        /**
-         * The {@link UpdateSite} ID.
-         */
+        /** The {@link UpdateSite} ID. */
         @NonNull public final String sourceId;
 
-        /**
-         * The latest jenkins.war.
-         */
+        /** The latest jenkins.war. */
         @NonNull public final Entry core;
 
-        /**
-         * Plugins in the repository, keyed by their artifact IDs.
-         */
+        /** Plugins in the repository, keyed by their artifact IDs. */
         @NonNull
         public final Map<String, Plugin> plugins = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         public Data(JSONObject o) {
             this.sourceId = o.getString("id");
             this.core = new Entry(sourceId, o.getJSONObject("core"));
-            for (Map.Entry<String, JSONObject> e : (Set<Map.Entry<String, JSONObject>>) o.getJSONObject("plugins").entrySet()) {
+            for (Map.Entry<String, JSONObject> e :
+                    (Set<Map.Entry<String, JSONObject>>) o.getJSONObject("plugins").entrySet()) {
                 Plugin p = new Plugin(sourceId, e.getValue());
                 plugins.put(e.getKey(), p);
             }
@@ -41,24 +34,16 @@ public final class UpdateSite {
     }
 
     public static class Entry {
-        /**
-         * {@link UpdateSite} ID.
-         */
+        /** {@link UpdateSite} ID. */
         @NonNull public final String sourceId;
 
-        /**
-         * Artifact ID.
-         */
+        /** Artifact ID. */
         @NonNull public final String name;
 
-        /**
-         * The version.
-         */
+        /** The version. */
         @NonNull public final String version;
 
-        /**
-         * Download URL.
-         */
+        /** Download URL. */
         @NonNull public final String url;
 
         public Entry(String sourceId, JSONObject o) {
@@ -70,19 +55,13 @@ public final class UpdateSite {
     }
 
     public static class Plugin extends Entry {
-        /**
-         * Human readable title of the plugin.
-         */
+        /** Human readable title of the plugin. */
         @CheckForNull public final String title;
 
-        /**
-         * Dependencies of this plugin, a name -&gt; version mapping.
-         */
+        /** Dependencies of this plugin, a name -&gt; version mapping. */
         @NonNull public final Map<String, String> dependencies = new HashMap<>();
 
-        /**
-         * Optional dependencies of this plugin.
-         */
+        /** Optional dependencies of this plugin. */
         @NonNull public final Map<String, String> optionalDependencies = new HashMap<>();
 
         public Plugin(String sourceId, JSONObject o) {

--- a/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -43,91 +43,138 @@ import java.util.List;
  * @author Frederic Camblor
  */
 public class CliOptions {
-    @Parameter(names = "-war", required = true,
-            description = "A WAR file to scan for plugins rather than looking in the update center.")
+    @Parameter(
+            names = "-war",
+            required = true,
+            description =
+                    "A WAR file to scan for plugins rather than looking in the update center.")
     private File war;
 
     @CheckForNull
-    @Parameter(names = "-testJDKHome",
+    @Parameter(
+            names = "-testJDKHome",
             description = "A path to JDK HOME to be used for running tests in plugins.")
     private File testJDKHome = null;
 
     @CheckForNull
-    @Parameter(names = "-testJavaArgs",
+    @Parameter(
+            names = "-testJavaArgs",
             description = "Java test arguments to be used for test runs.")
     private String testJavaArgs = null;
 
-    @Parameter(names = "-workDirectory", required = true,
+    @Parameter(
+            names = "-workDirectory",
+            required = true,
             description = "Work directory where plugin sources will be checked out")
     private File workDirectory;
 
-    @Parameter(names = "-reportFile", required = true,
-            description = "Output report xml file path. This path must contain a directory, e.g. 'out/pct-report.xml'")
+    @Parameter(
+            names = "-reportFile",
+            required = true,
+            description =
+                    "Output report xml file path. This path must contain a directory, e.g."
+                            + " 'out/pct-report.xml'")
     private File reportFile;
 
-    @Parameter(names = "-includePlugins",
-            description = "Comma separated list of plugins' artifactId to test.\n" +
-                    "If not set, every plugin will be tested.")
+    @Parameter(
+            names = "-includePlugins",
+            description =
+                    "Comma separated list of plugins' artifactId to test.\n"
+                            + "If not set, every plugin will be tested.")
     private String includePlugins = null;
 
-    @Parameter(names = "-excludePlugins",
-            description = "Comma separated list of plugins' artifactId to NOT test.\n" +
-                    "If not set, see includePlugins behaviour.")
+    @Parameter(
+            names = "-excludePlugins",
+            description =
+                    "Comma separated list of plugins' artifactId to NOT test.\n"
+                            + "If not set, see includePlugins behaviour.")
     private String excludePlugins = null;
 
-    @Parameter(names = "-excludeHooks",
-            description = "Comma separated list of hooks to NOT execute.\n" +
-                    "If not set, all hooks will be executed.")
+    @Parameter(
+            names = "-excludeHooks",
+            description =
+                    "Comma separated list of hooks to NOT execute.\n"
+                            + "If not set, all hooks will be executed.")
     private String excludeHooks = null;
 
-    @Parameter(names = "-fallbackGitHubOrganization",
-            description = "Include an alternative organization to use as a fallback to download the plugin.\n" +
-                    "It is useful to use your own fork releases for an specific plugin if the " +
-                    "version is not found in the official repository.\n" +
-                    "If set, The PCT will try to use the fallback if a plugin tag is not found in the regular URL.")
+    @Parameter(
+            names = "-fallbackGitHubOrganization",
+            description =
+                    "Include an alternative organization to use as a fallback to download the"
+                            + " plugin.\n"
+                            + "It is useful to use your own fork releases for an specific plugin if the"
+                            + " version is not found in the official repository.\n"
+                            + "If set, The PCT will try to use the fallback if a plugin tag is not"
+                            + " found in the regular URL.")
     private String fallbackGitHubOrganization = null;
 
-    @Parameter(names = "-m2SettingsFile",
+    @Parameter(
+            names = "-m2SettingsFile",
             description = "Maven settings file used while executing maven")
     private File m2SettingsFile;
 
-    @Parameter(names = "-mvn",
-            description = "External Maven executable")
+    @Parameter(names = "-mvn", description = "External Maven executable")
     @CheckForNull
     private File externalMaven;
 
-    @Parameter(names="-mavenProperties", description = "Define extra properties to be passed to the build." +
-          "Format: 'KEY1=VALUE1:KEY2=VALUE2'. These options will be used a la -D.\n" +
-            "If your property values contain ':' you must use the 'mavenPropertiesFile' option instead.")
+    @Parameter(
+            names = "-mavenProperties",
+            description =
+                    "Define extra properties to be passed to the build. Format:"
+                            + " 'KEY1=VALUE1:KEY2=VALUE2'. These options will be used a la -D.\n"
+                            + "If your property values contain ':' you must use the"
+                            + " 'mavenPropertiesFile' option instead.")
     private String mavenProperties;
 
-    @Parameter(names="-mavenPropertiesFile", description = "Allow loading some maven properties from a file using the standard java.util.Properties file format. " +
-            "These options will be used a la -D")
+    @Parameter(
+            names = "-mavenPropertiesFile",
+            description =
+                    "Allow loading some maven properties from a file using the standard"
+                            + " java.util.Properties file format. These options will be used a la -D")
     private String mavenPropertiesFile;
 
-    @Parameter(names="-mavenOptions", description = "Options to pass to Maven (like -Pxxx; not to be confused with Java options, nor Maven properties).")
+    @Parameter(
+            names = "-mavenOptions",
+            description =
+                    "Options to pass to Maven (like -Pxxx; not to be confused with Java options,"
+                            + " nor Maven properties).")
     private List<String> mavenOptions;
 
-    @Parameter(names="-hookPrefixes", description = "Prefixes of the extra hooks' classes")
+    @Parameter(names = "-hookPrefixes", description = "Prefixes of the extra hooks' classes")
     private String hookPrefixes;
 
-    @Parameter(names="-externalHooksJars", description = "Comma-separated list of external hooks jar file locations", listConverter = FileListConverter.class, validateWith = FileValidator.class)
+    @Parameter(
+            names = "-externalHooksJars",
+            description = "Comma-separated list of external hooks jar file locations",
+            listConverter = FileListConverter.class,
+            validateWith = FileValidator.class)
     private List<File> externalHooksJars;
 
-    @Parameter(names="-localCheckoutDir", description = "Folder containing either a local (possibly modified) clone of a plugin repository or a set of local clone of different plugins")
+    @Parameter(
+            names = "-localCheckoutDir",
+            description =
+                    "Folder containing either a local (possibly modified) clone of a plugin"
+                            + " repository or a set of local clone of different plugins")
     private String localCheckoutDir;
 
-    @Parameter(names="-help", description = "Print this help message", help = true)
+    @Parameter(names = "-help", description = "Print this help message", help = true)
     private boolean printHelp;
 
-    @Parameter(names = "-failOnError", description = "Immediately if the PCT run fails for a plugin. Error status will be also reported as a return code")
+    @Parameter(
+            names = "-failOnError",
+            description =
+                    "Immediately if the PCT run fails for a plugin. Error status will be also"
+                            + " reported as a return code")
     private boolean failOnError;
 
-    @Parameter(names = "-storeAll",
-            description = "By default only failed tests are stored in PCT report file. \n" +
-                    "If set, the PCT will store ALL executed test names for each plugin in report file. \n" +
-                    "Disabled by default because it may bloat reports for plugins which thousands of tests."
-    )
+    @Parameter(
+            names = "-storeAll",
+            description =
+                    "By default only failed tests are stored in PCT report file. \n"
+                            + "If set, the PCT will store ALL executed test names for each plugin in"
+                            + " report file. \n"
+                            + "Disabled by default because it may bloat reports for plugins which"
+                            + " thousands of tests.")
     private Boolean storeAll = null;
 
     public File getWar() {
@@ -178,7 +225,9 @@ public class CliOptions {
 
     @NonNull
     public List<String> getMavenOptions() {
-        return mavenOptions != null ? Collections.unmodifiableList(mavenOptions) : Collections.emptyList();
+        return mavenOptions != null
+                ? Collections.unmodifiableList(mavenOptions)
+                : Collections.emptyList();
     }
 
     public String getHookPrefixes() {
@@ -218,9 +267,9 @@ public class CliOptions {
     public static class FileListConverter implements IStringConverter<List<File>> {
         @Override
         public List<File> convert(String files) {
-            String [] paths = files.split(",");
+            String[] paths = files.split(",");
             List<File> fileList = new ArrayList<>();
-            for(String path : paths){
+            for (String path : paths) {
                 fileList.add(new File(path));
             }
             return fileList;
@@ -233,7 +282,8 @@ public class CliOptions {
             for (String path : value.split(",")) {
                 File jar = new File(path);
                 if (!jar.exists() || !jar.isFile()) {
-                    throw new ParameterException(path + " must exists and be a normal file (not a directory)");
+                    throw new ParameterException(
+                            path + " must exists and be a normal file (not a directory)");
                 }
             }
         }

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -57,20 +57,19 @@ public class PluginCompatTesterCli {
     @SuppressFBWarnings(
             value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
             justification =
-                    "We're already checking for null in each relevant instance, so why does SpotBugs complain?")
+                    "We're already checking for null in each relevant instance, so why does"
+                            + " SpotBugs complain?")
     public static void main(String[] args) throws IOException, PomExecutionException {
         CliOptions options = new CliOptions();
         JCommander jcommander = null;
         try {
-            jcommander = JCommander.newBuilder()
-                    .addObject(options)
-                    .build();
+            jcommander = JCommander.newBuilder().addObject(options).build();
             jcommander.parse(args);
             if (options.isPrintHelp()) {
                 jcommander.usage();
                 System.exit(0);
             }
-        }catch(ParameterException e){
+        } catch (ParameterException e) {
             System.err.println(e.getMessage());
             jcommander.usage();
             System.exit(1);
@@ -79,15 +78,18 @@ public class PluginCompatTesterCli {
         Files.createDirectories(options.getWorkDirectory().toPath());
 
         File reportFile = null;
-        if(!"NOREPORT".equals(options.getReportFile().getName())){
+        if (!"NOREPORT".equals(options.getReportFile().getName())) {
             reportFile = options.getReportFile();
         }
         if (reportFile != null) {
             // Check the format requirement
             File parentFile = reportFile.getParentFile();
             if (parentFile == null) {
-                throw new IllegalArgumentException("The -reportFile value '" + reportFile + "' does not have a directory specification. " +
-                        "A path should be something like 'out/pct-report.xml'");
+                throw new IllegalArgumentException(
+                        "The -reportFile value '"
+                                + reportFile
+                                + "' does not have a directory specification. "
+                                + "A path should be something like 'out/pct-report.xml'");
             }
         }
 
@@ -99,35 +101,35 @@ public class PluginCompatTesterCli {
         config.setWar(options.getWar());
         config.setExternalMaven(options.getExternalMaven());
 
-        if(options.getIncludePlugins() != null && !options.getIncludePlugins().isEmpty()){
+        if (options.getIncludePlugins() != null && !options.getIncludePlugins().isEmpty()) {
             config.setIncludePlugins(List.of(options.getIncludePlugins().toLowerCase().split(",")));
         }
-        if(options.getExcludePlugins() != null && !options.getExcludePlugins().isEmpty()){
+        if (options.getExcludePlugins() != null && !options.getExcludePlugins().isEmpty()) {
             config.setExcludePlugins(List.of(options.getExcludePlugins().toLowerCase().split(",")));
         }
-        if(options.getExcludeHooks() != null && !options.getExcludeHooks().isEmpty()){
+        if (options.getExcludeHooks() != null && !options.getExcludeHooks().isEmpty()) {
             config.setExcludeHooks(List.of(options.getExcludeHooks().split(",")));
         }
-        if(options.getHookPrefixes() != null && !options.getHookPrefixes().isEmpty()){
+        if (options.getHookPrefixes() != null && !options.getHookPrefixes().isEmpty()) {
             config.setHookPrefixes(List.of(options.getHookPrefixes().split(",")));
         }
-        if(options.getExternalHooksJars() != null && !options.getExternalHooksJars().isEmpty()){
+        if (options.getExternalHooksJars() != null && !options.getExternalHooksJars().isEmpty()) {
             config.setExternalHooksJars(options.getExternalHooksJars());
         }
-        if(options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()){
+        if (options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()) {
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());
         }
-        if(options.getTestJDKHome() != null) {
+        if (options.getTestJDKHome() != null) {
             config.setTestJDKHome(options.getTestJDKHome());
         }
         if (options.getTestJavaArgs() != null && !options.getTestJavaArgs().isEmpty()) {
             config.setTestJavaArgs(options.getTestJavaArgs());
         }
-        if (options.getFallbackGitHubOrganization() != null){
+        if (options.getFallbackGitHubOrganization() != null) {
             config.setFallbackGitHubOrganization(options.getFallbackGitHubOrganization());
         }
         if (options.isFailOnError()) {
-            //TODO: also interpolate it for the case when a single plugin passed?
+            // TODO: also interpolate it for the case when a single plugin passed?
             config.setFailOnError(true);
         }
 
@@ -149,8 +151,9 @@ public class PluginCompatTesterCli {
             }
             config.setMavenProperties(mavenProps);
         }
-        //TODO: Read property file here as well? No sense to do it letter unless PCT Hooks modify file
-        if(options.getMavenPropertiesFile() != null) {
+        // TODO: Read property file here as well? No sense to do it letter unless PCT Hooks modify
+        // file
+        if (options.getMavenPropertiesFile() != null) {
             config.setMavenPropertiesFiles(options.getMavenPropertiesFile());
         }
 

--- a/src/main/java/org/jenkins/tools/test/exception/ExecutedTestNamesSolverException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/ExecutedTestNamesSolverException.java
@@ -1,22 +1,22 @@
 package org.jenkins.tools.test.exception;
 
-public class ExecutedTestNamesSolverException  extends Exception {
+public class ExecutedTestNamesSolverException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
     public ExecutedTestNamesSolverException() {
-            super();
+        super();
     }
 
     public ExecutedTestNamesSolverException(String msg) {
-            super(msg);
+        super(msg);
     }
 
     public ExecutedTestNamesSolverException(String msg, Exception e) {
-            super(msg, e);
+        super(msg, e);
     }
 
     public ExecutedTestNamesSolverException(Exception e) {
-            super(e);
+        super(e);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/exception/PluginSourcesUnavailableException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PluginSourcesUnavailableException.java
@@ -34,7 +34,7 @@ package org.jenkins.tools.test.exception;
  */
 public class PluginSourcesUnavailableException extends Exception {
 
-    public PluginSourcesUnavailableException(String message, Throwable cause){
+    public PluginSourcesUnavailableException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
@@ -46,25 +46,39 @@ public class PomExecutionException extends Exception {
     private final ExecutedTestNamesDetails testDetails;
 
     public PomExecutionException(Throwable cause) {
-        this(cause.toString(), Collections.emptyList(), List.of(cause), new ExecutedTestNamesDetails());
+        this(
+                cause.toString(),
+                Collections.emptyList(),
+                List.of(cause),
+                new ExecutedTestNamesDetails());
     }
 
-    public PomExecutionException(PomExecutionException exceptionToCopy){
-        this(exceptionToCopy.getMessage(), exceptionToCopy.succeededPluginArtifactIds, exceptionToCopy.exceptionsThrown, exceptionToCopy.testDetails);
+    public PomExecutionException(PomExecutionException exceptionToCopy) {
+        this(
+                exceptionToCopy.getMessage(),
+                exceptionToCopy.succeededPluginArtifactIds,
+                exceptionToCopy.exceptionsThrown,
+                exceptionToCopy.testDetails);
     }
 
-    public PomExecutionException(String message, List<String> succeededPluginArtifactIds, List<Throwable> exceptionsThrown, ExecutedTestNamesDetails testDetails){
+    public PomExecutionException(
+            String message,
+            List<String> succeededPluginArtifactIds,
+            List<Throwable> exceptionsThrown,
+            ExecutedTestNamesDetails testDetails) {
         super(message, exceptionsThrown.isEmpty() ? null : exceptionsThrown.iterator().next());
         this.exceptionsThrown = new ArrayList<>(exceptionsThrown);
         this.succeededPluginArtifactIds = new ArrayList<>(succeededPluginArtifactIds);
         this.testDetails = testDetails;
     }
 
-    public String getErrorMessage(){
+    public String getErrorMessage() {
         StringBuilder strBldr = new StringBuilder();
-        strBldr.append(String.format("Message : %s %n %nExecuted plugins : %s %n %nStacktraces :%n",
-                this.getMessage(), Arrays.toString(succeededPluginArtifactIds.toArray())));
-        for(Throwable t : exceptionsThrown){
+        strBldr.append(
+                String.format(
+                        "Message : %s %n %nExecuted plugins : %s %n %nStacktraces :%n",
+                        this.getMessage(), Arrays.toString(succeededPluginArtifactIds.toArray())));
+        for (Throwable t : exceptionsThrown) {
             Writer writer = new StringWriter();
             PrintWriter printWriter = new PrintWriter(writer);
             t.printStackTrace(printWriter);

--- a/src/main/java/org/jenkins/tools/test/exception/PomTransformationException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PomTransformationException.java
@@ -33,7 +33,7 @@ package org.jenkins.tools.test.exception;
  */
 public class PomTransformationException extends Exception {
 
-    public PomTransformationException(String message, Throwable cause){
+    public PomTransformationException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -14,9 +14,7 @@ import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.PomData;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
 
-/**
- * Utility class to ease create simple hooks for multi-module projects
- */
+/** Utility class to ease create simple hooks for multi-module projects */
 public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBeforeCheckout {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractMultiParentHook.class.getName());
@@ -27,20 +25,24 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
 
     @Override
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
-        PluginCompatTesterConfig config = (PluginCompatTesterConfig)moreInfo.get("config");
-        UpdateSite.Plugin currentPlugin = (UpdateSite.Plugin)moreInfo.get("plugin");
+        PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
+        UpdateSite.Plugin currentPlugin = (UpdateSite.Plugin) moreInfo.get("plugin");
 
         // We should not execute the hook if using localCheckoutDir
-        boolean shouldExecuteHook = config.getLocalCheckoutDir() == null || !config.getLocalCheckoutDir().exists();
+        boolean shouldExecuteHook =
+                config.getLocalCheckoutDir() == null || !config.getLocalCheckoutDir().exists();
 
         if (shouldExecuteHook) {
             LOGGER.log(Level.INFO, "Executing hook for {0}", getParentProjectName());
-            // Determine if we need to run the download; only run for first identified plugin in the series
+            // Determine if we need to run the download; only run for first identified plugin in the
+            // series
             if (firstRun) {
                 LOGGER.log(Level.INFO, "Preparing for multi-module checkout");
 
-                // Checkout to the parent directory. All other processes will be on the child directory
-                File parentPath = new File(config.workDirectory.getAbsolutePath() + "/" + getParentFolder());
+                // Checkout to the parent directory. All other processes will be on the child
+                // directory
+                File parentPath =
+                        new File(config.workDirectory.getAbsolutePath() + "/" + getParentFolder());
 
                 pomData = (PomData) moreInfo.get("pomData");
                 String scmTag;
@@ -49,10 +51,18 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
                     LOGGER.log(Level.INFO, "Using SCM tag {0} from POM", scmTag);
                 } else {
                     scmTag = getParentProjectName() + "-" + currentPlugin.version;
-                    LOGGER.log(Level.INFO, "POM did not provide an SCM tag; inferring tag {0}", scmTag);
+                    LOGGER.log(
+                            Level.INFO,
+                            "POM did not provide an SCM tag; inferring tag {0}",
+                            scmTag);
                 }
                 // Like PluginCompatTester.cloneFromSCM but with subdirectories trimmed:
-                cloneFromSCM(currentPlugin, parentPath, scmTag, getUrl(), config.getFallbackGitHubOrganization());
+                cloneFromSCM(
+                        currentPlugin,
+                        parentPath,
+                        scmTag,
+                        getUrl(),
+                        config.getFallbackGitHubOrganization());
             }
 
             // Checkout already happened, don't run through again
@@ -60,9 +70,18 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
             firstRun = false;
 
             // Change the "download"" directory; after download, it's simply used for reference
-            File childPath = new File(config.workDirectory.getAbsolutePath() + "/" + getParentFolder() + "/" + getPluginFolderName(currentPlugin));
+            File childPath =
+                    new File(
+                            config.workDirectory.getAbsolutePath()
+                                    + "/"
+                                    + getParentFolder()
+                                    + "/"
+                                    + getPluginFolderName(currentPlugin));
 
-            LOGGER.log(Level.INFO, "Child path for {0}: {1}", new Object[]{currentPlugin.getDisplayName(), childPath.getPath()});
+            LOGGER.log(
+                    Level.INFO,
+                    "Child path for {0}: {1}",
+                    new Object[] {currentPlugin.getDisplayName(), childPath.getPath()});
             moreInfo.put("checkoutDir", childPath);
             moreInfo.put("pluginDir", childPath);
             moreInfo.put("parentFolder", getParentFolder());
@@ -73,19 +92,27 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
         return moreInfo;
     }
 
-    private void cloneFromSCM(UpdateSite.Plugin currentPlugin, File parentPath, String scmTag, String url, String fallbackGitHubOrganization)
+    private void cloneFromSCM(
+            UpdateSite.Plugin currentPlugin,
+            File parentPath,
+            String scmTag,
+            String url,
+            String fallbackGitHubOrganization)
             throws IOException {
 
         List<String> connectionURLs = new ArrayList<>();
         connectionURLs.add(url);
-        if(fallbackGitHubOrganization != null){
-            connectionURLs = PluginCompatTester.getFallbackConnectionURL(connectionURLs, url, fallbackGitHubOrganization);
+        if (fallbackGitHubOrganization != null) {
+            connectionURLs =
+                    PluginCompatTester.getFallbackConnectionURL(
+                            connectionURLs, url, fallbackGitHubOrganization);
         }
 
         IOException lastException = null;
-        for (String connectionURL: connectionURLs){
+        for (String connectionURL : connectionURLs) {
             if (connectionURL != null) {
-                connectionURL = connectionURL.replace("git://", "https://"); // See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
+                // See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
+                connectionURL = connectionURL.replace("git://", "https://");
             }
             try {
                 PluginCompatTester.clone(connectionURL, scmTag, parentPath);
@@ -107,9 +134,13 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
         return pomData.getConnectionUrl().replaceFirst("^(.+github[.]com/[^/]+/[^/]+)/.+", "$1");
     }
 
-    protected void configureLocalCheckOut(UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {
+    protected void configureLocalCheckOut(
+            UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {
         // Do nothing to keep compatibility with pre-existing Hooks
-        LOGGER.log(Level.INFO, "Ignoring local checkout directory for {0}", currentPlugin.getDisplayName());
+        LOGGER.log(
+                Level.INFO,
+                "Ignoring local checkout directory for {0}",
+                currentPlugin.getDisplayName());
     }
 
     /**
@@ -120,16 +151,16 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
 
     /**
      * Return the prefix to the SCM tag (usually the artifact ID of the base module). This will be
-     * used to form the checkout tag with the format {@code parentProjectName-version} in the (highly
-     * unlikely, and impossible for incrementalified plugins) event that the SCM tag is missing from
-     * the plugin's POM.
+     * used to form the checkout tag with the format {@code parentProjectName-version} in the
+     * (highly unlikely, and impossible for incrementalified plugins) event that the SCM tag is
+     * missing from the plugin's POM.
      */
     protected abstract String getParentProjectName();
 
     /**
      * Returns the plugin folder name. By default it will be the plugin name, but it can be
-     * overridden to support plugins (like {@code workflow-cps}) that are not located in a folder with
-     * the same name as the plugin itself.
+     * overridden to support plugins (like {@code workflow-cps}) that are not located in a folder
+     * with the same name as the plugin itself.
      */
     protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
         return currentPlugin.name;

--- a/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -3,10 +3,7 @@ package org.jenkins.tools.test.hook;
 import java.util.Map;
 import org.jenkins.tools.test.model.PomData;
 
-/**
- * Workaround for the Blue Ocean plugins since they are
- * stored in a central repository.
- */
+/** Workaround for the Blue Ocean plugins since they are stored in a central repository. */
 public class BlueOceanHook extends AbstractMultiParentHook {
 
     @Override
@@ -23,7 +20,8 @@ public class BlueOceanHook extends AbstractMultiParentHook {
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return "io.jenkins.blueocean".equals(data.groupId)
-                && (data.artifactId.startsWith("blueocean") || "jenkins-design-language".equals(data.artifactId))
+                && (data.artifactId.startsWith("blueocean")
+                        || "jenkins-design-language".equals(data.artifactId))
                 && "hpi".equals(data.getPackaging());
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -9,11 +9,12 @@ import org.jenkins.tools.test.model.PomData;
  */
 public class DeclarativePipelineHook extends AbstractMultiParentHook {
 
-    private static final Set<String> ARTIFACT_IDS = Set.of(
-            "pipeline-model-api",
-            "pipeline-model-definition",
-            "pipeline-model-extensions",
-            "pipeline-stage-tags-metadata");
+    private static final Set<String> ARTIFACT_IDS =
+            Set.of(
+                    "pipeline-model-api",
+                    "pipeline-model-definition",
+                    "pipeline-model-extensions",
+                    "pipeline-stage-tags-metadata");
 
     @Override
     protected String getParentFolder() {

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
@@ -5,14 +5,15 @@ import java.util.Set;
 import org.jenkins.tools.test.model.PomData;
 
 /**
- * Workaround for the Declarative Pipeline Migration Assistant plugins since they are
- * stored in a central repository.
+ * Workaround for the Declarative Pipeline Migration Assistant plugins since they are stored in a
+ * central repository.
  */
 public class DeclarativePipelineMigrationHook extends AbstractMultiParentHook {
 
-    private static final Set<String> ARTIFACT_IDS = Set.of(
-            "declarative-pipeline-migration-assistant",
-            "declarative-pipeline-migration-assistant-api");
+    private static final Set<String> ARTIFACT_IDS =
+            Set.of(
+                    "declarative-pipeline-migration-assistant",
+                    "declarative-pipeline-migration-assistant-api");
 
     @Override
     protected String getParentFolder() {

--- a/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
@@ -7,7 +7,8 @@ import org.jenkins.tools.test.model.PomData;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
 
 /**
- * Workaround for JaCoCo plugin since it needs execute the jacoco:prepare-agent goal before execution.
+ * Workaround for JaCoCo plugin since it needs execute the jacoco:prepare-agent goal before
+ * execution.
  */
 public class JacocoHook extends PluginCompatTesterHookBeforeExecution {
 
@@ -22,9 +23,17 @@ public class JacocoHook extends PluginCompatTesterHookBeforeExecution {
         List<String> args = (List<String>) info.get("args");
 
         if (args != null) {
-            int index = IntStream.range(0, args.size()).filter(i -> args.get(i).startsWith("hpi:")).findFirst().orElse(-1);
+            int index =
+                    IntStream.range(0, args.size())
+                            .filter(i -> args.get(i).startsWith("hpi:"))
+                            .findFirst()
+                            .orElse(-1);
             if (index == -1) {
-                index = IntStream.range(0, args.size()).filter(i -> args.get(i).equals("surefire:test")).findFirst().orElse(-1);
+                index =
+                        IntStream.range(0, args.size())
+                                .filter(i -> args.get(i).equals("surefire:test"))
+                                .findFirst()
+                                .orElse(-1);
             }
             if (index != -1) {
                 args.add(index, "jacoco:prepare-agent");
@@ -33,5 +42,4 @@ public class JacocoHook extends PluginCompatTesterHookBeforeExecution {
 
         return info;
     }
-
 }

--- a/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/NodeCleanupBeforeCompileHook.java
@@ -11,12 +11,15 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 
 public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCompile {
 
-    private static final Logger LOGGER = Logger.getLogger(NodeCleanupBeforeCompileHook.class.getName());
+    private static final Logger LOGGER =
+            Logger.getLogger(NodeCleanupBeforeCompileHook.class.getName());
 
     @Override
     public Map<String, Object> action(Map<String, Object> moreInfo) throws Exception {
         PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");
-        boolean shouldExecuteHook = config.getIncludePlugins().contains("sse-gateway") || config.getIncludePlugins().contains("workflow-cps");
+        boolean shouldExecuteHook =
+                config.getIncludePlugins().contains("sse-gateway")
+                        || config.getIncludePlugins().contains("workflow-cps");
 
         if (shouldExecuteHook) {
             File pluginDir = (File) moreInfo.get("pluginDir");
@@ -35,8 +38,7 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
     }
 
     @Override
-    public void validate(Map<String, Object> toCheck) {
-    }
+    public void validate(Map<String, Object> toCheck) {}
 
     private void compile(File path) throws IOException {
         LOGGER.log(Level.INFO, "Calling removeNodeFolders");
@@ -53,5 +55,4 @@ public class NodeCleanupBeforeCompileHook extends PluginCompatTesterHookBeforeCo
             FileUtils.deleteDirectory(nodeModulesFolder);
         }
     }
-
 }

--- a/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -7,9 +7,8 @@ import org.jenkins.tools.test.model.PomData;
 
 public class PipelineStageViewHook extends AbstractMultiParentHook {
 
-    private static final Set<String> ARTIFACT_IDS = Set.of(
-            "pipeline-rest-api",
-            "pipeline-stage-view");
+    private static final Set<String> ARTIFACT_IDS =
+            Set.of("pipeline-rest-api", "pipeline-stage-view");
 
     @Override
     protected String getParentFolder() {
@@ -22,7 +21,7 @@ public class PipelineStageViewHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin){
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
         return currentPlugin.name.equals("pipeline-rest-api") ? "rest-api" : "ui";
     }
 

--- a/src/main/java/org/jenkins/tools/test/hook/PluginWithFailsafeIntegrationTestsHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PluginWithFailsafeIntegrationTestsHook.java
@@ -4,7 +4,8 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Workaround for those plugins with integration tests since they need execute the failsafe:integration-test goal before execution.
+ * Workaround for those plugins with integration tests since they need execute the
+ * failsafe:integration-test goal before execution.
  */
 public class PluginWithFailsafeIntegrationTestsHook extends PluginWithIntegrationTestsHook {
 
@@ -17,5 +18,4 @@ public class PluginWithFailsafeIntegrationTestsHook extends PluginWithIntegratio
     public Collection<String> getTestTypes() {
         return List.of("failsafe");
     }
-
 }

--- a/src/main/java/org/jenkins/tools/test/hook/PluginWithIntegrationTestsHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PluginWithIntegrationTestsHook.java
@@ -6,18 +6,16 @@ import java.util.List;
 import java.util.Map;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
 
-/**
- * Hook for plugins with integration tests that need to be executed
- */
+/** Hook for plugins with integration tests that need to be executed */
 public abstract class PluginWithIntegrationTestsHook extends PluginCompatTesterHookBeforeExecution {
 
     /** Inform about goals to execute integration tests */
     @NonNull
-    abstract public Collection<String> getGoals();
+    public abstract Collection<String> getGoals();
 
     /** Inform about test type suite to execute integration test */
     @NonNull
-    abstract public Collection<String> getTestTypes();
+    public abstract Collection<String> getTestTypes();
 
     @SuppressWarnings("unchecked")
     @Override
@@ -34,5 +32,4 @@ public abstract class PluginWithIntegrationTestsHook extends PluginCompatTesterH
         }
         return info;
     }
-
 }

--- a/src/main/java/org/jenkins/tools/test/hook/SkipUIHelperPlugins.java
+++ b/src/main/java/org/jenkins/tools/test/hook/SkipUIHelperPlugins.java
@@ -22,9 +22,15 @@ public class SkipUIHelperPlugins extends PluginCompatTesterHookBeforeCheckout {
 
     private static final Logger LOGGER = Logger.getLogger(SkipUIHelperPlugins.class.getName());
 
-    private static List<String> allBundlePlugins = List.of(
-        "ace-editor", "bootstrap", "handlebars", "jquery-detached",
-        "js-module-base", "momentjs", "numeraljs");
+    private static List<String> allBundlePlugins =
+            List.of(
+                    "ace-editor",
+                    "bootstrap",
+                    "handlebars",
+                    "jquery-detached",
+                    "js-module-base",
+                    "momentjs",
+                    "numeraljs");
 
     public SkipUIHelperPlugins() {}
 
@@ -34,14 +40,14 @@ public class SkipUIHelperPlugins extends PluginCompatTesterHookBeforeCheckout {
     }
 
     /**
-     * The plugin was identified as something that should be skipped. Create a {@link TestExecutionResult}
-     * preventing forward movement. Also, indicates that we should skip the checkout completely.
+     * The plugin was identified as something that should be skipped. Create a {@link
+     * TestExecutionResult} preventing forward movement. Also, indicates that we should skip the
+     * checkout completely.
      */
     @Override
     public Map<String, Object> action(Map<String, Object> moreInfo) {
         LOGGER.log(Level.WARNING, "Plugin unsupported at this time, skipping");
-        moreInfo.put("executionResult",
-            new TestExecutionResult(new ExecutedTestNamesDetails()));
+        moreInfo.put("executionResult", new TestExecutionResult(new ExecutedTestNamesDetails()));
         moreInfo.put("runCheckout", false);
         return moreInfo;
     }

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -42,10 +42,12 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected void configureLocalCheckOut(UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {
+    protected void configureLocalCheckOut(
+            UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {
         File pluginDir = new File(localCheckoutDir, getPluginFolderName(currentPlugin));
         if (!pluginDir.exists() && !pluginDir.isDirectory()) {
-            throw new RuntimeException("Invalid localCheckoutDir for " + currentPlugin.getDisplayName());
+            throw new RuntimeException(
+                    "Invalid localCheckoutDir for " + currentPlugin.getDisplayName());
         }
 
         // Checkout already happened, don't run through again
@@ -53,7 +55,10 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
         firstRun = false;
 
         // Change the "download"" directory; after download, it's simply used for reference
-        LOGGER.log(Level.INFO, "Child path for {0}: {1}", new Object[]{currentPlugin.getDisplayName(), pluginDir.getPath()});
+        LOGGER.log(
+                Level.INFO,
+                "Child path for {0}: {1}",
+                new Object[] {currentPlugin.getDisplayName(), pluginDir.getPath()});
         moreInfo.put("checkoutDir", pluginDir);
         moreInfo.put("pluginDir", pluginDir);
     }

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
@@ -3,9 +3,7 @@ package org.jenkins.tools.test.hook;
 import java.util.Map;
 import org.jenkins.tools.test.model.PomData;
 
-/**
- * Workaround for Warnings NG plugin since it needs execute integration tests.
- */
+/** Workaround for Warnings NG plugin since it needs execute integration tests. */
 public class WarningsNGExecutionHook extends PluginWithFailsafeIntegrationTestsHook {
 
     @Override
@@ -14,5 +12,4 @@ public class WarningsNGExecutionHook extends PluginWithFailsafeIntegrationTestsH
         return "warnings-ng-parent".equals(data.artifactId) // localCheckoutDir
                 || "warnings-ng".equals(data.artifactId); // checkout
     }
-
 }

--- a/src/main/java/org/jenkins/tools/test/hook/WorkflowCpsHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WorkflowCpsHook.java
@@ -18,18 +18,20 @@ public class WorkflowCpsHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin){
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
         return "plugin";
     }
 
     @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
-        UpdateSite.Plugin plugin = info.get("plugin") != null ? (UpdateSite.Plugin) info.get("plugin") : null;
+        UpdateSite.Plugin plugin =
+                info.get("plugin") != null ? (UpdateSite.Plugin) info.get("plugin") : null;
         if (plugin != null && plugin.version != null) {
             VersionNumber pluginVersion = new VersionNumber(plugin.version);
             // 2803 was the final release before it became a multi-module project.
-            // The history of groovy-cps history was merged into the repo, so the first multi-module release will be a little over 3500.
+            // The history of groovy-cps history was merged into the repo, so the first multi-module
+            // release will be a little over 3500.
             VersionNumber multiModuleSince = new VersionNumber("3500");
             return "org.jenkins-ci.plugins.workflow".equals(data.groupId)
                     && "workflow-cps".equals(data.artifactId)

--- a/src/main/java/org/jenkins/tools/test/logging/LoggingConfiguration.java
+++ b/src/main/java/org/jenkins/tools/test/logging/LoggingConfiguration.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.MissingResourceException;
+import java.util.function.BiFunction;
 import java.util.logging.LogManager;
 
 /**
@@ -14,16 +15,26 @@ import java.util.logging.LogManager;
 public class LoggingConfiguration {
 
     public LoggingConfiguration() {
-        try (InputStream is = LoggingConfiguration.class.getResourceAsStream("logging.properties")) {
+        try (InputStream is =
+                LoggingConfiguration.class.getResourceAsStream("logging.properties")) {
             if (is == null) {
-                throw new MissingResourceException("Failed to load logging.properties", LoggingConfiguration.class.getName(), "logging.properties");
+                throw new MissingResourceException(
+                        "Failed to load logging.properties",
+                        LoggingConfiguration.class.getName(),
+                        "logging.properties");
             }
 
             // Prefer new non-null values over old values.
-            LogManager.getLogManager().updateConfiguration(is, property ->
-                    ((oldValue, newValue) -> oldValue == null && newValue == null ? null : (newValue == null ? oldValue : newValue)));
+            LogManager.getLogManager().updateConfiguration(is, property -> updateConfiguration());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private static BiFunction<String, String, String> updateConfiguration() {
+        return (oldValue, newValue) ->
+                oldValue == null && newValue == null
+                        ? null
+                        : (newValue == null ? oldValue : newValue);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/maven/MavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/MavenRunner.java
@@ -10,13 +10,14 @@ import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 
 public interface MavenRunner {
 
-    void run(Config config, File baseDirectory, File buildLogFile, String... goals) throws PomExecutionException;
+    void run(Config config, File baseDirectory, File buildLogFile, String... goals)
+            throws PomExecutionException;
 
     class Config {
 
         public final File userSettingsFile;
 
-        public final Map<String,String> userProperties = new TreeMap<>();
+        public final Map<String, String> userProperties = new TreeMap<>();
 
         public final List<String> mavenOptions;
 
@@ -25,7 +26,5 @@ public interface MavenRunner {
             userProperties.putAll(pctConfig.retrieveMavenProperties());
             mavenOptions = pctConfig.getMavenOptions();
         }
-
     }
-
 }

--- a/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenCoordinates.java
@@ -46,50 +46,61 @@ public class MavenCoordinates implements Comparable<MavenCoordinates> {
      *
      * @throws IllegalArgumentException one of the parameters is invalid.
      */
-    public MavenCoordinates(@NonNull String groupId, @NonNull String artifactId, @NonNull String version){
-        this.groupId = verifyInput( groupId, artifactId, version,"groupId", groupId);
-        this.artifactId = verifyInput( groupId, artifactId, version,"artifactId", artifactId);
-        this.version = verifyInput( groupId, artifactId, version,"version", version);
+    public MavenCoordinates(
+            @NonNull String groupId, @NonNull String artifactId, @NonNull String version) {
+        this.groupId = verifyInput(groupId, artifactId, version, "groupId", groupId);
+        this.artifactId = verifyInput(groupId, artifactId, version, "artifactId", artifactId);
+        this.version = verifyInput(groupId, artifactId, version, "version", version);
     }
 
-    private static String verifyInput(String groupId, String artifactId, String version,
-                                      String fieldName, String value) throws IllegalArgumentException {
+    private static String verifyInput(
+            String groupId, String artifactId, String version, String fieldName, String value)
+            throws IllegalArgumentException {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException(
-                    String.format("Invalid parameter passed for %s:%s:%s: Field %s; %s",
+                    String.format(
+                            "Invalid parameter passed for %s:%s:%s: Field %s; %s",
                             groupId, artifactId, version, fieldName, value));
         }
         return value.trim();
     }
 
     @Override
-    public boolean equals(Object o){
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MavenCoordinates c2 = (MavenCoordinates)o;
-        return Objects.equals(groupId, c2.groupId) && Objects.equals(artifactId, c2.artifactId) && Objects.equals(version, c2.version);
+        MavenCoordinates c2 = (MavenCoordinates) o;
+        return Objects.equals(groupId, c2.groupId)
+                && Objects.equals(artifactId, c2.artifactId)
+                && Objects.equals(version, c2.version);
     }
 
     @Override
-    public int hashCode(){
+    public int hashCode() {
         return Objects.hash(groupId, artifactId, version);
     }
 
     @Override
-    public String toString(){
-        return "MavenCoordinates[groupId="+groupId+", artifactId="+artifactId+", version="+version+"]";
+    public String toString() {
+        return "MavenCoordinates[groupId="
+                + groupId
+                + ", artifactId="
+                + artifactId
+                + ", version="
+                + version
+                + "]";
     }
 
     @Override
     public int compareTo(MavenCoordinates o) {
-        if((groupId+":"+artifactId).equals(o.groupId+":"+o.artifactId)){
+        if ((groupId + ":" + artifactId).equals(o.groupId + ":" + o.artifactId)) {
             return compareVersionTo(o.version);
         } else {
-            return (groupId+":"+artifactId).compareTo(o.groupId+":"+o.artifactId);
+            return (groupId + ":" + artifactId).compareTo(o.groupId + ":" + o.artifactId);
         }
     }
 

--- a/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -63,10 +63,10 @@ public class MavenPom {
 
     private static final Logger LOGGER = Logger.getLogger(MavenPom.class.getName());
 
-    private final static String GROUP_ID_ELEMENT = "groupId";
-    private final static String ARTIFACT_ID_ELEMENT = "artifactId";
-    private final static String VERSION_ELEMENT = "version";
-    private final static String CLASSIFIER_ELEMENT = "classifier";
+    private static final String GROUP_ID_ELEMENT = "groupId";
+    private static final String ARTIFACT_ID_ELEMENT = "artifactId";
+    private static final String VERSION_ELEMENT = "version";
+    private static final String CLASSIFIER_ELEMENT = "classifier";
 
     private File rootDir;
     private String pomFileName;
@@ -113,14 +113,14 @@ public class MavenPom {
 
             writeDocument(pom, doc);
         } catch (Exception e) {
-            throw new PomTransformationException("Error while transforming pom : " + pom.getAbsolutePath(), e);
+            throw new PomTransformationException(
+                    "Error while transforming pom : " + pom.getAbsolutePath(), e);
         }
     }
 
-    /**
-     * Removes the dependency if it exists.
-     */
-    public void removeDependency(@NonNull String groupId, @NonNull String artifactId) throws IOException {
+    /** Removes the dependency if it exists. */
+    public void removeDependency(@NonNull String groupId, @NonNull String artifactId)
+            throws IOException {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
         try {
@@ -141,8 +141,10 @@ public class MavenPom {
 
             Element groupIdElem = mavenDependency.element(GROUP_ID_ELEMENT);
             if (groupIdElem != null && groupId.equalsIgnoreCase(groupIdElem.getText())) {
-                LOGGER.log(Level.WARNING, "Removing dependency on {0}:{1}",
-                        new Object[]{groupId, artifactId});
+                LOGGER.log(
+                        Level.WARNING,
+                        "Removing dependency on {0}:{1}",
+                        new Object[] {groupId, artifactId});
                 dependencies.remove(mavenDependency);
             }
         }
@@ -152,9 +154,11 @@ public class MavenPom {
 
     /**
      * Create/Update a plugin management section with a set of plugins
+     *
      * @param includeGroupId - specify if we want to add the groupId or not
      */
-    public void addPluginManagement(List<MavenCoordinates> pluginsToAdd, boolean includeGroupId) throws IOException {
+    public void addPluginManagement(List<MavenCoordinates> pluginsToAdd, boolean includeGroupId)
+            throws IOException {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
         try {
@@ -192,9 +196,7 @@ public class MavenPom {
         writeDocument(pom, doc);
     }
 
-    /**
-     * Create/Update the properties section adding/updating some of them
-     */
+    /** Create/Update the properties section adding/updating some of them */
     public void addProperties(Properties propertiesToAdd) throws IOException {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
@@ -210,17 +212,23 @@ public class MavenPom {
         }
 
         for (Entry<Object, Object> property : propertiesToAdd.entrySet()) {
-            String key = (String)property.getKey();
+            String key = (String) property.getKey();
             Element entry = properties.element(key);
             if (entry == null) {
                 entry = properties.addElement(key);
             }
-            entry.setText((String)property.getValue());
+            entry.setText((String) property.getValue());
         }
         writeDocument(pom, doc);
     }
 
-    public void addDependencies(Map<String, VersionNumber> toAdd, Map<String, VersionNumber> toReplace, Map<String, VersionNumber> toAddTest, Map<String, VersionNumber> toReplaceTest, Map<String, String> pluginGroupIds, List<String> toConvert)
+    public void addDependencies(
+            Map<String, VersionNumber> toAdd,
+            Map<String, VersionNumber> toReplace,
+            Map<String, VersionNumber> toAddTest,
+            Map<String, VersionNumber> toReplaceTest,
+            Map<String, String> pluginGroupIds,
+            List<String> toConvert)
             throws IOException {
         File pom = new File(rootDir.getAbsolutePath() + "/" + pomFileName);
         Document doc;
@@ -234,26 +242,48 @@ public class MavenPom {
             dependencies = doc.getRootElement().addElement("dependencies");
         }
 
-        manageDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, doc, dependencies, true);
+        manageDependencies(
+                toAdd,
+                toReplace,
+                toAddTest,
+                toReplaceTest,
+                pluginGroupIds,
+                doc,
+                dependencies,
+                true);
         Element profiles = doc.getRootElement().element("profiles");
         if (profiles != null) {
             Map<String, VersionNumber> empty = new HashMap<>();
             Iterator<Element> elementIterator = profiles.elementIterator("profile");
-            while(elementIterator.hasNext()) {
+            while (elementIterator.hasNext()) {
                 Element e = elementIterator.next();
                 Element profileDependencies = e.element("dependencies");
                 if (profileDependencies == null) {
                     continue;
                 }
-                manageDependencies(empty, toReplace, empty, toReplaceTest, pluginGroupIds, doc, profileDependencies, false);
+                manageDependencies(
+                        empty,
+                        toReplace,
+                        empty,
+                        toReplaceTest,
+                        pluginGroupIds,
+                        doc,
+                        profileDependencies,
+                        false);
             }
         }
         writeDocument(pom, doc);
     }
 
-    private void manageDependencies(Map<String, VersionNumber> toAdd, Map<String, VersionNumber> toReplace,
-            Map<String, VersionNumber> toAddTest, Map<String, VersionNumber> toReplaceTest,
-            Map<String, String> pluginGroupIds, Document doc, Element dependencies, boolean addition) {
+    private void manageDependencies(
+            Map<String, VersionNumber> toAdd,
+            Map<String, VersionNumber> toReplace,
+            Map<String, VersionNumber> toAddTest,
+            Map<String, VersionNumber> toReplaceTest,
+            Map<String, String> pluginGroupIds,
+            Document doc,
+            Element dependencies,
+            boolean addition) {
         Set<String> depsWithoutClassifier = new HashSet<>();
         for (Element mavenDependency : dependencies.elements("dependency")) {
             Element artifactId = mavenDependency.element(ARTIFACT_ID_ELEMENT);
@@ -314,12 +344,16 @@ public class MavenPom {
             Element scope = mavenDependency.element("scope");
             if (scope != null && scope.getTextTrim().equals("test")) {
                 toReplaceTestUsed.put(trimmedArtifactId, replacement);
-                if (toReplaceTest.containsKey(trimmedArtifactId) && !depsWithoutClassifier.contains(trimmedArtifactId)) { // https://github.com/jenkinsci/bom/pull/301#issuecomment-694518923
+                if (toReplaceTest.containsKey(trimmedArtifactId)
+                        && !depsWithoutClassifier.contains(trimmedArtifactId)) {
+                    // https://github.com/jenkinsci/bom/pull/301#issuecomment-694518923
                     Element mainDep = mavenDependency.createCopy();
                     Element classifier = mainDep.element(CLASSIFIER_ELEMENT);
                     if (classifier != null) {
                         mainDep.remove(classifier);
-                        dependencies.add(mainDep); // would prefer to insert just before mavenDependency but API does not seem to support this
+                        // would prefer to insert just before mavenDependency but API does not seem
+                        // to support this
+                        dependencies.add(mainDep);
                     }
                 }
             } else {
@@ -328,7 +362,8 @@ public class MavenPom {
         }
 
         if (addition) {
-            // If the replacement dependencies weren't explicitly present in the pom, add them directly now
+            // If the replacement dependencies weren't explicitly present in the pom, add them
+            // directly now
             toReplace.entrySet().removeAll(toReplaceUsed.entrySet());
             toReplaceTest.entrySet().removeAll(toReplaceTestUsed.entrySet());
             toAdd.putAll(toReplace);
@@ -340,10 +375,12 @@ public class MavenPom {
         }
     }
 
-    /**
-     * Add the given new plugins to the pom file.
-     */
-    private void addPlugins(Map<String, VersionNumber> adding, Map<String, String> pluginGroupIds, Element dependencies, String scope) {
+    /** Add the given new plugins to the pom file. */
+    private void addPlugins(
+            Map<String, VersionNumber> adding,
+            Map<String, String> pluginGroupIds,
+            Element dependencies,
+            String scope) {
         for (Map.Entry<String, VersionNumber> dep : adding.entrySet()) {
             Element dependency = dependencies.addElement("dependency");
             String group = pluginGroupIds.get(dep.getKey());
@@ -384,5 +421,4 @@ public class MavenPom {
             return Charset.defaultCharset();
         }
     }
-
 }

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatReport.java
@@ -56,13 +56,13 @@ public class PluginCompatReport {
     private SortedSet<MavenCoordinates> testedCoreCoordinates;
     private String testJavaVersion;
 
-    public PluginCompatReport(){
+    public PluginCompatReport() {
         this.pluginCompatTests = new TreeMap<>();
         this.testedCoreCoordinates = new TreeSet<>();
     }
 
-    public void add(PluginInfos infos, PluginCompatResult result){
-        if(!this.pluginCompatTests.containsKey(infos)){
+    public void add(PluginInfos infos, PluginCompatResult result) {
+        if (!this.pluginCompatTests.containsKey(infos)) {
             this.pluginCompatTests.put(infos, new ArrayList<>());
         }
 
@@ -77,7 +77,7 @@ public class PluginCompatReport {
 
     public void save(File reportPath) throws IOException {
         // Ensuring every PluginCompatResult list is sorted
-        for(List<PluginCompatResult> results : this.pluginCompatTests.values()){
+        for (List<PluginCompatResult> results : this.pluginCompatTests.values()) {
             Collections.sort(results);
         }
 
@@ -86,7 +86,11 @@ public class PluginCompatReport {
         try (Writer out =
                 Files.newBufferedWriter(tempReportPath.toPath(), Charset.defaultCharset())) {
             out.write(String.format("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>%n"));
-            out.write(String.format("<?xml-stylesheet href=\"" + getXslFilename(reportPath) + "\" type=\"text/xsl\"?>%n"));
+            out.write(
+                    String.format(
+                            "<?xml-stylesheet href=\""
+                                    + getXslFilename(reportPath)
+                                    + "\" type=\"text/xsl\"?>%n"));
             XStream xstream = createXStream();
             xstream.toXML(this, out);
             out.flush();
@@ -96,28 +100,31 @@ public class PluginCompatReport {
         Files.move(tempReportPath.toPath(), reportPath.toPath(), StandardCopyOption.ATOMIC_MOVE);
     }
 
-    public static String getXslFilename(@NonNull File reportPath){
-        return getBaseFilename(reportPath)+".xsl";
+    public static String getXslFilename(@NonNull File reportPath) {
+        return getBaseFilename(reportPath) + ".xsl";
     }
 
-    public static File getXslFilepath(@NonNull File reportPath){
-        return new File(getBaseFilepath(reportPath)+".xsl");
+    public static File getXslFilepath(@NonNull File reportPath) {
+        return new File(getBaseFilepath(reportPath) + ".xsl");
     }
 
-    public static File getHtmlFilepath(@NonNull File reportPath){
-        return new File(getBaseFilepath(reportPath)+".html");
+    public static File getHtmlFilepath(@NonNull File reportPath) {
+        return new File(getBaseFilepath(reportPath) + ".html");
     }
 
-    public static String getBaseFilepath(@NonNull File reportPath){
+    public static String getBaseFilepath(@NonNull File reportPath) {
         File parentFile = reportPath.getParentFile();
         if (parentFile == null) {
-            throw new IllegalArgumentException("The report path " + reportPath + " does not have a directory specification. " +
-                    "A correct path should be something like 'out/pct-report.xml'");
+            throw new IllegalArgumentException(
+                    "The report path "
+                            + reportPath
+                            + " does not have a directory specification. "
+                            + "A correct path should be something like 'out/pct-report.xml'");
         }
-        return parentFile.getAbsolutePath()+"/"+getBaseFilename(reportPath);
+        return parentFile.getAbsolutePath() + "/" + getBaseFilename(reportPath);
     }
 
-    public static String getBaseFilename(File reportPath){
+    public static String getBaseFilename(File reportPath) {
         return reportPath.getName().split("\\.")[0];
     }
 
@@ -134,25 +141,31 @@ public class PluginCompatReport {
 
         // Reading report file from reportPath
         XStream xstream = createXStream();
-        try(FileInputStream istream = new FileInputStream(reportPath)) {
-            report = (PluginCompatReport)xstream.fromXML(istream);
+        try (FileInputStream istream = new FileInputStream(reportPath)) {
+            report = (PluginCompatReport) xstream.fromXML(istream);
         } catch (FileNotFoundException e) {
             // Path doesn't exist => create a new report object
             report = new PluginCompatReport();
         }
 
         // Ensuring we are using a TreeMap for pluginCompatTests
-        if(!(report.pluginCompatTests instanceof SortedMap)){
+        if (!(report.pluginCompatTests instanceof SortedMap)) {
             report.pluginCompatTests = new TreeMap<>(report.pluginCompatTests);
         }
 
         return report;
     }
 
-    private static XStream createXStream(){
+    private static XStream createXStream() {
         XStream xstream = new XStream(new MXParserDomDriver());
         xstream.setMode(XStream.NO_REFERENCES);
-        xstream.allowTypes(new Class[] {MavenCoordinates.class, PluginCompatReport.class, PluginCompatResult.class, PluginInfos.class});
+        xstream.allowTypes(
+                new Class[] {
+                    MavenCoordinates.class,
+                    PluginCompatReport.class,
+                    PluginCompatResult.class,
+                    PluginInfos.class
+                });
         xstream.alias("pluginInfos", PluginInfos.class);
         xstream.alias("coord", MavenCoordinates.class);
         xstream.alias("compatResult", PluginCompatResult.class);
@@ -173,7 +186,7 @@ public class PluginCompatReport {
         return testJavaVersion;
     }
 
-    public Map<PluginInfos, List<PluginCompatResult>> getPluginCompatTests(){
+    public Map<PluginInfos, List<PluginCompatResult>> getPluginCompatTests() {
         return new TreeMap<>(pluginCompatTests);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatResult.java
@@ -48,16 +48,23 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
 
     private String buildLogPath = "";
 
-    public PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, Set<String> testDetails,
-                              String buildLogPath){
+    public PluginCompatResult(
+            MavenCoordinates coreCoordinates,
+            TestStatus status,
+            String errorMessage,
+            Set<String> testDetails,
+            String buildLogPath) {
         // Create new result with current date
         this(coreCoordinates, status, errorMessage, testDetails, buildLogPath, new Date());
     }
 
-    private PluginCompatResult(MavenCoordinates coreCoordinates, TestStatus status,
-                              String errorMessage, Set<String> testDetails,
-                              String buildLogPath, Date compatTestExecutedOn){
+    private PluginCompatResult(
+            MavenCoordinates coreCoordinates,
+            TestStatus status,
+            String errorMessage,
+            Set<String> testDetails,
+            String buildLogPath,
+            Date compatTestExecutedOn) {
         this.coreCoordinates = coreCoordinates;
 
         this.status = status;
@@ -71,19 +78,19 @@ public class PluginCompatResult implements Comparable<PluginCompatResult> {
     }
 
     @Override
-    public boolean equals(Object o){
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PluginCompatResult res = (PluginCompatResult)o;
+        PluginCompatResult res = (PluginCompatResult) o;
         return Objects.equals(coreCoordinates, res.coreCoordinates);
     }
 
     @Override
-    public int hashCode(){
+    public int hashCode() {
         return Objects.hash(coreCoordinates);
     }
 

--- a/src/main/java/org/jenkins/tools/test/model/PluginInfos.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginInfos.java
@@ -38,34 +38,35 @@ public class PluginInfos implements Comparable<PluginInfos> {
     public final String pluginVersion;
     public final String pluginUrl;
 
-    public PluginInfos(String pluginName, String pluginVersion, String pluginUrl){
+    public PluginInfos(String pluginName, String pluginVersion, String pluginUrl) {
         this.pluginName = pluginName;
         this.pluginVersion = pluginVersion;
         this.pluginUrl = pluginUrl;
     }
 
     @Override
-    public boolean equals(Object o){
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PluginInfos infos = (PluginInfos)o;
-        return Objects.equals(pluginName, infos.pluginName) && Objects.equals(pluginVersion, infos.pluginVersion);
+        PluginInfos infos = (PluginInfos) o;
+        return Objects.equals(pluginName, infos.pluginName)
+                && Objects.equals(pluginVersion, infos.pluginVersion);
     }
 
     @Override
-    public int hashCode(){
+    public int hashCode() {
         return Objects.hash(pluginName, pluginVersion);
     }
 
     @Override
     public int compareTo(PluginInfos o) {
-        if(pluginName.equals(o.pluginName)){
+        if (pluginName.equals(o.pluginName)) {
             return pluginVersion.compareTo(o.pluginVersion);
-        }else{
+        } else {
             return pluginName.compareToIgnoreCase(o.pluginName);
         }
     }

--- a/src/main/java/org/jenkins/tools/test/model/PomData.java
+++ b/src/main/java/org/jenkins/tools/test/model/PomData.java
@@ -38,15 +38,19 @@ public class PomData {
     public final String artifactId;
     public final String groupId;
 
-    @NonNull
-    private final String packaging;
+    @NonNull private final String packaging;
 
-    @CheckForNull
-    public final MavenCoordinates parent;
+    @CheckForNull public final MavenCoordinates parent;
     private String connectionUrl;
     private String scmTag;
 
-    public PomData(String artifactId, @CheckForNull String packaging, String connectionUrl, String scmTag, @CheckForNull MavenCoordinates parent, String groupId){
+    public PomData(
+            String artifactId,
+            @CheckForNull String packaging,
+            String connectionUrl,
+            String scmTag,
+            @CheckForNull MavenCoordinates parent,
+            String groupId) {
         this.artifactId = artifactId;
         this.groupId = groupId;
         this.packaging = packaging != null ? packaging : "jar";

--- a/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
+++ b/src/main/java/org/jenkins/tools/test/model/TestExecutionResult.java
@@ -37,7 +37,7 @@ public class TestExecutionResult {
 
     private final ExecutedTestNamesDetails testDetails;
 
-    public TestExecutionResult(ExecutedTestNamesDetails testDetails){
+    public TestExecutionResult(ExecutedTestNamesDetails testDetails) {
         this.testDetails = testDetails;
     }
 

--- a/src/main/java/org/jenkins/tools/test/model/TestStatus.java
+++ b/src/main/java/org/jenkins/tools/test/model/TestStatus.java
@@ -32,15 +32,18 @@ package org.jenkins.tools.test.model;
  * @author Frederic Camblor
  */
 public enum TestStatus {
-    INTERNAL_ERROR(0.0), COMPILATION_ERROR(1.0), TEST_FAILURES(2.0), SUCCESS(3.0);
+    INTERNAL_ERROR(0.0),
+    COMPILATION_ERROR(1.0),
+    TEST_FAILURES(2.0),
+    SUCCESS(3.0);
 
     private final double weight;
 
-    TestStatus(double weight){
+    TestStatus(double weight) {
         this.weight = weight;
     }
 
-    public boolean isLowerThan(TestStatus s){
+    public boolean isLowerThan(TestStatus s) {
         return weight < s.weight;
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/comparators/VersionComparator.java
+++ b/src/main/java/org/jenkins/tools/test/model/comparators/VersionComparator.java
@@ -41,36 +41,41 @@ public class VersionComparator implements Comparator<String>, Serializable {
         String[] splitO1Version = o1.split("\\.|-");
         String[] splitO2Version = o2.split("\\.|-");
 
-        for(int i=0; i<splitO1Version.length; i++){
-            if(i >= splitO2Version.length){
+        for (int i = 0; i < splitO1Version.length; i++) {
+            if (i >= splitO2Version.length) {
                 return 1;
             }
 
             Comparable chunk1;
             try {
                 chunk1 = Integer.valueOf(splitO1Version[i]);
-            }catch(NumberFormatException e){
+            } catch (NumberFormatException e) {
                 chunk1 = splitO1Version[i];
             }
 
             Comparable chunk2;
             try {
                 chunk2 = Integer.valueOf(splitO2Version[i]);
-            }catch(NumberFormatException e){
+            } catch (NumberFormatException e) {
                 chunk2 = splitO2Version[i];
             }
 
             if (chunk1.getClass() != chunk2.getClass()) {
-                throw new IllegalArgumentException("Comparing different types in chunk " + i +
-                        ". Version 1 = " + o1 + ", version 2 = " + o2);
+                throw new IllegalArgumentException(
+                        "Comparing different types in chunk "
+                                + i
+                                + ". Version 1 = "
+                                + o1
+                                + ", version 2 = "
+                                + o2);
             }
 
-            if(!splitO1Version[i].equals(splitO2Version[i])){
+            if (!splitO1Version[i].equals(splitO2Version[i])) {
                 return chunk1.compareTo(chunk2);
             }
         }
 
-        if(splitO1Version.length == splitO2Version.length){
+        if (splitO1Version.length == splitO2Version.length) {
             return 0;
         } else {
             return -1;

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHook.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHook.java
@@ -13,38 +13,36 @@ import java.util.Map;
  * enable Plugin Compatibility Tester to actually go about testing the plugin rather than throwing
  * up its hands in defeat.
  */
- public interface PluginCompatTesterHook {
+public interface PluginCompatTesterHook {
 
-     /**
-      * Check if the plugin should be affected by this hook. There are several different ways this
-      * could be implemented, and the details are left up to the user.
-      *
-      * <p>Always run this hook unless otherwise specified.
-      */
-     default boolean check(Map<String, Object> info) {
-         return true;
-     }
+    /**
+     * Check if the plugin should be affected by this hook. There are several different ways this
+     * could be implemented, and the details are left up to the user.
+     *
+     * <p>Always run this hook unless otherwise specified.
+     */
+    default boolean check(Map<String, Object> info) {
+        return true;
+    }
 
-     /**
-      * The core action of what actually needs to be done by the hook. This can do a number of things
-      * such as transform the POM, return custom Maven arguments, etc.
-      *
-      * <p>Certain implementations could throw exceptions.
-      */
-     Map<String, Object> action(Map<String, Object> moreInfo) throws Exception;
+    /**
+     * The core action of what actually needs to be done by the hook. This can do a number of things
+     * such as transform the POM, return custom Maven arguments, etc.
+     *
+     * <p>Certain implementations could throw exceptions.
+     */
+    Map<String, Object> action(Map<String, Object> moreInfo) throws Exception;
 
-     /**
-      * List the plugins this hook affects. This can be a single plugin, a list of plugins, or simply
-      * all plugins.
-      *
-      * <p>Apply this hook to all plugins unless otherwise specified.
-      */
-     default List<String> transformedPlugins() {
-         return new ArrayList<>(Collections.singletonList("all"));
-     }
+    /**
+     * List the plugins this hook affects. This can be a single plugin, a list of plugins, or simply
+     * all plugins.
+     *
+     * <p>Apply this hook to all plugins unless otherwise specified.
+     */
+    default List<String> transformedPlugins() {
+        return new ArrayList<>(Collections.singletonList("all"));
+    }
 
-     /**
-      * Check the object used for this hook.
-      */
-     void validate(Map<String, Object> toCheck);
- }
+    /** Check the object used for this hook. */
+    void validate(Map<String, Object> toCheck);
+}

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCheckout.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCheckout.java
@@ -16,11 +16,14 @@ public abstract class PluginCompatTesterHookBeforeCheckout implements PluginComp
      */
     @Override
     public void validate(Map<String, Object> toCheck) {
-        if((toCheck.get("runCheckout") != null &&
-            (toCheck.get("runCheckout").getClass().isPrimitive() || ClassUtils.wrapperToPrimitive(toCheck.get("runCheckout").getClass()) != null)) &&
-            (toCheck.get("pluginDir") != null &&
-            toCheck.get("pluginDir") instanceof String) ) {
-                throw new IllegalArgumentException("A hook modified a required parameter for plugin checkout.");
+        if (toCheck.get("runCheckout") != null
+                && (toCheck.get("runCheckout").getClass().isPrimitive()
+                        || ClassUtils.wrapperToPrimitive(toCheck.get("runCheckout").getClass())
+                                != null)
+                && toCheck.get("pluginDir") != null
+                && toCheck.get("pluginDir") instanceof String) {
+            throw new IllegalArgumentException(
+                    "A hook modified a required parameter for plugin checkout.");
         }
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCompile.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCompile.java
@@ -17,5 +17,4 @@ package org.jenkins.tools.test.model.hook;
 public abstract class PluginCompatTesterHookBeforeCompile implements PluginCompatTesterHook {
 
     public static final String OVERRIDE_DEFAULT_COMPILE = "ranCompile";
-
 }

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeExecution.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeExecution.java
@@ -16,11 +16,10 @@ public abstract class PluginCompatTesterHookBeforeExecution implements PluginCom
      */
     @Override
     public void validate(Map<String, Object> toCheck) {
-        if((toCheck.get("args") != null &&
-            toCheck.get("args") instanceof String) &&
-            (toCheck.get("pomData") != null &&
-            toCheck.get("pomData") instanceof PomData) ) {
-                throw new IllegalArgumentException("A hook modified a required parameter for plugin test execution.");
+        if ((toCheck.get("args") != null && toCheck.get("args") instanceof String)
+                && (toCheck.get("pomData") != null && toCheck.get("pomData") instanceof PomData)) {
+            throw new IllegalArgumentException(
+                    "A hook modified a required parameter for plugin test execution.");
         }
     }
 }

--- a/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesDetails.java
+++ b/src/main/java/org/jenkins/tools/test/util/ExecutedTestNamesDetails.java
@@ -46,7 +46,9 @@ public class ExecutedTestNamesDetails {
     }
 
     private Set<String> get(String key) {
-        return this.tests.containsKey(key) ? Collections.unmodifiableSet(new TreeSet<>(this.tests.get(key))) : null;
+        return this.tests.containsKey(key)
+                ? Collections.unmodifiableSet(new TreeSet<>(this.tests.get(key)))
+                : null;
     }
 
     private void add(String key, String test) {

--- a/src/main/java/org/jenkins/tools/test/util/StreamGobbler.java
+++ b/src/main/java/org/jenkins/tools/test/util/StreamGobbler.java
@@ -25,7 +25,8 @@ public class StreamGobbler extends Thread {
 
     @Override
     public void run() {
-        try (Reader r = new InputStreamReader(is, Charset.defaultCharset()); BufferedReader br = new BufferedReader(r)) {
+        try (Reader r = new InputStreamReader(is, Charset.defaultCharset());
+                BufferedReader br = new BufferedReader(r)) {
             String line;
             while ((line = br.readLine()) != null) {
                 output.append(line);

--- a/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -49,11 +49,12 @@ import org.jvnet.hudson.test.Issue;
  */
 public class PluginCompatTesterTest {
 
-    private static final String REPORT_FILE = String.format("%s%sreports%sPluginCompatReport.xml",
-            System.getProperty("java.io.tmpdir"), File.separator, File.separator);
+    private static final String REPORT_FILE =
+            String.format(
+                    "%s%sreports%sPluginCompatReport.xml",
+                    System.getProperty("java.io.tmpdir"), File.separator, File.separator);
 
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
+    @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -166,11 +167,13 @@ public class PluginCompatTesterTest {
     @Issue("JENKINS-50454")
     public void testCustomWarPackagerVersions() {
         // TODO: needs more filtering
-        String fileName = "WEB-INF/lib/jenkins-core-256.0-my-branch-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
+        String fileName =
+                "WEB-INF/lib/jenkins-core-256.0-my-branch-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
         Matcher m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
         assertTrue("No matches", m.matches());
 
-        fileName = "WEB-INF/lib/jenkins-core-256.0-2090468d82e49345519a2457f1d1e7426f01540b-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
+        fileName =
+                "WEB-INF/lib/jenkins-core-256.0-2090468d82e49345519a2457f1d1e7426f01540b-2090468d82e49345519a2457f1d1e7426f01540b-SNAPSHOT.jar";
         m = Pattern.compile(PluginCompatTester.JENKINS_CORE_FILE_REGEX).matcher(fileName);
         assertTrue("No matches", m.matches());
     }

--- a/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
+++ b/src/test/java/org/jenkins/tools/test/ScmConnectionSpecialCasesTest.java
@@ -43,9 +43,16 @@ import org.junit.Test;
  */
 public class ScmConnectionSpecialCasesTest {
 
-    private static void runComputeScmConnectionAgainst(String scmUrlToTest, String artifactId, String expectedComputedScmUrl) {
-        PomData pom = new PomData(artifactId, "hpi", scmUrlToTest, "jenkins-2.150.1",
-                new MavenCoordinates("org.jenkins-ci.main", "cli", "2.150.1"), "org.jenkins-ci.main");
+    private static void runComputeScmConnectionAgainst(
+            String scmUrlToTest, String artifactId, String expectedComputedScmUrl) {
+        PomData pom =
+                new PomData(
+                        artifactId,
+                        "hpi",
+                        scmUrlToTest,
+                        "jenkins-2.150.1",
+                        new MavenCoordinates("org.jenkins-ci.main", "cli", "2.150.1"),
+                        "org.jenkins-ci.main");
         PluginRemoting.computeScmConnection(pom);
         assertThat(pom.getConnectionUrl(), is(equalTo(expectedComputedScmUrl)));
     }
@@ -53,103 +60,103 @@ public class ScmConnectionSpecialCasesTest {
     @Test
     public void shouldOldJavaNetSubversionRepoUrlBeenMigrated() {
         runComputeScmConnectionAgainst(
-                "scm:svn:https://guest@svn.dev.java.net/svn/hudson/tags/scm-sync-configuration/scm-sync-configuration-0.0.1", // old java.net url
+                // old java.net url
+                "scm:svn:https://guest@svn.dev.java.net/svn/hudson/tags/scm-sync-configuration/scm-sync-configuration-0.0.1",
                 "",
-                "scm:svn:https://guest@svn.java.net/svn/hudson~svn/tags/scm-sync-configuration/scm-sync-configuration-0.0.1"
-        );
+                "scm:svn:https://guest@svn.java.net/svn/hudson~svn/tags/scm-sync-configuration/scm-sync-configuration-0.0.1");
         runComputeScmConnectionAgainst(
-                "scm:svn:https://guest@hudson.dev.java.net/svn/hudson/tags/labeled-test-groups-publisher-1.2.6", // old java.net url
+                // old java.net url
+                "scm:svn:https://guest@hudson.dev.java.net/svn/hudson/tags/labeled-test-groups-publisher-1.2.6",
                 "",
-                "scm:svn:https://guest@svn.java.net/svn/hudson~svn/tags/labeled-test-groups-publisher-1.2.6"
-        );
+                "scm:svn:https://guest@svn.java.net/svn/hudson~svn/tags/labeled-test-groups-publisher-1.2.6");
     }
 
     @Test
     public void shouldProjectArtifactIdCorrectlyReplacedInUrls() {
         runComputeScmConnectionAgainst(
-                "scm:git:git://github.com/jenkinsci/${project.artifactId}.git", // ${project.artifactId}
+                // ${project.artifactId}
+                "scm:git:git://github.com/jenkinsci/${project.artifactId}.git",
                 "scm-sync-configuration-plugin",
-                "scm:git:git://github.com/jenkinsci/scm-sync-configuration-plugin.git"
-        );
+                "scm:git:git://github.com/jenkinsci/scm-sync-configuration-plugin.git");
     }
 
     @Ignore("disabled this transformation")
     @Test
     public void shouldGithubUsernamedUrlBeFiltered() {
         runComputeScmConnectionAgainst(
-                "scm:git:https://sikakura@github.com/jenkinsci/mail-commander-plugin.git", // user specific authentication
+                // user specific authentication
+                "scm:git:https://sikakura@github.com/jenkinsci/mail-commander-plugin.git",
                 "",
-                "scm:git:git://github.com/jenkinsci/mail-commander-plugin.git"
-        );
+                "scm:git:git://github.com/jenkinsci/mail-commander-plugin.git");
     }
 
     @Test
     public void shouldPluginSuffixOnlyAppliedOnScmSyncConfiguration() {
         runComputeScmConnectionAgainst(
-                "scm:git:git://github.com/jenkinsci/scm-sync-configuration.git",  // special case of scm-sync-configuration
+                // special case of scm-sync-configuration
+                "scm:git:git://github.com/jenkinsci/scm-sync-configuration.git",
                 "scm-sync-configuration",
-                "scm:git:git://github.com/jenkinsci/scm-sync-configuration-plugin.git"
-        );
+                "scm:git:git://github.com/jenkinsci/scm-sync-configuration-plugin.git");
         runComputeScmConnectionAgainst(
                 "scm:git:git://github.com/magnayn/Jenkins-AdaptivePlugin.git",
                 "Jenkins-AdaptivePlugin",
-                "scm:git:git://github.com/magnayn/Jenkins-AdaptivePlugin.git"
-        );
+                "scm:git:git://github.com/magnayn/Jenkins-AdaptivePlugin.git");
         runComputeScmConnectionAgainst(
                 "scm:git:git://github.com/jenkinsci/copy-project-link.git",
                 "copy-project-link",
-                "scm:git:git://github.com/jenkinsci/copy-project-link.git"
-        );
+                "scm:git:git://github.com/jenkinsci/copy-project-link.git");
     }
 
     @Test
     public void shouldGithubDotComBeFollowedBySlashes() {
         runComputeScmConnectionAgainst(
-                "scm:git:git://github.com:cittools/artifactdeployer-plugin.git", // No / after github.com
+                // No / after github.com
+                "scm:git:git://github.com:cittools/artifactdeployer-plugin.git",
                 "",
-                "scm:git:git://github.com/cittools/artifactdeployer-plugin.git"
-        );
+                "scm:git:git://github.com/cittools/artifactdeployer-plugin.git");
     }
 
     @Test
     public void shouldGitHudsonRepoBeMigratedToJenkinsCI() {
         runComputeScmConnectionAgainst(
-                "scm:git:git://github.com/hudson/hudson-clearcase-plugin.git", // hudson repository
+                // hudson repository
+                "scm:git:git://github.com/hudson/hudson-clearcase-plugin.git",
                 "",
-                "scm:git:git://github.com/jenkinsci/hudson-clearcase-plugin.git"
-        );
+                "scm:git:git://github.com/jenkinsci/hudson-clearcase-plugin.git");
     }
 
     @Test
     public void shouldScmConnectionBeTrimmed() {
         runComputeScmConnectionAgainst(
-                "\n   scm:git:https://github.com/jenkinsci/cifs-plugin.git  \n   ", // ssh protocol requiring ssh host key
+                // ssh protocol requiring ssh host key
+                "\n   scm:git:https://github.com/jenkinsci/cifs-plugin.git  \n   ",
                 "",
-                "scm:git:https://github.com/jenkinsci/cifs-plugin.git"
-        );
+                "scm:git:https://github.com/jenkinsci/cifs-plugin.git");
     }
 
     @Ignore("disabled this transformation")
     @Test
     public void shouldGitAtGithubReplaceByGitProtocol() {
         runComputeScmConnectionAgainst(
-                "scm:git:git@github.com:jenkinsci/jquery-plugin.git", // git@github.com
+                // git@github.com
+                "scm:git:git@github.com:jenkinsci/jquery-plugin.git",
                 "",
-                "scm:git:git://github.com/jenkinsci/jquery-plugin.git"
-        );
+                "scm:git:git://github.com/jenkinsci/jquery-plugin.git");
     }
 
     @Test()
     public void shouldEmptyConnectionUrlImpliesGithubUrlGeneration() {
         runComputeScmConnectionAgainst(
-                "", // ssh protocol requiring ssh host key
+                // ssh protocol requiring ssh host key
+                "",
                 "hudsontrayapp",
-                "scm:git:git://github.com/jenkinsci/hudsontrayapp-plugin.git"  // Special case
-        );
+                // Special case
+                "scm:git:git://github.com/jenkinsci/hudsontrayapp-plugin.git");
         runComputeScmConnectionAgainst(
-                "", // ssh protocol requiring ssh host key
+                // ssh protocol requiring ssh host key
+                "",
                 "jenkinswalldisplay",
-                "scm:git:git://github.com/jenkinsci/walldisplay-plugin.git"   // Special case
-        );
+                // Special case
+                "scm:git:git://github.com/jenkinsci/walldisplay-plugin.git");
     }
 }

--- a/src/test/java/org/jenkins/tools/test/VersionComparatorTest.java
+++ b/src/test/java/org/jenkins/tools/test/VersionComparatorTest.java
@@ -41,33 +41,33 @@ import org.junit.Test;
  */
 public class VersionComparatorTest {
 
-    private static final Map<String, Integer> OPERAND_CONVERSION = Map.of(
-            "<", -1,
-            "=", 0,
-            ">", 1
-    );
+    private static final Map<String, Integer> OPERAND_CONVERSION =
+            Map.of(
+                    "<", -1,
+                    "=", 0,
+                    ">", 1);
 
-    private void test(String v1, String operator, String v2){
+    private void test(String v1, String operator, String v2) {
         test(v1, OPERAND_CONVERSION.get(operator), v2);
     }
 
-    private void test(String v1, int compResult, String v2){
+    private void test(String v1, int compResult, String v2) {
         assertThat(new VersionComparator().compare(v1, v2), is(equalTo(compResult)));
     }
 
-    private void testAndCommutate(String v1, String operand, String v2){
+    private void testAndCommutate(String v1, String operand, String v2) {
         test(v1, OPERAND_CONVERSION.get(operand), v2);
         test(v2, OPERAND_CONVERSION.get(operand) * -1, v1);
     }
 
     @Test
-    public void shouldBasicEqualComparisonTestBeOk(){
+    public void shouldBasicEqualComparisonTestBeOk() {
         test("1.2.3", "=", "1.2.3");
         test("1", "=", "1");
     }
 
     @Test
-    public void shouldBasicNonEqualComparisonTestBeOk(){
+    public void shouldBasicNonEqualComparisonTestBeOk() {
         testAndCommutate("1", "<", "2");
         testAndCommutate("10", ">", "2");
         testAndCommutate("1.2", "<", "2.1");
@@ -77,7 +77,7 @@ public class VersionComparatorTest {
     }
 
     @Test
-    public void shouldSpecialCasesBeHandledCorrectly(){
+    public void shouldSpecialCasesBeHandledCorrectly() {
         test("1", "<", "1.2.1");
         test("1.2", "<", "1.2.1");
         test("1.1-beta", ">", "1.1-alpha");

--- a/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
@@ -18,14 +18,29 @@ public class JacocoHookTest {
     @Test
     public void testCheckMethod() {
         final JacocoHook hook = new JacocoHook();
-        final MavenCoordinates parent = new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.57");
+        final MavenCoordinates parent =
+                new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.57");
 
-        PomData pomData = new PomData("jacoco", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        PomData pomData =
+                new PomData(
+                        "jacoco",
+                        "hpi",
+                        "it-does-not-matter",
+                        "whatever",
+                        parent,
+                        "org.jenkins-ci.plugins");
         Map<String, Object> info = new HashMap<>();
         info.put("pomData", pomData);
         assertTrue(hook.check(info));
 
-        pomData = new PomData("other-plugin", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        pomData =
+                new PomData(
+                        "other-plugin",
+                        "hpi",
+                        "it-does-not-matter",
+                        "whatever",
+                        parent,
+                        "org.jenkins-ci.plugins");
         info = new HashMap<>();
         info.put("pomData", pomData);
         assertFalse(hook.check(info));
@@ -36,32 +51,34 @@ public class JacocoHookTest {
         final JacocoHook hook = new JacocoHook();
 
         Map<String, Object> info = new HashMap<>();
-        info.put("args", new ArrayList<>(List.of(
-                "--define=forkCount=1",
-                "hpi:resolve-test-dependencies",
-                "hpi:test-hpl",
-                "surefire:test")));
+        info.put(
+                "args",
+                new ArrayList<>(
+                        List.of(
+                                "--define=forkCount=1",
+                                "hpi:resolve-test-dependencies",
+                                "hpi:test-hpl",
+                                "surefire:test")));
         Map<String, Object> afterAction = hook.action(info);
         List<String> args = (List<String>) afterAction.get("args");
         assertThat(args.size(), is(5));
         assertThat(args.get(1), is("jacoco:prepare-agent"));
 
         info = new HashMap<>();
-        info.put("args", new ArrayList<>(List.of(
-                "--define=forkCount=1",
-                "other-plugin:other-goal",
-                "surefire:test")));
+        info.put(
+                "args",
+                new ArrayList<>(
+                        List.of(
+                                "--define=forkCount=1",
+                                "other-plugin:other-goal",
+                                "surefire:test")));
         afterAction = hook.action(info);
         args = (List<String>) afterAction.get("args");
         assertThat(args.size(), is(4));
         assertThat(args.get(2), is("jacoco:prepare-agent"));
 
         info = new HashMap<>();
-        info.put("args", new ArrayList<>(List.of(
-                "element1",
-                "element2",
-                "element3",
-                "element4")));
+        info.put("args", new ArrayList<>(List.of("element1", "element2", "element3", "element4")));
         afterAction = hook.action(info);
         args = (List<String>) afterAction.get("args");
         assertThat(args.size(), is(4));

--- a/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
@@ -18,14 +18,29 @@ public class WarningsNGExecutionHookTest {
     @Test
     public void testCheckMethod() {
         final WarningsNGExecutionHook hook = new WarningsNGExecutionHook();
-        final MavenCoordinates parent = new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.57");
+        final MavenCoordinates parent =
+                new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "3.57");
 
-        PomData pomData = new PomData("warnings-ng", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        PomData pomData =
+                new PomData(
+                        "warnings-ng",
+                        "hpi",
+                        "it-does-not-matter",
+                        "whatever",
+                        parent,
+                        "org.jenkins-ci.plugins");
         Map<String, Object> info = new HashMap<>();
         info.put("pomData", pomData);
         assertTrue(hook.check(info));
 
-        pomData = new PomData("other-plugin", "hpi", "it-does-not-matter", "whatever", parent, "org.jenkins-ci.plugins");
+        pomData =
+                new PomData(
+                        "other-plugin",
+                        "hpi",
+                        "it-does-not-matter",
+                        "whatever",
+                        parent,
+                        "org.jenkins-ci.plugins");
         info = new HashMap<>();
         info.put("pomData", pomData);
         assertFalse(hook.check(info));
@@ -36,11 +51,14 @@ public class WarningsNGExecutionHookTest {
         final WarningsNGExecutionHook hook = new WarningsNGExecutionHook();
 
         Map<String, Object> info = new HashMap<>();
-        info.put("args", new ArrayList<>(List.of(
-                "--define=forkCount=1",
-                "hpi:resolve-test-dependencies",
-                "hpi:test-hpl",
-                "surefire:test")));
+        info.put(
+                "args",
+                new ArrayList<>(
+                        List.of(
+                                "--define=forkCount=1",
+                                "hpi:resolve-test-dependencies",
+                                "hpi:test-hpl",
+                                "surefire:test")));
         Map<String, Object> afterAction = hook.action(info);
         List<String> args = (List<String>) afterAction.get("args");
         assertThat(args.size(), is(5));

--- a/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
@@ -21,8 +21,7 @@ import org.jvnet.hudson.test.Issue;
 
 public class MavenPomTest {
 
-    @Rule
-    public TemporaryFolder tmp = new TemporaryFolder();
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     @Issue("https://github.com/jenkinsci/bom/pull/301#issuecomment-694518923")
     @Test
@@ -30,23 +29,158 @@ public class MavenPomTest {
         File prj = tmp.newFolder();
         File pom = createPomFileFromResource(prj, "credentials-binding-pom-before.xml");
 
-        Map<String, VersionNumber> toAdd = new HashMap<>(Map.of("trilead-api", new VersionNumber("1.0.8")));
-        Map<String, VersionNumber> toReplace = new HashMap<>(Map.of("credentials", new VersionNumber("2.3.12"), "ssh-credentials", new VersionNumber("1.18.1"), "plain-credentials", new VersionNumber("1.7")));
+        Map<String, VersionNumber> toAdd =
+                new HashMap<>(Map.of("trilead-api", new VersionNumber("1.0.8")));
+        Map<String, VersionNumber> toReplace =
+                new HashMap<>(
+                        Map.of(
+                                "credentials",
+                                new VersionNumber("2.3.12"),
+                                "ssh-credentials",
+                                new VersionNumber("1.18.1"),
+                                "plain-credentials",
+                                new VersionNumber("1.7")));
         Map<String, VersionNumber> toAddTest = new HashMap<>();
-        Map<String, VersionNumber> toReplaceTest = new HashMap<>(Map.of("workflow-scm-step", new VersionNumber("2.11"), "workflow-durable-task-step", new VersionNumber("2.35"), "display-url-api", new VersionNumber("2.3.3"), "script-security", new VersionNumber("1.74"), "workflow-cps", new VersionNumber("2.83")));
-        toReplaceTest.putAll(Map.of("workflow-support", new VersionNumber("3.5"), "workflow-job", new VersionNumber("2.39"), "workflow-basic-steps", new VersionNumber("2.20")));
-        Map<String, String> pluginGroupIds = new HashMap<>(Map.of("credentials-binding", "org.jenkins-ci.plugins", "pipeline-build-step", "org.jenkins-ci.plugins", "credentials", "org.jenkins-ci.plugins", "jdk-tool", "org.jenkins-ci.plugins", "snakeyaml-api", "io.jenkins.plugins"));
-        pluginGroupIds.putAll(Map.of("workflow-step-api", "org.jenkins-ci.plugins.workflow", "plain-credentials", "org.jenkins-ci.plugins", "trilead-api", "org.jenkins-ci.plugins", "command-launcher", "org.jenkins-ci.plugins", "jquery", "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(Map.of("matrix-project", "org.jenkins-ci.plugins", "jquery-detached", "org.jenkins-ci.ui", "ace-editor", "org.jenkins-ci.ui", "git", "org.jenkins-ci.plugins", "workflow-durable-task-step", "org.jenkins-ci.plugins.workflow"));
-        pluginGroupIds.putAll(Map.of("git-client", "org.jenkins-ci.plugins", "ssh-credentials", "org.jenkins-ci.plugins", "variant", "org.jenkins-ci.plugins", "cloudbees-folder", "org.jenkins-ci.plugins", "scm-api", "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(Map.of("pipeline-stage-step", "org.jenkins-ci.plugins", "junit-attachments", "org.jenkins-ci.plugins", "durable-task", "org.jenkins-ci.plugins", "workflow-job", "org.jenkins-ci.plugins.workflow", "workflow-basic-steps", "org.jenkins-ci.plugins.workflow"));
-        pluginGroupIds.putAll(Map.of("jsch", "org.jenkins-ci.plugins", "timestamper", "org.jenkins-ci.plugins", "junit", "org.jenkins-ci.plugins", "apache-httpcomponents-client-4-api", "org.jenkins-ci.plugins", "structs", "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(Map.of("workflow-cps-global-lib", "org.jenkins-ci.plugins.workflow", "configuration-as-code", "io.jenkins", "workflow-cps", "org.jenkins-ci.plugins.workflow", "workflow-support", "org.jenkins-ci.plugins.workflow", "ssh-slaves", "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(Map.of("htmlpublisher", "org.jenkins-ci.plugins", "mailer", "org.jenkins-ci.plugins", "ansicolor", "org.jenkins-ci.plugins", "jackson2-api", "org.jenkins-ci.plugins", "workflow-scm-step", "org.jenkins-ci.plugins.workflow"));
-        pluginGroupIds.putAll(Map.of("display-url-api", "org.jenkins-ci.plugins", "token-macro", "org.jenkins-ci.plugins", "script-security", "org.jenkins-ci.plugins", "pipeline-input-step", "org.jenkins-ci.plugins", "branch-api", "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(Map.of("workflow-api", "org.jenkins-ci.plugins.workflow", "git-server", "org.jenkins-ci.plugins"));
+        Map<String, VersionNumber> toReplaceTest =
+                new HashMap<>(
+                        Map.of(
+                                "workflow-scm-step",
+                                new VersionNumber("2.11"),
+                                "workflow-durable-task-step",
+                                new VersionNumber("2.35"),
+                                "display-url-api",
+                                new VersionNumber("2.3.3"),
+                                "script-security",
+                                new VersionNumber("1.74"),
+                                "workflow-cps",
+                                new VersionNumber("2.83")));
+        toReplaceTest.putAll(
+                Map.of(
+                        "workflow-support",
+                        new VersionNumber("3.5"),
+                        "workflow-job",
+                        new VersionNumber("2.39"),
+                        "workflow-basic-steps",
+                        new VersionNumber("2.20")));
+        Map<String, String> pluginGroupIds =
+                new HashMap<>(
+                        Map.of(
+                                "credentials-binding",
+                                "org.jenkins-ci.plugins",
+                                "pipeline-build-step",
+                                "org.jenkins-ci.plugins",
+                                "credentials",
+                                "org.jenkins-ci.plugins",
+                                "jdk-tool",
+                                "org.jenkins-ci.plugins",
+                                "snakeyaml-api",
+                                "io.jenkins.plugins"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "workflow-step-api",
+                        "org.jenkins-ci.plugins.workflow",
+                        "plain-credentials",
+                        "org.jenkins-ci.plugins",
+                        "trilead-api",
+                        "org.jenkins-ci.plugins",
+                        "command-launcher",
+                        "org.jenkins-ci.plugins",
+                        "jquery",
+                        "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "matrix-project",
+                        "org.jenkins-ci.plugins",
+                        "jquery-detached",
+                        "org.jenkins-ci.ui",
+                        "ace-editor",
+                        "org.jenkins-ci.ui",
+                        "git",
+                        "org.jenkins-ci.plugins",
+                        "workflow-durable-task-step",
+                        "org.jenkins-ci.plugins.workflow"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "git-client",
+                        "org.jenkins-ci.plugins",
+                        "ssh-credentials",
+                        "org.jenkins-ci.plugins",
+                        "variant",
+                        "org.jenkins-ci.plugins",
+                        "cloudbees-folder",
+                        "org.jenkins-ci.plugins",
+                        "scm-api",
+                        "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "pipeline-stage-step",
+                        "org.jenkins-ci.plugins",
+                        "junit-attachments",
+                        "org.jenkins-ci.plugins",
+                        "durable-task",
+                        "org.jenkins-ci.plugins",
+                        "workflow-job",
+                        "org.jenkins-ci.plugins.workflow",
+                        "workflow-basic-steps",
+                        "org.jenkins-ci.plugins.workflow"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "jsch",
+                        "org.jenkins-ci.plugins",
+                        "timestamper",
+                        "org.jenkins-ci.plugins",
+                        "junit",
+                        "org.jenkins-ci.plugins",
+                        "apache-httpcomponents-client-4-api",
+                        "org.jenkins-ci.plugins",
+                        "structs",
+                        "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "workflow-cps-global-lib",
+                        "org.jenkins-ci.plugins.workflow",
+                        "configuration-as-code",
+                        "io.jenkins",
+                        "workflow-cps",
+                        "org.jenkins-ci.plugins.workflow",
+                        "workflow-support",
+                        "org.jenkins-ci.plugins.workflow",
+                        "ssh-slaves",
+                        "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "htmlpublisher",
+                        "org.jenkins-ci.plugins",
+                        "mailer",
+                        "org.jenkins-ci.plugins",
+                        "ansicolor",
+                        "org.jenkins-ci.plugins",
+                        "jackson2-api",
+                        "org.jenkins-ci.plugins",
+                        "workflow-scm-step",
+                        "org.jenkins-ci.plugins.workflow"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "display-url-api",
+                        "org.jenkins-ci.plugins",
+                        "token-macro",
+                        "org.jenkins-ci.plugins",
+                        "script-security",
+                        "org.jenkins-ci.plugins",
+                        "pipeline-input-step",
+                        "org.jenkins-ci.plugins",
+                        "branch-api",
+                        "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(
+                Map.of(
+                        "workflow-api",
+                        "org.jenkins-ci.plugins.workflow",
+                        "git-server",
+                        "org.jenkins-ci.plugins"));
         List<String> toConvert = Collections.emptyList();
-        new MavenPom(prj).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
+        new MavenPom(prj)
+                .addDependencies(
+                        toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
 
         assertResourceEqualsXmlFile("credentials-binding-pom-after.xml", pom);
     }
@@ -57,10 +191,8 @@ public class MavenPomTest {
         File folder = tmp.newFolder();
         File pomFile = createPomFileFromResource(folder, "demo-plugin-pom-before.xml");
 
-        MavenCoordinates coreCoordinates = new MavenCoordinates(
-                "org.jenkins-ci.plugins",
-                "plugin",
-                "2.235.1");
+        MavenCoordinates coreCoordinates =
+                new MavenCoordinates("org.jenkins-ci.plugins", "plugin", "2.235.1");
 
         MavenPom mavenPom = new MavenPom(pomFile.getParentFile());
         mavenPom.transformPom(coreCoordinates);
@@ -80,15 +212,20 @@ public class MavenPomTest {
         Map<String, String> pluginGroupIds = new HashMap<>();
         pluginGroupIds.put("workflow-step-api", "org.jenkins-ci.plugins.workflow");
         List<String> toConvert = Collections.emptyList();
-        new MavenPom(folder).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
+        new MavenPom(folder)
+                .addDependencies(
+                        toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
         assertResourceEqualsXmlFile("demo-plugin-properties-pom-after.xml", pomFile);
     }
 
-    private void assertResourceEqualsXmlFile(String resource, File pom) throws IOException, URISyntaxException {
+    private void assertResourceEqualsXmlFile(String resource, File pom)
+            throws IOException, URISyntaxException {
         assertEquals(
-                normalizeXmlString(Files.readString(Paths.get(getClass().getResource(resource).toURI()), StandardCharsets.UTF_8)),
-                normalizeXmlString(FileUtils.readFileToString(pom, StandardCharsets.UTF_8))
-        );
+                normalizeXmlString(
+                        Files.readString(
+                                Paths.get(getClass().getResource(resource).toURI()),
+                                StandardCharsets.UTF_8)),
+                normalizeXmlString(FileUtils.readFileToString(pom, StandardCharsets.UTF_8)));
     }
 
     private File createPomFileFromResource(File parentFolder, String resource) throws IOException {
@@ -100,7 +237,8 @@ public class MavenPomTest {
     private static String normalizeXmlString(String source) {
         return source
                 // remove leading and trailing spaces
-                .replaceAll("(?m)[ \t]+$", "").replaceAll("(?m)^[ \t] +", "")
+                .replaceAll("(?m)[ \t]+$", "")
+                .replaceAll("(?m)^[ \t] +", "")
                 // normalize new line characters
                 .replaceAll("\r\n", "\n")
                 // ensure new line at end of line


### PR DESCRIPTION
While I normally try to avoid going on formatting crusades in the Jenkins community, trying to read this code in its current state of formatting drove me past the point of sanity. Among other things, I found:

- Incorrect indentation for complex functions in the most critical code paths, making it difficult to understand the logic
- Different conventions within the same method and the same file, making it distracting to read the code
- Files indented with odd numbers of spaces (no comment)

I decided that even though a human can do a better job than an automatic formatter, an automatic formatter can do a better job than the current state of the codebase. So I added Google Java Format to the Spotless configuration and ran `mvn spotless:apply`. This will be enforced during `mvn clean verify` but can be disabled during development with `-Dspotless.check.skip` or `-Pquick-build`.

The result allows me to read the code more easily and reason about the logic more clearly with correct indentation. I know that the Google Java Format style isn't perfect, but I think it is good enough and the advantages outweigh the disadvantages. I think it is better than the status quo which is extremely difficult to read.

If this is accepted, I will squash merge and then add a `.git-blame-ignore-revs` file to the repository with the revision so that GitHub does not show this change in `git blame`.

Reviewers are encouraged to review this PR with the **Hide Whitespace** feature enabled.

To test this I ran `PLUGINS=text-finder TEST=InjectedTest bash local-test.sh` with these changes.