### PR TITLE
Get rid of Reflections in `PluginCompatTesterHooks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,15 +90,9 @@
       <version>1.11</version>
     </dependency>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.10.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.kohsuke.metainf-services</groupId>
+      <artifactId>metainf-services</artifactId>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -191,23 +185,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <!-- Version specified in parent POM -->
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>info.picocli</groupId>
-              <artifactId>picocli-codegen</artifactId>
-              <version>${picocli.version}</version>
-            </path>
-          </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -96,9 +96,7 @@ public class PluginCompatTester {
     public void testPlugins() throws PluginCompatibilityTesterException {
         PluginCompatTesterHooks pcth =
                 new PluginCompatTesterHooks(
-                        config.getHookPrefixes(),
-                        config.getExternalHooksJars(),
-                        config.getExcludeHooks());
+                        config.getExternalHooksJars(), config.getExcludeHooks());
         // Determine the plugin data
 
         // Scan bundled plugins. If there is any bundled plugin, only these plugins will be taken

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -132,15 +132,6 @@ public class PluginCompatTesterCli implements Callable<Integer> {
 
     @CheckForNull
     @CommandLine.Option(
-            names = "--hook-prefixes",
-            split = ",",
-            arity = "1",
-            paramLabel = "prefix",
-            description = "Comma-separated list of prefixes of extra hook classes.")
-    private List<String> hookPrefixes;
-
-    @CheckForNull
-    @CommandLine.Option(
             names = "--external-hooks-jars",
             split = ",",
             arity = "1",
@@ -188,9 +179,6 @@ public class PluginCompatTesterCli implements Callable<Integer> {
         }
         if (mavenArgs != null) {
             config.setMavenArgs(mavenArgs);
-        }
-        if (hookPrefixes != null) {
-            config.setHookPrefixes(hookPrefixes);
         }
         if (externalHooksJars != null) {
             config.setExternalHooksJars(externalHooksJars);

--- a/src/main/java/org/jenkins/tools/test/hook/AnalysisPomExecutionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AnalysisPomExecutionHook.java
@@ -4,11 +4,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+import org.kohsuke.MetaInfServices;
 
 /**
  * Custom execution hook for plugins whose parent is {@code org.jvnet.hudson.plugins:analysis-pom}.
  * These plugins use Maven Failsafe Plugin in their test suites.
  */
+@MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
 public class AnalysisPomExecutionHook extends PluginWithFailsafeIntegrationTestsHook {
 
     private static final Set<String> ARTIFACT_IDS =

--- a/src/main/java/org/jenkins/tools/test/hook/AwsJavaSdkHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AwsJavaSdkHook.java
@@ -3,7 +3,10 @@ package org.jenkins.tools.test.hook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class AwsJavaSdkHook extends AbstractMultiParentHook {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/BlueOceanHook.java
@@ -3,8 +3,11 @@ package org.jenkins.tools.test.hook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
 /** Workaround for the Blue Ocean plugins since they are stored in a central repository. */
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class BlueOceanHook extends AbstractMultiParentHook {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/ConfigurationAsCodeHook.java
@@ -3,7 +3,10 @@ package org.jenkins.tools.test.hook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class ConfigurationAsCodeHook extends AbstractMultiParentHook {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -4,10 +4,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
 /**
  * Workaround for the Pipeline: Declarative plugins since they are stored in a central repository.
  */
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class DeclarativePipelineHook extends AbstractMultiParentHook {
 
     private static final Set<String> ARTIFACT_IDS =

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
@@ -4,11 +4,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
 /**
  * Workaround for the Declarative Pipeline Migration Assistant plugins since they are stored in a
  * central repository.
  */
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class DeclarativePipelineMigrationHook extends AbstractMultiParentHook {
 
     private static final Set<String> ARTIFACT_IDS =

--- a/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
@@ -16,6 +16,7 @@ import org.jenkins.tools.test.maven.MavenRunner;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+import org.kohsuke.MetaInfServices;
 
 /**
  * The {@code overrideWar} option is available in HPI Plugin 3.29 or later, but many plugins under
@@ -24,6 +25,7 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
  * the managed set are using a plugin parent POM with HPI Plugin 3.29 or later (i.e., plugin parent
  * POM 4.44 or later), this can be deleted.
  */
+@MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
 public class HpiPluginHook extends PluginCompatTesterHookBeforeExecution {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
@@ -6,11 +6,13 @@ import java.util.stream.IntStream;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+import org.kohsuke.MetaInfServices;
 
 /**
  * Workaround for JaCoCo plugin since it needs execute the jacoco:prepare-agent goal before
  * execution.
  */
+@MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
 public class JacocoHook extends PluginCompatTesterHookBeforeExecution {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/MinaSshdApi.java
+++ b/src/main/java/org/jenkins/tools/test/hook/MinaSshdApi.java
@@ -3,7 +3,10 @@ package org.jenkins.tools.test.hook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class MinaSshdApi extends AbstractMultiParentHook {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -27,7 +27,9 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHooks;
 import org.jenkins.tools.test.model.hook.Stage;
 import org.jenkins.tools.test.model.hook.StageContext;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCompile.class)
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "intended behavior")
 public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile {
 

--- a/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -4,7 +4,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class PipelineStageViewHook extends AbstractMultiParentHook {
 
     private static final Set<String> ARTIFACT_IDS =

--- a/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/SwarmHook.java
@@ -3,7 +3,10 @@ package org.jenkins.tools.test.hook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class SwarmHook extends AbstractMultiParentHook {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -6,7 +6,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
 
     private static final Logger LOGGER = Logger.getLogger(WarningsNGCheckoutHook.class.getName());

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
@@ -3,8 +3,11 @@ package org.jenkins.tools.test.hook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+import org.kohsuke.MetaInfServices;
 
 /** Workaround for Warnings NG plugin since it needs execute integration tests. */
+@MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
 public class WarningsNGExecutionHook extends PluginWithFailsafeIntegrationTestsHook {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/hook/WorkflowCpsHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WorkflowCpsHook.java
@@ -4,7 +4,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.VersionNumber;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class WorkflowCpsHook extends AbstractMultiParentHook {
 
     @Override

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -29,7 +29,6 @@ package org.jenkins.tools.test.model;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -72,9 +71,6 @@ public class PluginCompatTesterConfig {
     @NonNull private Map<String, String> mavenProperties = Map.of();
 
     @NonNull private List<String> mavenArgs = List.of();
-
-    // Classpath prefixes of the extra hooks
-    @NonNull private List<String> hookPrefixes = List.of("org.jenkins");
 
     // External hooks jar files path locations
     @NonNull private List<File> externalHooksJars = List.of();
@@ -171,19 +167,6 @@ public class PluginCompatTesterConfig {
 
     public void setMavenArgs(@NonNull List<String> mavenArgs) {
         this.mavenArgs = List.copyOf(mavenArgs);
-    }
-
-    @NonNull
-    public List<String> getHookPrefixes() {
-        return hookPrefixes;
-    }
-
-    public void setHookPrefixes(@NonNull List<String> hookPrefixes) {
-        // Want to also process the default
-        List<String> combined = new ArrayList<>();
-        combined.addAll(this.hookPrefixes);
-        combined.addAll(hookPrefixes);
-        this.hookPrefixes = List.copyOf(combined);
     }
 
     @NonNull

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -3,8 +3,6 @@ package org.jenkins.tools.test.model.hook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.UncheckedIOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -13,16 +11,10 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Supplier;
+import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.jenkins.tools.test.exception.PluginCompatibilityTesterException;
-import org.reflections.Reflections;
-import org.reflections.util.ConfigurationBuilder;
 
 /**
  * Loads and executes hooks for modifying the state of Plugin Compatibility Tester at different
@@ -37,27 +29,22 @@ public class PluginCompatTesterHooks {
 
     private ClassLoader classLoader = PluginCompatTesterHooks.class.getClassLoader();
 
-    @NonNull private final List<String> hookPrefixes;
-
     public static final Map<Stage, List<PluginCompatTesterHook<StageContext>>> hooksByStage =
             new EnumMap<>(Stage.class);
 
     @NonNull private final List<String> excludeHooks;
 
     public PluginCompatTesterHooks(
-            @NonNull List<String> extraPrefixes,
-            @NonNull List<File> externalJars,
-            @NonNull List<String> excludeHooks) {
-        this.hookPrefixes = extraPrefixes;
+            @NonNull List<File> externalJars, @NonNull List<String> excludeHooks) {
         this.excludeHooks = excludeHooks;
         setupExternalClassLoaders(externalJars);
         setupHooksByStage();
     }
 
     private void setupHooksByStage() {
-        for (Stage stage : Stage.values()) {
-            hooksByStage.put(stage, findHooks(stage));
-        }
+        hooksByStage.put(Stage.CHECKOUT, findHooks(PluginCompatTesterHookBeforeCheckout.class));
+        hooksByStage.put(Stage.COMPILATION, findHooks(PluginCompatTesterHookBeforeCompile.class));
+        hooksByStage.put(Stage.EXECUTION, findHooks(PluginCompatTesterHookBeforeExecution.class));
     }
 
     private void setupExternalClassLoaders(List<File> externalJars) {
@@ -107,80 +94,14 @@ public class PluginCompatTesterHooks {
         }
     }
 
-    private List<PluginCompatTesterHook<StageContext>> findHooks(Stage stage) {
+    private List<PluginCompatTesterHook<StageContext>> findHooks(
+            Class<? extends PluginCompatTesterHook<? extends StageContext>> clazz) {
         List<PluginCompatTesterHook<StageContext>> sortedHooks = new ArrayList<>();
-
-        // Search for all hooks defined within the given classpath prefix
-        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-        configurationBuilder.addClassLoaders(classLoader);
-        for (String hookPrefix : hookPrefixes) {
-            configurationBuilder.forPackage(hookPrefix, classLoader);
+        for (PluginCompatTesterHook<? extends StageContext> hook :
+                ServiceLoader.load(clazz, classLoader)) {
+            sortedHooks.add((PluginCompatTesterHook<StageContext>) hook);
         }
-        Reflections reflections = new Reflections(configurationBuilder);
-        NavigableSet<Class<? extends PluginCompatTesterHook<? extends StageContext>>> subTypes;
-
-        // Find all steps for a given stage. Long due to casting
-        switch (stage) {
-            case COMPILATION:
-                Set<Class<? extends PluginCompatTesterHookBeforeCompile>> compSteps =
-                        reflections.getSubTypesOf(PluginCompatTesterHookBeforeCompile.class);
-                subTypes =
-                        compSteps.stream()
-                                .map(this::casting)
-                                .filter(c -> !Modifier.isAbstract(c.getModifiers()))
-                                .collect(Collectors.toCollection(navigableSet()));
-                break;
-            case EXECUTION:
-                Set<Class<? extends PluginCompatTesterHookBeforeExecution>> exeSteps =
-                        reflections.getSubTypesOf(PluginCompatTesterHookBeforeExecution.class);
-                subTypes =
-                        exeSteps.stream()
-                                .map(this::casting)
-                                .filter(c -> !Modifier.isAbstract(c.getModifiers()))
-                                .collect(Collectors.toCollection(navigableSet()));
-                break;
-            case CHECKOUT:
-                Set<Class<? extends PluginCompatTesterHookBeforeCheckout>> checkSteps =
-                        reflections.getSubTypesOf(PluginCompatTesterHookBeforeCheckout.class);
-                subTypes =
-                        checkSteps.stream()
-                                .map(this::casting)
-                                .filter(c -> !Modifier.isAbstract(c.getModifiers()))
-                                .collect(Collectors.toCollection(navigableSet()));
-                break;
-            default: // Not valid; nothing will get executed
-                throw new IllegalArgumentException("Invalid stage: " + stage);
-        }
-
-        for (Class<? extends PluginCompatTesterHook<? extends StageContext>> c : subTypes) {
-            try {
-                LOGGER.log(Level.FINE, "Loading hook: {0}", c.getName());
-                Constructor<? extends PluginCompatTesterHook<? extends StageContext>> constructor =
-                        c.getConstructor();
-                PluginCompatTesterHook<StageContext> hook =
-                        (PluginCompatTesterHook<StageContext>) constructor.newInstance();
-                sortedHooks.add(hook);
-            } catch (ReflectiveOperationException e) {
-                throw new RuntimeException("Error when loading " + c.getName(), e);
-            }
-        }
-
+        sortedHooks.sort(Comparator.comparing(hook -> hook.getClass().getName()));
         return sortedHooks;
-    }
-
-    private static Supplier<
-                    NavigableSet<Class<? extends PluginCompatTesterHook<? extends StageContext>>>>
-            navigableSet() {
-        return () -> new TreeSet<>(Comparator.comparing(Class::getName));
-    }
-
-    /**
-     * This seems ridiculous, but it is needed to actually convert between the two types of {@link
-     * Set}s. Gets around a generics error: {@code incompatible types: inference variable T has
-     * incompatible bounds}.
-     */
-    private Class<? extends PluginCompatTesterHook<? extends StageContext>> casting(
-            Class<? extends PluginCompatTesterHook<? extends StageContext>> c) {
-        return c;
     }
 }

--- a/src/main/resources/org/jenkins/tools/test/logging/logging.properties
+++ b/src/main/resources/org/jenkins/tools/test/logging/logging.properties
@@ -29,10 +29,3 @@ handlers= java.util.logging.ConsoleHandler
 ############################################################
 
 java.util.logging.ConsoleHandler.formatter = io.jenkins.lib.support_log_formatter.SupportLogFormatter
-
-############################################################
-# Facility-specific properties.
-# Provides extra control for each logger.
-############################################################
-
-org.reflections.level= WARNING


### PR DESCRIPTION
Fixes #394 by dropping the dependency on Reflections in favor of `ServiceLoader`. This requires each hook to be annotated with `@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)`, `@MetaInfServices(PluginCompatTesterHookBeforeCompile.class)`, or `@MetaInfServices(PluginCompatTesterHookBeforeExecution.class)` and obviates the need for a `--hook-prefixes` option. To test this I verified in the debugger that the same hooks got loaded as before this PR (in the same order).