### PR TITLE
use redirect file for help:evaluate

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -704,9 +704,9 @@ public class PluginCompatTester {
         }
         File log = new File(parentFile.getAbsolutePath() + File.separatorChar + "modules.log");
         runner.run(
-                Map.of("expression", "project.modules", "forceStdout", "true"),
+                Map.of("expression", "project.modules", "output", log.getAbsolutePath()),
                 parentFile,
-                log,
+                null,
                 "-q",
                 "help:evaluate");
         List<String> lines;

--- a/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -186,9 +186,9 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
 
         File log = new File(parentFile.getAbsolutePath() + File.separatorChar + "version.log");
         runner.run(
-                Map.of("expression", "project.version", "forceStdout", "true"),
+                Map.of("expression", "project.version", "output", log.getAbsolutePath()),
                 parentFile,
-                log,
+                null,
                 "-q",
                 "help:evaluate");
         List<String> output;

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -2,6 +2,7 @@ package org.jenkins.tools.test.maven;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.File;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang.SystemUtils;
 import org.jenkins.tools.test.exception.PomExecutionException;
 
@@ -107,9 +109,9 @@ public class ExternalMavenRunner implements MavenRunner {
 
         @NonNull private final Process p;
 
-        @NonNull private final File buildLogFile;
+        @CheckForNull private final File buildLogFile;
 
-        public MavenGobbler(@NonNull Process p, @NonNull File buildLogFile) {
+        public MavenGobbler(@NonNull Process p, @Nullable File buildLogFile) {
             this.p = p;
             this.buildLogFile = buildLogFile;
         }
@@ -119,7 +121,7 @@ public class ExternalMavenRunner implements MavenRunner {
             try (InputStream is = p.getInputStream();
                     Reader isr = new InputStreamReader(is, Charset.defaultCharset());
                     BufferedReader r = new BufferedReader(isr);
-                    OutputStream os = new FileOutputStream(buildLogFile, true);
+                    OutputStream os = buildLogFile == null ? NullOutputStream.NULL_OUTPUT_STREAM : new FileOutputStream(buildLogFile, true);
                     Writer osw = new OutputStreamWriter(os, Charset.defaultCharset());
                     PrintWriter w = new PrintWriter(osw)) {
                 String line;

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -120,7 +120,10 @@ public class ExternalMavenRunner implements MavenRunner {
             try (InputStream is = p.getInputStream();
                     Reader isr = new InputStreamReader(is, Charset.defaultCharset());
                     BufferedReader r = new BufferedReader(isr);
-                    OutputStream os = buildLogFile == null ? OutputStream.nullOutputStream() : new FileOutputStream(buildLogFile, true);
+                    OutputStream os =
+                            buildLogFile == null
+                                    ? OutputStream.nullOutputStream()
+                                    : new FileOutputStream(buildLogFile, true);
                     Writer osw = new OutputStreamWriter(os, Charset.defaultCharset());
                     PrintWriter w = new PrintWriter(osw)) {
                 String line;

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang.SystemUtils;
 import org.jenkins.tools.test.exception.PomExecutionException;
 
@@ -121,7 +120,7 @@ public class ExternalMavenRunner implements MavenRunner {
             try (InputStream is = p.getInputStream();
                     Reader isr = new InputStreamReader(is, Charset.defaultCharset());
                     BufferedReader r = new BufferedReader(isr);
-                    OutputStream os = buildLogFile == null ? NullOutputStream.NULL_OUTPUT_STREAM : new FileOutputStream(buildLogFile, true);
+                    OutputStream os = buildLogFile == null ? OutputStream.nullOutputStream() : new FileOutputStream(buildLogFile, true);
                     Writer osw = new OutputStreamWriter(os, Charset.defaultCharset());
                     PrintWriter w = new PrintWriter(osw)) {
                 String line;


### PR DESCRIPTION
maven can and will produce output even if `-q` is specified

in the best case this is just uneeded IO, but at the worst this could cause platform specific breakage.

Current code _mostly_ gets away with this as the output is usually the last line, or the code is looking for specific string

tested with `mina-sshd-api-common`

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
