### PR TITLE
Set `jth.jenkins-war.path` unconditionally when running tests

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -420,6 +420,7 @@ public class PluginCompatTester {
         args = (List<String>) forExecutionHooks.get("args");
 
         Map<String, String> properties = new LinkedHashMap<>(config.getMavenProperties());
+        properties.put("jth.jenkins-war.path", config.getWar().toString());
         properties.put("overrideWar", config.getWar().toString());
         properties.put("jenkins.version", coreCoordinates.version);
         properties.put("useUpperBounds", "true");


### PR DESCRIPTION
`jenkinsci/bom` was already setting this in https://github.com/jenkinsci/bom/blob/20596aa1ebeb0f56aea9b76993ad7d17487e192f/pct.sh#L49 but I think it makes more sense for this to live in common code in `plugin-compat-tester` and avoid the need for consumers to have to worry about it. It only seems to be used by https://github.com/jenkinsci/jenkins-test-harness/blob/26e453e914e6931350b13a469ca2adfc1db943fd/src/main/java/org/jvnet/hudson/test/WarExploder.java. Assuming there are no problems on the CloudBees side with setting this, I plan to delete https://github.com/jenkinsci/bom/blob/20596aa1ebeb0f56aea9b76993ad7d17487e192f/pct.sh#L49 once this is merged.