### PR TITLE
allow interpolation of SCM urls

### DIFF
--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -36,6 +36,7 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.apache.maven.model.Model;
@@ -118,9 +119,23 @@ public class PluginRemoting {
         return new PomData(
                 model.getArtifactId(),
                 model.getPackaging(),
-                model.getScm().getConnection(),
+                // scm may contain properties so it needs to be resolved.
+                interpolateString(model.getScm().getConnection(), model.getArtifactId()),
                 model.getScm().getTag(),
                 parent,
                 model.getGroupId());
+    }
+
+    /**
+     * Replaces any occurence of {@code "${project.artifactId}"} or  {@code "${artifactId}"} with the supplied value of the artifactId/
+     * @param original the original string
+     * @param artifactId the interpolated String
+     * @return the original string with any interpolation for the artifactId resolved.
+     */
+    static String interpolateString(String original, String artifactId) {
+        if (original == null) {
+            return null;
+        }
+        return original.replace("${project.artifactId}", artifactId).replace("${artifactId}", artifactId);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -136,6 +136,6 @@ public class PluginRemoting {
         if (original == null) {
             return null;
         }
-        return original.replace("${project.artifactId}", artifactId).replace("${artifactId}", artifactId);
+        return original.replace("${project.artifactId}", artifactId);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -36,7 +36,6 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.apache.maven.model.Model;

--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -126,7 +126,9 @@ public class PluginRemoting {
     }
 
     /**
-     * Replaces any occurence of {@code "${project.artifactId}"} or  {@code "${artifactId}"} with the supplied value of the artifactId/
+     * Replaces any occurence of {@code "${project.artifactId}"} or {@code "${artifactId}"} with the
+     * supplied value of the artifactId/
+     *
      * @param original the original string
      * @param artifactId the interpolated String
      * @return the original string with any interpolation for the artifactId resolved.

--- a/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
@@ -1,0 +1,24 @@
+package org.jenkins.tools.test.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class PluginRemotingTest {
+
+    @Test
+    public void testStringInterpolation() {
+        assertThat(PluginRemoting.interpolateString("${project.artifactId}", "wibble"), is("wibble"));
+        assertThat(PluginRemoting.interpolateString("prefix-${project.artifactId}", "blah"), is("prefix-blah"));
+        assertThat(PluginRemoting.interpolateString("${project.artifactId}suffix", "something"), is("somethingsuffix"));
+
+        // no interpolation - contains neither ${artifactId} not ${project.artifactId}
+        assertThat(PluginRemoting.interpolateString(null, "wibble"), nullValue());
+        assertThat(PluginRemoting.interpolateString("${aartifactId}suffix", "something"), is("${aartifactId}suffix"));
+        assertThat(PluginRemoting.interpolateString("${projectXartifactId}suffix", "something"), is("${projectXartifactId}suffix"));
+
+    }
+
+}

--- a/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
@@ -1,24 +1,31 @@
 package org.jenkins.tools.test.model;
 
-import org.junit.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.Test;
 
 public class PluginRemotingTest {
 
     @Test
     public void testStringInterpolation() {
-        assertThat(PluginRemoting.interpolateString("${project.artifactId}", "wibble"), is("wibble"));
-        assertThat(PluginRemoting.interpolateString("prefix-${project.artifactId}", "blah"), is("prefix-blah"));
-        assertThat(PluginRemoting.interpolateString("${project.artifactId}suffix", "something"), is("somethingsuffix"));
+        assertThat(
+                PluginRemoting.interpolateString("${project.artifactId}", "wibble"), is("wibble"));
+        assertThat(
+                PluginRemoting.interpolateString("prefix-${project.artifactId}", "blah"),
+                is("prefix-blah"));
+        assertThat(
+                PluginRemoting.interpolateString("${project.artifactId}suffix", "something"),
+                is("somethingsuffix"));
 
         // no interpolation - contains neither ${artifactId} not ${project.artifactId}
         assertThat(PluginRemoting.interpolateString(null, "wibble"), nullValue());
-        assertThat(PluginRemoting.interpolateString("${aartifactId}suffix", "something"), is("${aartifactId}suffix"));
-        assertThat(PluginRemoting.interpolateString("${projectXartifactId}suffix", "something"), is("${projectXartifactId}suffix"));
-
+        assertThat(
+                PluginRemoting.interpolateString("${aartifactId}suffix", "something"),
+                is("${aartifactId}suffix"));
+        assertThat(
+                PluginRemoting.interpolateString("${projectXartifactId}suffix", "something"),
+                is("${projectXartifactId}suffix"));
     }
-
 }


### PR DESCRIPTION
ammend #442 to allow use of project.artifactId and artifactId as properties inside the SCM section

testing a project with maven 4.0.0-alpha4 showed no warnings or errors about this use case, and we have many plugins that use it.

Whilst fixing all the plugin is nobale - that would unessescarily hold up future improvements.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
