### PR TITLE
Remove `-mavenOptions` argument

### DIFF
--- a/src/main/java/org/jenkins/tools/test/CliOptions.java
+++ b/src/main/java/org/jenkins/tools/test/CliOptions.java
@@ -114,11 +114,10 @@ public class CliOptions {
     private String mavenPropertiesFile;
 
     @Parameter(
-            names = "-mavenOptions",
+            names = "-mavenArgs",
             description =
-                    "Options to pass to Maven (like -Pxxx; not to be confused with Java options,"
-                            + " nor Maven properties).")
-    private List<String> mavenOptions;
+                    "Arguments to pass to Maven (like -Pxxx; not to be confused with Java arguments or Maven properties).")
+    private List<String> mavenArgs;
 
     @Parameter(names = "-hookPrefixes", description = "Prefixes of the extra hooks' classes")
     private String hookPrefixes;
@@ -190,9 +189,9 @@ public class CliOptions {
     }
 
     @NonNull
-    public List<String> getMavenOptions() {
-        return mavenOptions != null
-                ? Collections.unmodifiableList(mavenOptions)
+    public List<String> getMavenArgs() {
+        return mavenArgs != null
+                ? Collections.unmodifiableList(mavenArgs)
                 : Collections.emptyList();
     }
 

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -130,7 +130,7 @@ public class PluginCompatTesterCli {
             config.setMavenPropertiesFiles(options.getMavenPropertiesFile());
         }
 
-        config.setMavenOptions(options.getMavenOptions());
+        config.setMavenArgs(options.getMavenArgs());
 
         PluginCompatTester tester = new PluginCompatTester(config);
         tester.testPlugins();

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -61,7 +61,7 @@ public class ExternalMavenRunner implements MavenRunner {
         for (Map.Entry<String, String> entry : config.userProperties.entrySet()) {
             cmd.add("--define=" + entry);
         }
-        cmd.addAll(config.mavenOptions);
+        cmd.addAll(config.mavenArgs);
         cmd.addAll(List.of(goals));
         LOGGER.log(
                 Level.INFO,

--- a/src/main/java/org/jenkins/tools/test/maven/MavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/MavenRunner.java
@@ -20,7 +20,7 @@ public interface MavenRunner {
 
         public final Map<String, String> userProperties = new TreeMap<>();
 
-        public final List<String> mavenOptions;
+        public final List<String> mavenArgs;
 
         public Config(PluginCompatTesterConfig pctConfig) {
             userSettingsFile = pctConfig.getM2SettingsFile();
@@ -29,7 +29,7 @@ public interface MavenRunner {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-            mavenOptions = pctConfig.getMavenOptions();
+            mavenArgs = pctConfig.getMavenArgs();
         }
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -80,7 +80,7 @@ public class PluginCompatTesterConfig {
     private Map<String, String> mavenProperties = Collections.emptyMap();
     private String mavenPropertiesFile;
 
-    private List<String> mavenOptions = Collections.emptyList();
+    private List<String> mavenArgs = Collections.emptyList();
 
     // Classpath prefixes of the extra hooks
     private List<String> hookPrefixes = new ArrayList<>(List.of("org.jenkins"));
@@ -172,12 +172,12 @@ public class PluginCompatTesterConfig {
         this.mavenPropertiesFile = mavenPropertiesFile;
     }
 
-    public List<String> getMavenOptions() {
-        return mavenOptions;
+    public List<String> getMavenArgs() {
+        return mavenArgs;
     }
 
-    public void setMavenOptions(List<String> mavenOptions) {
-        this.mavenOptions = mavenOptions;
+    public void setMavenArgs(List<String> mavenArgs) {
+        this.mavenArgs = mavenArgs;
     }
 
     /**


### PR DESCRIPTION
I could not find anything using this argument in open-source or proprietary code, and its present just increases the complexity of the code for no reason. If a legitimate use case is found for this argument it can always be restored, but for now let us err in favor of removing unused code.