### PR TITLE
Require a minimum version of the Jenkins Test Harness

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook.java
@@ -1,0 +1,22 @@
+package org.jenkins.tools.test.hook;
+
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+import org.kohsuke.MetaInfServices;
+
+/**
+ * Recent core versions require a relatively recent Jenkins Test Harness, so ensure that a minimum
+ * supported version is in place.
+ */
+@MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
+public class JenkinsTestHarnessHook extends PropertyVersionHook {
+
+    @Override
+    public String getProperty() {
+        return "jenkins-test-harness.version";
+    }
+
+    @Override
+    public String getMinimumVersion() {
+        return "1903.vf505ecb_63589";
+    }
+}

--- a/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook.java
@@ -19,4 +19,9 @@ public class JenkinsTestHarnessHook extends PropertyVersionHook {
     public String getMinimumVersion() {
         return "1903.vf505ecb_63589";
     }
+
+    @Override
+    public String getMinimumPluginParentPomVersion() {
+        return "4.44";
+    }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook.java
@@ -22,6 +22,6 @@ public class JenkinsTestHarnessHook extends PropertyVersionHook {
 
     @Override
     public String getMinimumPluginParentPomVersion() {
-        return "4.44";
+        return "4.48";
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/PropertyVersionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PropertyVersionHook.java
@@ -1,5 +1,6 @@
 package org.jenkins.tools.test.hook;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.VersionNumber;
 import java.io.File;
@@ -36,6 +37,7 @@ public abstract class PropertyVersionHook extends PluginCompatTesterHookBeforeEx
      * parent POM, the property will not be updated. Return {@code null} to skip the minimum plugin
      * POM version check.
      */
+    @CheckForNull
     public String getMinimumPluginParentPomVersion() {
         return null;
     }
@@ -53,6 +55,9 @@ public abstract class PropertyVersionHook extends PluginCompatTesterHookBeforeEx
             try {
                 if (getMinimumPluginParentPomVersion() != null) {
                     String pluginParentPomVersion = getPluginParentPomVersion(pluginDir, runner);
+                    if (pluginParentPomVersion == null) {
+                        return false;
+                    }
                     if (new VersionNumber(pluginParentPomVersion)
                             .isOlderThan(new VersionNumber(getMinimumPluginParentPomVersion()))) {
                         return false;
@@ -73,6 +78,7 @@ public abstract class PropertyVersionHook extends PluginCompatTesterHookBeforeEx
         context.getArgs().add(String.format("-D%s=%s", getProperty(), getMinimumVersion()));
     }
 
+    @CheckForNull
     private static String getPluginParentPomVersion(File pluginPath, MavenRunner runner)
             throws PomExecutionException {
         String cur;


### PR DESCRIPTION
We often see the need to update the test harness to a newer version when testing new core versions, so enforce a minimum version. This PR refactors the existing code to be more reusable. I tested this by running the `jenkinsci/bom` test suite, with the only two failures being fixed by https://github.com/jenkinsci/workflow-scm-step-plugin/pull/94 and https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/595.