### PR TITLE
Remove unused `Add-Opens` directive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,18 +180,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <!-- Version specified in parent POM -->
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Add-Opens>java.base/java.util</Add-Opens>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.4.1</version>
         <executions>


### PR DESCRIPTION
No longer needed now that we have stopped depending on XStream. Tested with `PLUGINS=text-finder TEST=InjectedTest bash local-test.sh`.