### PR TITLE
Remove `-testJDKHome` argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ demo: target/plugins-compat-tester-cli.jar $(WAR_PATH) print-java-home
 	     -workDirectory $(CURDIR)/work \
 	     -mvn $(MVN_EXECUTABLE) \
 	     -war $(CURDIR)/$(WAR_PATH) \
-	     -testJDKHome "$(TEST_JDK_HOME)" \
 	     -includePlugins $(PLUGIN_NAME) \
 	     $(EXTRA_OPTS)
 

--- a/README.md
+++ b/README.md
@@ -121,14 +121,6 @@ java -jar target/plugins-compat-tester-cli.jar \
 
 ### Running PCT with custom Java versions
 
-Plugin compat tester supports running Test Suites with a Java version different 
-from the one being used to run PCT and build the plugins.
-For example, such mode can be used to run tests with JDK11 starting from Jenkins 2.163.
-
-Two options can be passed to PCT CLI for such purpose:
-
-* `testJDKHome` - A path to JDK HOME to be used for running tests in plugins
-
 You can run the example by running the following command:
 
     make demo TEST_JDK_HOME=${YOUR_JDK_HOME} PLUGIN_NAME=git

--- a/src/main/docker/run-pct.sh
+++ b/src/main/docker/run-pct.sh
@@ -162,7 +162,6 @@ echo java ${JAVA_OPTS} ${extra_java_opts[@]} \
   ${LOCAL_CHECKOUT_ARG} \
   -includePlugins "${ARTIFACT_ID}" \
   -m2SettingsFile "${MVN_SETTINGS_FILE}" \
-  -testJDKHome "${TEST_JDK_HOME}" \
   "$@" \
   "|| echo \$? > /pct/tmp/pct_exit_code" > /pct/tmp/pct_command
 chmod +x /pct/tmp/pct_command

--- a/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -50,12 +50,6 @@ public class CliOptions {
                     "A WAR file to scan for plugins rather than looking in the update center.")
     private File war;
 
-    @CheckForNull
-    @Parameter(
-            names = "-testJDKHome",
-            description = "A path to JDK HOME to be used for running tests in plugins.")
-    private File testJDKHome;
-
     @Parameter(
             names = "-workDirectory",
             required = true,
@@ -216,11 +210,6 @@ public class CliOptions {
 
     public boolean isPrintHelp() {
         return printHelp;
-    }
-
-    @CheckForNull
-    public File getTestJDKHome() {
-        return testJDKHome;
     }
 
     public boolean isFailFast() {

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -105,9 +105,6 @@ public class PluginCompatTesterCli {
         if (options.getLocalCheckoutDir() != null && !options.getLocalCheckoutDir().isEmpty()) {
             config.setLocalCheckoutDir(options.getLocalCheckoutDir());
         }
-        if (options.getTestJDKHome() != null) {
-            config.setTestJDKHome(options.getTestJDKHome());
-        }
         if (options.getFallbackGitHubOrganization() != null) {
             config.setFallbackGitHubOrganization(options.getFallbackGitHubOrganization());
         }


### PR DESCRIPTION
This seems to be used by proprietary code but only seems to set the `jvm` Maven property and I could not find any documentation regarding what that actually does. Regardless it seems cleaner to dispense with this option and just have consumers set `JAVA_HOME` which is what the `mvn` command uses to determine which version of Java to run.