### PR TITLE
Fail fast when attempting to run PCT against a release with a missing or nondeterministic tag

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
@@ -9,6 +9,12 @@ import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class TagValidationHook extends PluginCompatTesterHookBeforeCheckout {
+
+    @Override
+    public boolean check(@NonNull BeforeCheckoutContext context) {
+        return context.getConfig().getLocalCheckoutDir() == null;
+    }
+
     @Override
     public void action(@NonNull BeforeCheckoutContext context)
             throws PluginSourcesUnavailableException {

--- a/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
@@ -8,7 +8,7 @@ import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
 import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
-public class VersionValidationHook extends PluginCompatTesterHookBeforeCheckout {
+public class TagValidationHook extends PluginCompatTesterHookBeforeCheckout {
     @Override
     public void action(@NonNull BeforeCheckoutContext context)
             throws PluginSourcesUnavailableException {

--- a/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/VersionValidationHook.java
@@ -1,0 +1,21 @@
+package org.jenkins.tools.test.hook;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.maven.model.Model;
+import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
+import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
+public class VersionValidationHook extends PluginCompatTesterHookBeforeCheckout {
+    @Override
+    public void action(@NonNull BeforeCheckoutContext context)
+            throws PluginSourcesUnavailableException {
+        Model model = context.getModel();
+        if (model.getScm().getTag() == null || model.getScm().getTag().equals("HEAD")) {
+            throw new PluginSourcesUnavailableException(
+                    "Failed to check out plugin sources for " + model.getVersion());
+        }
+    }
+}


### PR DESCRIPTION
#496 but filed against the proper origin. See #496 for the description.