### PR TITLE
Parse `pom.xml` without SCM section in `PluginRemoting#retrievePomData`

### DIFF
--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -119,8 +119,10 @@ public class PluginRemoting {
                 model.getArtifactId(),
                 model.getPackaging(),
                 // scm may contain properties so it needs to be resolved.
-                interpolateString(model.getScm().getConnection(), model.getArtifactId()),
-                model.getScm().getTag(),
+                interpolateString(
+                        model.getScm() != null ? model.getScm().getConnection() : null,
+                        model.getArtifactId()),
+                model.getScm() != null ? model.getScm().getTag() : null,
                 parent,
                 model.getGroupId());
     }

--- a/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
@@ -53,7 +53,7 @@ public class PluginRemotingTest {
         assertThat(
                 pomData.parent,
                 is(new MavenCoordinates("com.example.jenkins", "example-parent", "4.1")));
-        assertThat(pomData.groupId, is("com.example.jenkins"));
+        assertThat(pomData.groupId, nullValue());
         assertThat(pomData.artifactId, is("example"));
         assertThat(pomData.getPackaging(), is("hpi"));
         assertThat(pomData.getConnectionUrl(), nullValue());

--- a/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.io.File;
 import org.junit.Test;
 
 public class PluginRemotingTest {
@@ -27,5 +28,35 @@ public class PluginRemotingTest {
         assertThat(
                 PluginRemoting.interpolateString("${projectXartifactId}suffix", "something"),
                 is("${projectXartifactId}suffix"));
+    }
+
+    @Test
+    public void smokes() throws Exception {
+        File pomFile = new File(getClass().getResource("smokes/pom.xml").toURI());
+        PluginRemoting pluginRemoting = new PluginRemoting(pomFile);
+        PomData pomData = pluginRemoting.retrievePomData();
+        assertThat(pomData.parent, nullValue());
+        assertThat(pomData.groupId, is("com.example.jenkins"));
+        assertThat(pomData.artifactId, is("example"));
+        assertThat(pomData.getPackaging(), is("hpi"));
+        assertThat(
+                pomData.getConnectionUrl(),
+                is("scm:git:https://jenkins.example.com/example-plugin.git"));
+        assertThat(pomData.getScmTag(), is("example-4.1"));
+    }
+
+    @Test
+    public void noScm() throws Exception {
+        File pomFile = new File(getClass().getResource("scm/pom.xml").toURI());
+        PluginRemoting pluginRemoting = new PluginRemoting(pomFile);
+        PomData pomData = pluginRemoting.retrievePomData();
+        assertThat(
+                pomData.parent,
+                is(new MavenCoordinates("com.example.jenkins", "example-parent", "4.1")));
+        assertThat(pomData.groupId, is("com.example.jenkins"));
+        assertThat(pomData.artifactId, is("example"));
+        assertThat(pomData.getPackaging(), is("hpi"));
+        assertThat(pomData.getConnectionUrl(), nullValue());
+        assertThat(pomData.getScmTag(), nullValue());
     }
 }

--- a/src/test/resources/org/jenkins/tools/test/model/scm/pom.xml
+++ b/src/test/resources/org/jenkins/tools/test/model/scm/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example.jenkins</groupId>
+    <artifactId>example-parent</artifactId>
+    <version>4.1</version>
+  </parent>
+  <artifactId>example</artifactId>
+  <packaging>hpi</packaging>
+  <name>Example</name>
+  <url>https://jenkins.example.com/example-plugin</url>
+</project>

--- a/src/test/resources/org/jenkins/tools/test/model/smokes/pom.xml
+++ b/src/test/resources/org/jenkins/tools/test/model/smokes/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.jenkins</groupId>
+  <artifactId>example</artifactId>
+  <version>4.1</version>
+  <packaging>hpi</packaging>
+  <name>Example</name>
+  <url>https://jenkins.example.com/example-plugin</url>
+  <licenses>
+    <license>
+      <name>The MIT License (MIT)</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:https://jenkins.example.com/example-plugin.git</connection>
+    <developerConnection>scm:git:git@jenkins.example.com/example-plugin.git</developerConnection>
+    <tag>example-4.1</tag>
+    <url>https://jenkins.example.com/example-plugin</url>
+  </scm>
+  <distributionManagement>
+    <repository>
+      <id>maven.example.com</id>
+      <url>https://repo.example.com/releases/</url>
+    </repository>
+    <snapshotRepository>
+      <id>maven.example.com</id>
+      <url>https://repo.example.com/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+  <repositories>
+    <repository>
+      <id>repo.example.com</id>
+      <url>https://repo.example.com/public/</url>
+    </repository>
+  </repositories>
+</project>


### PR DESCRIPTION
A small regression introduced in #442, noticed when testing some proprietary plugins: there was a missing null check for cases where no SCM section was present. This PR adds a test for the normal case, a test that reproduces the problem, and a fix for the failing test.