### PR TITLE
fix multi-parent hooks to wok with --local-checkout-dir

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -131,7 +131,7 @@ public class PluginCompatTester {
                 && localCheckoutProvided()
                 && !data.plugins.containsKey(config.getIncludePlugins().get(0))) {
             String artifactId = config.getIncludePlugins().get(0);
-            UpdateSite.Plugin extracted = extractFromLocalCheckout();
+            UpdateSite.Plugin extracted = extractFromLocalCheckout(artifactId);
             data.plugins.put(artifactId, extracted);
         }
 
@@ -205,15 +205,22 @@ public class PluginCompatTester {
         }
     }
 
-    private UpdateSite.Plugin extractFromLocalCheckout() throws PluginSourcesUnavailableException {
+    /**
+     * Extracts SCM information from the local checkout directory and together with {@code plugin}
+     * constructs an ({@code UpdateSite.Plugin} entry.
+     *
+     * @param plugin the name of the plugin. This may differ from what is in the local checkout for
+     *     multi module builds
+     * @return
+     * @throws PluginSourcesUnavailableException
+     */
+    private UpdateSite.Plugin extractFromLocalCheckout(String plugin)
+            throws PluginSourcesUnavailableException {
         Model model =
                 new PluginRemoting(new File(config.getLocalCheckoutDir(), "pom.xml"))
                         .retrieveModel();
         return new UpdateSite.Plugin(
-                model.getArtifactId(),
-                "" /* version is not required */,
-                model.getScm().getConnection(),
-                null);
+                plugin, "" /* version is not required */, model.getScm().getConnection(), null);
     }
 
     private static File createBuildLogFile(

--- a/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -77,12 +77,20 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
     }
 
     protected void configureLocalCheckOut(
-            File localCheckoutDir, @NonNull BeforeCheckoutContext context) {
-        // Do nothing to keep compatibility with pre-existing Hooks
-        LOGGER.log(
-                Level.INFO,
-                "Ignoring local checkout directory for {0}",
-                context.getPlugin().getDisplayName());
+            File localCheckoutDir, @NonNull BeforeCheckoutContext context)
+            throws PluginSourcesUnavailableException {
+
+        File pluginDir = new File(localCheckoutDir, getPluginFolderName(context));
+        if (!pluginDir.exists() && !pluginDir.isDirectory()) {
+            throw new PluginSourcesUnavailableException(
+                    "Invalid localCheckoutDir for " + context.getPlugin().getDisplayName());
+        }
+        // behave exactly as if we have cloned so other hooks do not need to handle the difference
+        // between a localcheckout and a fresh clone
+        context.setRanCheckout(true);
+        context.setCheckoutDir(pluginDir);
+        // context.setParentFolder("."); // it won;t be in a subdirectory like we had a clone
+        context.setPluginDir(pluginDir);
     }
 
     /**

--- a/src/main/java/org/jenkins/tools/test/hook/AwsJavaSdkHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AwsJavaSdkHook.java
@@ -1,7 +1,6 @@
 package org.jenkins.tools.test.hook;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
 import org.kohsuke.MetaInfServices;
@@ -16,12 +15,6 @@ public class AwsJavaSdkHook extends AbstractMultiParentHook {
 
     @Override
     public boolean check(@NonNull BeforeCheckoutContext context) {
-        Model model = context.getModel();
-        return ("org.jenkins-ci.plugins".equals(model.getGroupId())
-                        && "aws-java-sdk".equals(model.getArtifactId())
-                        && "hpi".equals(model.getPackaging()))
-                || ("org.jenkins-ci.plugins.aws-java-sdk".equals(model.getGroupId())
-                        && model.getArtifactId().startsWith("aws-java-sdk")
-                        && "hpi".equals(model.getPackaging()));
+        return context.getPlugin().name.startsWith("aws-java-sdk");
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -1,22 +1,12 @@
 package org.jenkins.tools.test.hook;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.File;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
 import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
-
-    private static final Logger LOGGER = Logger.getLogger(WarningsNGCheckoutHook.class.getName());
-
-    private static final Set<String> ARTIFACT_IDS =
-            Set.of(/* localCheckoutDir */ "warnings-ng-parent", /* checkout */ "warnings-ng");
 
     @Override
     protected String getParentFolder() {
@@ -25,36 +15,11 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
 
     @Override
     public boolean check(@NonNull BeforeCheckoutContext context) {
-        Model model = context.getModel();
-        return "io.jenkins.plugins".equals(model.getGroupId())
-                && ARTIFACT_IDS.contains(model.getArtifactId())
-                && "hpi".equals(model.getPackaging());
+        return "warnings-ng".equals(context.getPlugin().name);
     }
 
     @Override
     protected String getPluginFolderName(@NonNull BeforeCheckoutContext context) {
         return "plugin";
-    }
-
-    @Override
-    protected void configureLocalCheckOut(
-            File localCheckoutDir, @NonNull BeforeCheckoutContext context) {
-        File pluginDir = new File(localCheckoutDir, getPluginFolderName(context));
-        if (!pluginDir.exists() && !pluginDir.isDirectory()) {
-            throw new RuntimeException(
-                    "Invalid localCheckoutDir for " + context.getPlugin().getDisplayName());
-        }
-
-        // Checkout already happened, don't run through again
-        context.setRanCheckout(true);
-        firstRun = false;
-
-        // Change the "download"" directory; after download, it's simply used for reference
-        LOGGER.log(
-                Level.INFO,
-                "Child path for {0}: {1}",
-                new Object[] {context.getPlugin().getDisplayName(), pluginDir.getPath()});
-        context.setCheckoutDir(pluginDir);
-        context.setPluginDir(pluginDir);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGExecutionHook.java
@@ -1,8 +1,6 @@
 package org.jenkins.tools.test.hook;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Set;
-import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
 import org.kohsuke.MetaInfServices;
@@ -11,14 +9,8 @@ import org.kohsuke.MetaInfServices;
 @MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
 public class WarningsNGExecutionHook extends PluginWithFailsafeIntegrationTestsHook {
 
-    private static final Set<String> ARTIFACT_IDS =
-            Set.of(/* localCheckoutDir */ "warnings-ng-parent", /* checkout */ "warnings-ng");
-
     @Override
     public boolean check(@NonNull BeforeExecutionContext context) {
-        Model model = context.getModel();
-        return "io.jenkins.plugins".equals(model.getGroupId())
-                && ARTIFACT_IDS.contains(model.getArtifactId())
-                && "hpi".equals(model.getPackaging());
+        return "warnings-ng".equals(context.getPlugin().name);
     }
 }

--- a/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
@@ -7,9 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
 import org.junit.jupiter.api.Test;
+import hudson.model.UpdateSite;
 
 class WarningsNGExecutionHookTest {
 
@@ -17,17 +17,15 @@ class WarningsNGExecutionHookTest {
     void testCheckMethod() {
         final WarningsNGExecutionHook hook = new WarningsNGExecutionHook();
 
-        Model model = new Model();
-        model.setGroupId("io.jenkins.plugins");
-        model.setArtifactId("warnings-ng");
-        model.setPackaging("hpi");
+        UpdateSite.Plugin plugin = new UpdateSite.Plugin("warnings-ng", null, null, null);
 
         BeforeExecutionContext context =
-                new BeforeExecutionContext(null, model, null, null, null, null, List.of(), null);
+                new BeforeExecutionContext(plugin, null, null, null, null, null, List.of(), null);
+        UpdateSite.Plugin plugin2 = context.getPlugin();
         assertTrue(hook.check(context));
 
-        model.setArtifactId("other-plugin");
-        context = new BeforeExecutionContext(null, model, null, null, null, null, List.of(), null);
+        plugin = new UpdateSite.Plugin("other-plugin", null, null, null);
+        context = new BeforeExecutionContext(plugin, null, null, null, null, null, List.of(), null);
         assertFalse(hook.check(context));
     }
 


### PR DESCRIPTION
improves multi-parent hooks to work with a local checkout when testing a single plugin

tested with the aws-java-sdk-minimal plugin in a local checkout.

```
--working-dir=c:\workarea\source\github\cloudbees\unified-release\output-oc-it\work
--war=c:\workarea\source\github\cloudbees\unified-release\products\core-cm\target\core-cm.war
--fallback-github-organization=jenkinsci-cert
--external-hooks-jars=c:\workarea\source\github\cloudbees\unified-release\tests\cb-pct-hooks\target\cb-pct-hooks.jar
--include-plugins=oc-it
--local-checkout-dir=c:\workarea\source\github\cloudbees\unified-release\.\tests\operations-center-it
-Dsurefire.excludesFile=c:\workarea\source\github\cloudbees\unified-release/src/test/resources/pct-surefire-exclusion-list
-Dsurefire.rerunFailingTestsCount=0
-DreuseForks=false
-DforkCount=1
-Dmaven.test.failure.ignore=true
```

needs further testing

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
