### PR TITLE
Fix opt-in for Maven Failsafe plugin

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/AnalysisPomExecutionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AnalysisPomExecutionHook.java
@@ -1,0 +1,32 @@
+package org.jenkins.tools.test.hook;
+
+import java.util.Map;
+import java.util.Set;
+import org.jenkins.tools.test.model.PomData;
+
+/**
+ * Custom execution hook for plugins whose parent is {@code org.jvnet.hudson.plugins:analysis-pom}.
+ * These plugins use Maven Failsafe Plugin in their test suites.
+ */
+public class AnalysisPomExecutionHook extends PluginWithFailsafeIntegrationTestsHook {
+
+    private static final Set<String> ARTIFACT_IDS =
+            Set.of(
+                    "analysis-model-api",
+                    "bootstrap5-api",
+                    "checks-api",
+                    "echarts-api",
+                    "font-awesome-api",
+                    "forensics-api",
+                    "jquery3-api",
+                    "plugin-util-api",
+                    "popper2-api");
+
+    @Override
+    public boolean check(Map<String, Object> info) {
+        PomData data = (PomData) info.get("pomData");
+        return "io.jenkins.plugins".equals(data.groupId)
+                && ARTIFACT_IDS.contains(data.artifactId)
+                && "hpi".equals(data.getPackaging());
+    }
+}

--- a/src/main/java/org/jenkins/tools/test/hook/PluginWithFailsafeIntegrationTestsHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PluginWithFailsafeIntegrationTestsHook.java
@@ -7,7 +7,8 @@ import java.util.List;
  * Workaround for those plugins with integration tests since they need execute the
  * failsafe:integration-test goal before execution.
  */
-public class PluginWithFailsafeIntegrationTestsHook extends PluginWithIntegrationTestsHook {
+public abstract class PluginWithFailsafeIntegrationTestsHook
+        extends PluginWithIntegrationTestsHook {
 
     @Override
     public Collection<String> getGoals() {


### PR DESCRIPTION
Fixes #461. `PluginWithFailsafeIntegrationTestsHook` was meant to be a way for plugins to opt-in to having their Maven Failsafe plugin tests executed, but the class is not marked as `abstract`. Since https://github.com/jenkinsci/plugin-compat-tester/blob/0838e05345e7d6333331a95dc5052e84cafbe130/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java#L186 executes all non-abstract hooks, `PluginWithFailsafeIntegrationTestsHook` gets executed unconditionally, resulting in workarounds like https://github.com/jenkinsci/bom/blob/c72362731c98313189c04025c3b7bc181da4c121/pct.sh#L22-L25. This PR solves the problem by marking `PluginWithFailsafeIntegrationTestsHook` as abstract, which allows the abovementioned workaround to be removed. That, in turn, exposed the fact that Dr Ullrich Hafner's plugins run their tests using a combination of Surefire and Failsafe, so to ensure the status quo is preserved I added a new hook to explicitly opt in to Failsafe for those plugins. And with that, https://github.com/jenkinsci/bom/pull/1764 now passes.