### PR TITLE
Fail fast when attempting to run PCT against a release with a missing or nondeterministic tag

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
@@ -4,14 +4,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.exception.PluginCompatibilityTesterException;
 import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
-import org.jenkins.tools.test.model.hook.BeforeCompilationContext;
-import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
+import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
 import org.kohsuke.MetaInfServices;
 
-@MetaInfServices(PluginCompatTesterHookBeforeCompile.class)
-public class VersionValidationHook extends PluginCompatTesterHookBeforeCompile {
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
+public class VersionValidationHook extends PluginCompatTesterHookBeforeCheckout {
     @Override
-    public void action(@NonNull BeforeCompilationContext context)
+    public void action(@NonNull BeforeCheckoutContext context)
             throws PluginCompatibilityTesterException {
         Model model = context.getModel();
         if (model.getScm().getTag() == null || model.getScm().getTag().equals("HEAD")) {

--- a/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
@@ -1,19 +1,9 @@
 package org.jenkins.tools.test.hook;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
+import org.apache.maven.model.Model;
 import org.jenkins.tools.test.exception.PluginCompatibilityTesterException;
 import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
-import org.jenkins.tools.test.exception.PomExecutionException;
-import org.jenkins.tools.test.maven.ExternalMavenRunner;
-import org.jenkins.tools.test.maven.MavenRunner;
-import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.hook.BeforeCompilationContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
 import org.kohsuke.MetaInfServices;
@@ -23,39 +13,10 @@ public class VersionValidationHook extends PluginCompatTesterHookBeforeCompile {
     @Override
     public void action(@NonNull BeforeCompilationContext context)
             throws PluginCompatibilityTesterException {
-        PluginCompatTesterConfig config = context.getConfig();
-        MavenRunner runner =
-                new ExternalMavenRunner(
-                        config.getExternalMaven(),
-                        config.getMavenSettings(),
-                        config.getMavenArgs());
-        File pluginDir = context.getPluginDir();
-        if (pluginDir != null) {
-            String version = getVersion(pluginDir, runner);
-            if (version.endsWith("-SNAPSHOT")) {
-                throw new PluginSourcesUnavailableException(
-                        "Failed to check out plugin sources for " + version);
-            }
+        Model model = context.getModel();
+        if (model.getScm().getTag() == null || model.getScm().getTag().equals("HEAD")) {
+            throw new PluginSourcesUnavailableException(
+                    "Failed to check out plugin sources for " + model.getVersion());
         }
-    }
-
-    private static String getVersion(File pluginPath, MavenRunner runner)
-            throws PomExecutionException {
-        String property = "project.version";
-        Path log = pluginPath.toPath().resolve(property + ".log");
-        runner.run(
-                Map.of("expression", property, "output", log.toAbsolutePath().toString()),
-                pluginPath,
-                null,
-                "-q",
-                "help:evaluate");
-        String output;
-        try {
-            output = Files.readString(log, Charset.defaultCharset()).trim();
-            Files.deleteIfExists(log);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        return output;
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
@@ -1,0 +1,61 @@
+package org.jenkins.tools.test.hook;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.jenkins.tools.test.exception.PluginCompatibilityTesterException;
+import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
+import org.jenkins.tools.test.exception.PomExecutionException;
+import org.jenkins.tools.test.maven.ExternalMavenRunner;
+import org.jenkins.tools.test.maven.MavenRunner;
+import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.hook.BeforeCompilationContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCompile;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices(PluginCompatTesterHookBeforeCompile.class)
+public class VersionValidationHook extends PluginCompatTesterHookBeforeCompile {
+    @Override
+    public void action(@NonNull BeforeCompilationContext context)
+            throws PluginCompatibilityTesterException {
+        PluginCompatTesterConfig config = context.getConfig();
+        MavenRunner runner =
+                new ExternalMavenRunner(
+                        config.getExternalMaven(),
+                        config.getMavenSettings(),
+                        config.getMavenArgs());
+        File pluginDir = context.getPluginDir();
+        if (pluginDir != null) {
+            String version = getVersion(pluginDir, runner);
+            if (version.endsWith("-SNAPSHOT")) {
+                throw new PluginSourcesUnavailableException(
+                        "Failed to check out plugin sources for " + version);
+            }
+        }
+    }
+
+    private static String getVersion(File pluginPath, MavenRunner runner)
+            throws PomExecutionException {
+        String property = "project.version";
+        Path log = pluginPath.toPath().resolve(property + ".log");
+        runner.run(
+                Map.of("expression", property, "output", log.toAbsolutePath().toString()),
+                pluginPath,
+                null,
+                "-q",
+                "help:evaluate");
+        String output;
+        try {
+            output = Files.readString(log, Charset.defaultCharset()).trim();
+            Files.deleteIfExists(log);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return output;
+    }
+}


### PR DESCRIPTION
A CloudBees employed complained about PCT, writing

> There is no way the PCT job could actually check out this revision of sources—that information is not even available in the snapshot that I know of. But it should at least skip running this plugin at all. Fine to mark the plugin as a PCT checkout failure. Just do not pretend to run it, actually checking out something else (`master` apparently).

With this PR we mark such `-SNAPSHOT` plugins as a PCT checkout failure. Note that this covers both regular snapshots and timestamped snapshots.

To test this I deployed https://repo.jenkins-ci.org/artifactory/snapshots/org/jenkins-ci/plugins/text-finder/1.24-SNAPSHOT/ and updated `jenkinsci/bom` with

```xml
diff --git a/bom-weekly/pom.xml b/bom-weekly/pom.xml
index c91af8d..c093a49 100644
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -557,7 +557,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>text-finder</artifactId>
-                <version>1.23</version>
+                <version>1.24-20230322.225534-1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
diff --git a/sample-plugin/pom.xml b/sample-plugin/pom.xml
index 20da6a7..69e473c 100644
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -592,6 +592,13 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
+        <repository>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <id>snapshots</id>
+          <url>https://repo.jenkins-ci.org/snapshots/</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
```

I then ran `PLUGINS=text-finder TEST=InjectedTest bash local-test.sh` before and after this PR. Before this PR, the test passed but checked out `master` not the timestamped snapshot requested. After this PR, PCT failed as expected.