### PR TITLE
Allow Dependabot to update Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,10 +112,15 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-war</artifactId>
+      <artifactId>jenkins-core</artifactId>
       <version>${jenkins.version}</version>
-      <type>executable-war</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -208,13 +213,20 @@
         <!-- Version specified in parent POM -->
         <executions>
           <execution>
-            <id>copy-dependencies</id>
+            <id>jenkins-war</id>
             <goals>
-              <goal>copy-dependencies</goal>
+              <goal>copy</goal>
             </goals>
             <phase>process-test-classes</phase>
             <configuration>
-              <includeTypes>executable-war</includeTypes>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.jenkins-ci.main</groupId>
+                  <artifactId>jenkins-war</artifactId>
+                  <version>${jenkins.version}</version>
+                  <type>executable-war</type>
+                </artifactItem>
+              </artifactItems>
               <outputDirectory>${project.build.directory}</outputDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
Dependabot was not updating `jenkins.version` as intended because it couldn't copy with the `executable-war` type. Here we use a regular `jar` dependency for Dependabot (excluding transitive dependencies so as not to pollute the test classpath) and copy the WAR file using a `copy` task rather than a `copy-dependencies` task.