### PR TITLE
Drop support for `git://` URLs

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -462,6 +462,13 @@ public class PluginCompatTester {
                                 "https://github.com/jenkinsci/authentication-tokens-plugin");
 
                 // TODO pending release of
+                // https://github.com/jenkinsci/aws-global-configuration-plugin/pull/51
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/aws-global-configuration-plugin",
+                                "https://github.com/jenkinsci/aws-global-configuration-plugin");
+
+                // TODO pending release of
                 // https://github.com/jenkinsci/blueocean-display-url-plugin/pull/227
                 connectionURL =
                         connectionURL.replace(

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -551,6 +551,13 @@ public class PluginCompatTester {
                                 "https://github.com/jenkinsci/google-oauth-plugin");
 
                 // TODO pending release of
+                // https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/37
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/kubernetes-credentials-plugin",
+                                "https://github.com/jenkinsci/kubernetes-credentials-plugin");
+
+                // TODO pending release of
                 // https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/pull/75
                 connectionURL =
                         connectionURL.replace(

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -455,6 +455,20 @@ public class PluginCompatTester {
                                 "https://github.com/jenkinsci/antisamy-markup-formatter-plugin");
 
                 // TODO pending release of
+                // https://github.com/jenkinsci/authentication-tokens-plugin/pull/106
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/authentication-tokens-plugin",
+                                "https://github.com/jenkinsci/authentication-tokens-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/blueocean-display-url-plugin/pull/227
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/blueocean-display-url-plugin",
+                                "https://github.com/jenkinsci/blueocean-display-url-plugin");
+
+                // TODO pending release of
                 // https://github.com/jenkinsci/bootstrap5-api-plugin/commit/8c5f60ab5e21c03b68d696e7b760caa991b25aa9
                 connectionURL =
                         connectionURL.replace(
@@ -509,6 +523,33 @@ public class PluginCompatTester {
                                 "git://github.com/jenkinsci/github-api-plugin",
                                 "https://github.com/jenkinsci/github-api-plugin");
 
+                // TODO pending release of
+                // https://github.com/jenkinsci/google-kubernetes-engine-plugin/pull/312
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/google-kubernetes-engine-plugin",
+                                "https://github.com/jenkinsci/google-kubernetes-engine-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/google-metadata-plugin/pull/50
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/google-metadata-plugin",
+                                "https://github.com/jenkinsci/google-metadata-plugin");
+
+                // TODO pending release of https://github.com/jenkinsci/google-oauth-plugin/pull/176
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/google-oauth-plugin",
+                                "https://github.com/jenkinsci/google-oauth-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/pull/75
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/kubernetes-credentials-provider-plugin",
+                                "https://github.com/jenkinsci/kubernetes-credentials-provider-plugin");
+
                 // TODO pending adoption of https://github.com/jenkinsci/matrix-auth-plugin/pull/131
                 connectionURL =
                         connectionURL.replace(
@@ -516,11 +557,37 @@ public class PluginCompatTester {
                                 "https://github.com/jenkinsci/matrix-auth-plugin");
 
                 // TODO pending release of
+                // https://github.com/jenkinsci/node-iterator-api-plugin/pull/11
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/node-iterator-api-plugin",
+                                "https://github.com/jenkinsci/node-iterator-api-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/oauth-credentials-plugin/pull/9
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/oauth-credentials-plugin",
+                                "https://github.com/jenkinsci/oauth-credentials-plugin");
+
+                // TODO pending release of
                 // https://github.com/jenkinsci/popper2-api-plugin/commit/bf781e31b072103f3f72d7195e9071863f7f4dd9
                 connectionURL =
                         connectionURL.replace(
                                 "git://github.com/jenkinsci/popper2-api-plugin",
                                 "https://github.com/jenkinsci/popper2-api-plugin");
