### PR TITLE
Inline SpotBugs exclusions

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -26,6 +26,7 @@
 
 package org.jenkins.tools.test;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.UpdateSite;
 import hudson.util.VersionNumber;
 import java.io.File;
@@ -70,6 +71,7 @@ import org.jenkins.tools.test.util.StreamGobbler;
  *
  * @author Frederic Camblor, Olivier Lamy
  */
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "intended behavior")
 public class PluginCompatTester {
 
     private static final Logger LOGGER = Logger.getLogger(PluginCompatTester.class.getName());
@@ -495,6 +497,7 @@ public class PluginCompatTester {
      * @param checkoutDirectory the directory in which to clone the Git repository
      * @throws IOException if an error occurs
      */
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "intended behavior")
     private static void cloneImpl(String gitUrl, String scmTag, File checkoutDirectory)
             throws IOException, PluginSourcesUnavailableException {
         LOGGER.log(
@@ -636,6 +639,7 @@ public class PluginCompatTester {
      *     or "normal" plugins in the war file
      * @return Update center data
      */
+    @SuppressFBWarnings(value = "REDOS", justification = "intended behavior")
     private UpdateSite.Data scanWAR(File war, String pluginRegExp) {
         UpdateSite.Entry core = null;
         List<UpdateSite.Plugin> plugins = new ArrayList<>();

--- a/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -1,5 +1,6 @@
 package org.jenkins.tools.test.hook;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.UpdateSite;
 import java.io.File;
 import java.util.Map;
@@ -21,6 +22,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
     private PomData pomData;
 
     @Override
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "intended behavior")
     public Map<String, Object> action(Map<String, Object> moreInfo)
             throws PluginSourcesUnavailableException {
         PluginCompatTesterConfig config = (PluginCompatTesterConfig) moreInfo.get("config");

--- a/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -1,5 +1,6 @@
 package org.jenkins.tools.test.hook;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -23,6 +24,7 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHook;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHooks;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "intended behavior")
 public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile {
 
     private static final Logger LOGGER = Logger.getLogger(MultiParentCompileHook.class.getName());

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -2,6 +2,7 @@ package org.jenkins.tools.test.maven;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -50,6 +51,7 @@ public class ExternalMavenRunner implements MavenRunner {
     }
 
     @Override
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "intended behavior")
     public void run(
             Map<String, String> properties, File baseDirectory, File buildLogFile, String... args)
             throws PomExecutionException {

--- a/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -27,6 +27,7 @@
 package org.jenkins.tools.test.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import java.io.File;
 import java.io.IOException;
@@ -59,6 +60,7 @@ import org.jenkins.tools.test.exception.PomTransformationException;
  *
  * @author Frederic Camblor
  */
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "intended behavior")
 public class MavenPom {
 
     private static final Logger LOGGER = Logger.getLogger(MavenPom.class.getName());

--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -26,6 +26,7 @@
 
 package org.jenkins.tools.test.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -73,8 +75,14 @@ public class PluginRemoting {
         }
     }
 
+    @SuppressFBWarnings(
+            value = "URLCONNECTION_SSRF_FD",
+            justification = "Only file: URLs are supported")
     private String retrievePomContentFromHpi() throws IOException {
         URL url = new URL(hpiRemoteUrl);
+        if (!url.getProtocol().equals("jar") || !url.getFile().startsWith("file:")) {
+            throw new MalformedURLException("Invalid URL: " + url);
+        }
         try (InputStream is = url.openStream();
                 ZipInputStream zis = new ZipInputStream(is)) {
             ZipEntry ze;

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,6 +1,0 @@
-<FindBugsFilter>
-    <Match>
-        <!-- Irrelevant for a development tool. -->
-        <Bug category="SECURITY"/>
-    </Match>
-</FindBugsFilter>


### PR DESCRIPTION
This PR removes the global `src/spotbugs/excludesFilter.xml` file which was suppressing a wide variety of SpotBugs errors in favor of suppressing just the errors that we know are false positives where they occur. The purpose of this is to ensure that new errors do not go unnoticed. While I was here I tightened up the logic that parses `pom.xml` files to ensure that it is always fetching local files (rather than remote URLs) as expected. I tested this with the `text-finder` plugin in `jenkinsci/bom`.