### PR TITLE
Remove support for plugins without an SCM tag

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -310,7 +310,7 @@ public class PluginCompatTester {
                         cloneFromScm(
                                 pomData.getConnectionUrl(),
                                 config.getFallbackGitHubOrganization(),
-                                getScmTag(pomData, plugin.name, plugin.version),
+                                pomData.getScmTag(),
                                 pluginCheckoutDir);
                     }
                 } else {
@@ -341,7 +341,7 @@ public class PluginCompatTester {
                 cloneFromScm(
                         pomData.getConnectionUrl(),
                         config.getFallbackGitHubOrganization(),
-                        getScmTag(pomData, plugin.name, plugin.version),
+                        pomData.getScmTag(),
                         pluginCheckoutDir);
             }
         } else {
@@ -591,18 +591,6 @@ public class PluginCompatTester {
             throw new PluginSourcesUnavailableException(
                     "git checkout FETCH_HEAD was interrupted", e);
         }
-    }
-
-    public static String getScmTag(PomData pomData, String name, String version) {
-        String scmTag;
-        if (pomData.getScmTag() != null) {
-            scmTag = pomData.getScmTag();
-            LOGGER.log(Level.INFO, "Using SCM tag {0} from POM", scmTag);
-        } else {
-            scmTag = name + "-" + version;
-            LOGGER.log(Level.INFO, "POM did not provide an SCM tag; inferring tag {0}", scmTag);
-        }
-        return scmTag;
     }
 
     public static List<String> getFallbackConnectionURL(

--- a/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -33,7 +33,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
         boolean shouldExecuteHook = localCheckoutDir == null || !localCheckoutDir.exists();
 
         if (shouldExecuteHook) {
-            LOGGER.log(Level.INFO, "Executing hook for {0}", getParentProjectName());
+            LOGGER.log(Level.INFO, "Executing hook for {0}", currentPlugin.getDisplayName());
             // Determine if we need to run the download; only run for first identified plugin in the
             // series
             if (firstRun) {
@@ -48,10 +48,9 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
                 pomData = (PomData) moreInfo.get("pomData");
                 // Like the call in PluginCompatTester#runHooks but with subdirectories trimmed:
                 PluginCompatTester.cloneFromScm(
-                        getUrl(),
+                        pomData.getConnectionUrl(),
                         config.getFallbackGitHubOrganization(),
-                        PluginCompatTester.getScmTag(
-                                pomData, getParentProjectName(), currentPlugin.version),
+                        pomData.getScmTag(),
                         parentPath);
             }
 
@@ -82,10 +81,6 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
         return moreInfo;
     }
 
-    public String getUrl() {
-        return pomData.getConnectionUrl().replaceFirst("^(.+github[.]com/[^/]+/[^/]+)/.+", "$1");
-    }
-
     protected void configureLocalCheckOut(
             UpdateSite.Plugin currentPlugin, File localCheckoutDir, Map<String, Object> moreInfo) {
         // Do nothing to keep compatibility with pre-existing Hooks
@@ -100,14 +95,6 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
      * of the plugin's Git repository.
      */
     protected abstract String getParentFolder();
-
-    /**
-     * Return the prefix to the SCM tag (usually the artifact ID of the base module). This will be
-     * used to form the checkout tag with the format {@code parentProjectName-version} in the
-     * (highly unlikely, and impossible for incrementalified plugins) event that the SCM tag is
-     * missing from the plugin's POM.
-     */
-    protected abstract String getParentProjectName();
 
     /**
      * Returns the plugin folder name. By default it will be the plugin name, but it can be

--- a/src/main/java/org/jenkins/tools/test/hook/AwsJavaSdkHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AwsJavaSdkHook.java
@@ -11,11 +11,6 @@ public class AwsJavaSdkHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "aws-java-sdk-parent";
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return ("org.jenkins-ci.plugins".equals(data.groupId)

--- a/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -12,11 +12,6 @@ public class BlueOceanHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "blueocean-parent";
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return "io.jenkins.blueocean".equals(data.groupId)

--- a/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
@@ -12,11 +12,6 @@ public class ConfigurationAsCodeHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "configuration-as-code";
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return "io.jenkins".equals(data.groupId)

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -22,11 +22,6 @@ public class DeclarativePipelineHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "pipeline-model-definition";
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return "org.jenkinsci.plugins".equals(data.groupId)

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
@@ -21,11 +21,6 @@ public class DeclarativePipelineMigrationHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "declarative-pipeline-migration-assistant";
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return "org.jenkins-ci.plugins.to-declarative".equals(data.groupId)

--- a/src/main/java/org/jenkins/tools/test/hook/MinaSshdApi.java
+++ b/src/main/java/org/jenkins/tools/test/hook/MinaSshdApi.java
@@ -11,11 +11,6 @@ public class MinaSshdApi extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "mina-sshd-api-parent";
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         PomData data = (PomData) info.get("pomData");
         return "io.jenkins.plugins.mina-sshd-api".equals(data.groupId)

--- a/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -16,11 +16,6 @@ public class PipelineStageViewHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "pipeline-stage-view";
-    }
-
-    @Override
     protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
         return currentPlugin.name.equals("pipeline-rest-api") ? "rest-api" : "ui";
     }

--- a/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
@@ -12,11 +12,6 @@ public class SwarmHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "swarm-plugin";
-    }
-
-    @Override
     protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
         return "plugin";
     }

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -17,11 +17,6 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "warnings-ng";
-    }
-
-    @Override
     public boolean check(Map<String, Object> info) {
         return isWarningsNG(info);
     }

--- a/src/main/java/org/jenkins/tools/test/hook/WorkflowCpsHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WorkflowCpsHook.java
@@ -13,11 +13,6 @@ public class WorkflowCpsHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected String getParentProjectName() {
-        return "workflow-cps";
-    }
-
-    @Override
     protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
         return "plugin";
     }

--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -127,10 +127,8 @@ public class PluginRemoting {
                 model.getArtifactId(),
                 model.getPackaging(),
                 // scm may contain properties so it needs to be resolved.
-                interpolateString(
-                        model.getScm() != null ? model.getScm().getConnection() : null,
-                        model.getArtifactId()),
-                model.getScm() != null ? model.getScm().getTag() : null,
+                interpolateString(model.getScm().getConnection(), model.getArtifactId()),
+                model.getScm().getTag(),
                 parent,
                 model.getGroupId());
     }
@@ -144,9 +142,6 @@ public class PluginRemoting {
      * @return the original string with any interpolation for the artifactId resolved.
      */
     static String interpolateString(String original, String artifactId) {
-        if (original == null) {
-            return null;
-        }
         return original.replace("${project.artifactId}", artifactId);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/model/PomData.java
+++ b/src/main/java/org/jenkins/tools/test/model/PomData.java
@@ -35,36 +35,36 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @author Frederic Camblor
  */
 public class PomData {
-    public final String artifactId;
-    public final String groupId;
+    @NonNull public final String artifactId;
+
+    @CheckForNull public final String groupId;
 
     @NonNull private final String packaging;
 
     @CheckForNull public final MavenCoordinates parent;
-    private String connectionUrl;
-    private String scmTag;
+
+    @NonNull private String connectionUrl;
+
+    @NonNull private String scmTag;
 
     public PomData(
-            String artifactId,
+            @NonNull String artifactId,
             @CheckForNull String packaging,
-            String connectionUrl,
-            String scmTag,
+            @NonNull String connectionUrl,
+            @NonNull String scmTag,
             @CheckForNull MavenCoordinates parent,
-            String groupId) {
+            @CheckForNull String groupId) {
         this.artifactId = artifactId;
         this.groupId = groupId;
         this.packaging = packaging != null ? packaging : "jar";
-        this.setConnectionUrl(connectionUrl);
+        this.connectionUrl = connectionUrl;
         this.scmTag = scmTag;
         this.parent = parent;
     }
 
+    @NonNull
     public String getConnectionUrl() {
         return connectionUrl;
-    }
-
-    public void setConnectionUrl(String connectionUrl) {
-        this.connectionUrl = connectionUrl;
     }
 
     @NonNull
@@ -72,6 +72,7 @@ public class PomData {
         return packaging;
     }
 
+    @NonNull
     public String getScmTag() {
         return scmTag;
     }

--- a/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
@@ -21,7 +21,6 @@ class PluginRemotingTest {
                 is("somethingsuffix"));
 
         // no interpolation - contains neither ${artifactId} not ${project.artifactId}
-        assertThat(PluginRemoting.interpolateString(null, "wibble"), nullValue());
         assertThat(
                 PluginRemoting.interpolateString("${aartifactId}suffix", "something"),
                 is("${aartifactId}suffix"));
@@ -46,7 +45,7 @@ class PluginRemotingTest {
     }
 
     @Test
-    void noScm() throws Exception {
+    void parent() throws Exception {
         File pomFile = new File(getClass().getResource("scm/pom.xml").toURI());
         PluginRemoting pluginRemoting = new PluginRemoting(pomFile);
         PomData pomData = pluginRemoting.retrievePomData();
@@ -56,7 +55,9 @@ class PluginRemotingTest {
         assertThat(pomData.groupId, nullValue());
         assertThat(pomData.artifactId, is("example"));
         assertThat(pomData.getPackaging(), is("hpi"));
-        assertThat(pomData.getConnectionUrl(), nullValue());
-        assertThat(pomData.getScmTag(), nullValue());
+        assertThat(
+                pomData.getConnectionUrl(),
+                is("scm:git:https://jenkins.example.com/example-plugin.git"));
+        assertThat(pomData.getScmTag(), is("example-4.1"));
     }
 }

--- a/src/test/resources/org/jenkins/tools/test/model/scm/pom.xml
+++ b/src/test/resources/org/jenkins/tools/test/model/scm/pom.xml
@@ -10,4 +10,10 @@
   <packaging>hpi</packaging>
   <name>Example</name>
   <url>https://jenkins.example.com/example-plugin</url>
+  <scm>
+    <connection>scm:git:https://jenkins.example.com/example-plugin.git</connection>
+    <developerConnection>scm:git:git@jenkins.example.com/example-plugin.git</developerConnection>
+    <tag>example-4.1</tag>
+    <url>https://jenkins.example.com/example-plugin</url>
+  </scm>
 </project>


### PR DESCRIPTION
Fixes #452 and removes the temporary workaround added in #451. Plugins in `jenkinsci/bom` should be OK but there are a handful (less than 5) proprietary plugins that are missing SCM sections. It shouldn't be too hard to patch them up with SCM sections and do releases, at which point this code can be simplified.