+
+                // TODO pending release of https://github.com/jenkinsci/pubsub-light-plugin/pull/100
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/pubsub-light-plugin",
+                                "https://github.com/jenkinsci/pubsub-light-plugin");
+
+                // TODO pending release of https://github.com/jenkinsci/s3-plugin/pull/243
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/s3-plugin",
+                                "https://github.com/jenkinsci/s3-plugin");
 
                 // TODO pending release of https://github.com/jenkinsci/ssh-agent-plugin/pull/116
                 connectionURL =

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -444,8 +444,102 @@ public class PluginCompatTester {
                 if (StringUtils.startsWith(connectionURL, "scm:git:")) {
                     connectionURL = StringUtils.substringAfter(connectionURL, "scm:git:");
                 }
+
                 // See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
-                connectionURL = connectionURL.replace("git://", "https://");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/antisamy-markup-formatter-plugin/pull/106
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/antisamy-markup-formatter-plugin",
+                                "https://github.com/jenkinsci/antisamy-markup-formatter-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/bootstrap5-api-plugin/commit/8c5f60ab5e21c03b68d696e7b760caa991b25aa9
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/bootstrap5-api-plugin",
+                                "https://github.com/jenkinsci/bootstrap5-api-plugin");
+
+                // TODO pending backport of
+                // https://github.com/jenkinsci/cloudbees-folder-plugin/pull/260
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/cloudbees-folder-plugin",
+                                "https://github.com/jenkinsci/cloudbees-folder-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/configuration-as-code-plugin/pull/2166
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/configuration-as-code-plugin",
+                                "https://github.com/jenkinsci/configuration-as-code-plugin");
+
+                // TODO pending backport of
+                // https://github.com/jenkinsci/custom-folder-icon-plugin/pull/109
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/custom-folder-icon-plugin",
+                                "https://github.com/jenkinsci/custom-folder-icon-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/data-tables-api-plugin/commit/97dc7555017e6c7ea17f0b67cc292773f1114a54
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/data-tables-api-plugin",
+                                "https://github.com/jenkinsci/data-tables-api-plugin");
+
+                // TODO pending backport of
+                // https://github.com/jenkinsci/echarts-api-plugin/commit/d6951a26e6f1c27b82c8308359f7f76e182de3e3
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/echarts-api-plugin",
+                                "https://github.com/jenkinsci/echarts-api-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/file-parameters-plugin/pull/142
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/file-parameters-plugin",
+                                "https://github.com/jenkinsci/file-parameters-plugin");
+
+                // TODO pending release of https://github.com/jenkinsci/github-api-plugin/pull/182
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/github-api-plugin",
+                                "https://github.com/jenkinsci/github-api-plugin");
+
+                // TODO pending adoption of https://github.com/jenkinsci/matrix-auth-plugin/pull/131
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/matrix-auth-plugin",
+                                "https://github.com/jenkinsci/matrix-auth-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/popper2-api-plugin/commit/bf781e31b072103f3f72d7195e9071863f7f4dd9
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/popper2-api-plugin",
+                                "https://github.com/jenkinsci/popper2-api-plugin");
+
+                // TODO pending release of https://github.com/jenkinsci/ssh-agent-plugin/pull/116
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/ssh-agent-plugin",
+                                "https://github.com/jenkinsci/ssh-agent-plugin");
+
+                // TODO pending release of https://github.com/jenkinsci/ssh-slaves-plugin/pull/352
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/ssh-slaves-plugin",
+                                "https://github.com/jenkinsci/ssh-slaves-plugin");
+
+                // TODO pending release of
+                // https://github.com/jenkinsci/theme-manager-plugin/pull/154
+                connectionURL =
+                        connectionURL.replace(
+                                "git://github.com/jenkinsci/theme-manager-plugin",
+                                "https://github.com/jenkinsci/theme-manager-plugin");
             }
             try {
                 cloneImpl(connectionURL, scmTag, checkoutDirectory);


### PR DESCRIPTION
Workarounds can sometimes be necessary in order to move a system forward without waiting an unreasonably long amount of time for consumers to be adjusted. Temporary workarounds can be tolerated for a short period of time, but the maintenance burden increases when those workarounds become permanent additions to the codebase. Such permanent workarounds increase the cognitive load required to understand the code.

The dynamic rewriting of `git://` URLs to `https://` is a workaround: if plugins properly declared their metadata with a working URL, there would be no need to do dynamic rewriting. The problem with this workaround is its scope: not only does it apply to all existing plugins (including plugins that already have valid URLs and do not need rewriting) but also all future plugins that are added to the managed set. In other words, with this workaround in place we might increase the amount of technical debt we have to bear without realizing it. This unbounded scope makes it more likely that the workaround will become permanent rather than temporary.

A setting like `git config --global url.https://github.com/.insteadOf git://github.com/` (either applied automatically or advised via documentation) is even worse than the status quo. Not only is this a workaround for incorrect upstream metadata that allows us to introduce new plugins to the managed set with incorrect metadata without noticing it (like the status quo), but also it involves changing global Git configuration on the test system or developer system. Asking developers to make global changes for the sake of a particular repository is likely to cause trouble if different repositories have different global settings. The persistent and global nature of such a configuration can lead to drift, where a developer accumulates a large number of such changes and must then painstakingly recreate their old environment when moving to a new system. The fewer dependencies we have on global and persistent customizations, the better.

In contrast, this PR offers an improvement over the status quo by _bounding_ the workaround to only the plugins that currently need it (because they define an invalid SCM URL). This is an improvement over the status quo because it means that new plugins _cannot_ be added to the managed set unless their metadata is compliant. Thus the problem can only shrink, not grow. Over time, the problem will shrink to nothing, at which point the workaround can be removed, including its associated cognitive load and maintenance cost. Explicitly limiting the workaround to its smallest possible scope thus ensures that the workaround does not become permanent but remains temporary and can possibly be removed entirely, resulting in simpler code that is easier to understand and maintain.

To test this I have been running the BOM test suite in https://ci.jenkins.io/job/Tools/job/bom/job/PR-1826/ and limiting the workaround to apply to any plugins where I saw test failures.