### PR TITLE
Move `UpdateSite` into PCT package

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -27,7 +27,6 @@
 package org.jenkins.tools.test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.model.UpdateSite;
 import hudson.util.VersionNumber;
 import java.io.File;
 import java.io.IOException;
@@ -61,6 +60,7 @@ import org.jenkins.tools.test.maven.MavenRunner;
 import org.jenkins.tools.test.model.MavenPom;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.PluginRemoting;
+import org.jenkins.tools.test.model.UpdateSite;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
 import org.jenkins.tools.test.model.hook.BeforeCompilationContext;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;

--- a/src/main/java/org/jenkins/tools/test/model/UpdateSite.java
+++ b/src/main/java/org/jenkins/tools/test/model/UpdateSite.java
@@ -1,4 +1,4 @@
-package hudson.model;
+package org.jenkins.tools.test.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeCheckoutContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeCheckoutContext.java
@@ -2,11 +2,11 @@ package org.jenkins.tools.test.model.hook;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.UpdateSite;
 import java.io.File;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.UpdateSite;
 
 public final class BeforeCheckoutContext extends StageContext {
 

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeCompilationContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeCompilationContext.java
@@ -2,11 +2,11 @@ package org.jenkins.tools.test.model.hook;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.UpdateSite;
 import java.io.File;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.UpdateSite;
 
 public final class BeforeCompilationContext extends StageContext {
 

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeExecutionContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeExecutionContext.java
@@ -2,13 +2,13 @@ package org.jenkins.tools.test.model.hook;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.UpdateSite;
 import java.io.File;
 import java.util.List;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.MavenPom;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.UpdateSite;
 
 public final class BeforeExecutionContext extends StageContext {
 

--- a/src/main/java/org/jenkins/tools/test/model/hook/StageContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/StageContext.java
@@ -1,10 +1,10 @@
 package org.jenkins.tools.test.model.hook;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.UpdateSite;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.UpdateSite;
 
 public abstract class StageContext {
 

--- a/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import hudson.model.UpdateSite;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +43,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
+import org.jenkins.tools.test.model.UpdateSite;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;


### PR DESCRIPTION
Now that `jenkins-core` is back on the test classpath (just for Dependabot!) it seems safer to move this class into the PCT package to prevent any risk of conflict while running this repository's tests.  @jtnord this will require a trivial update to the import in `CloudBeesModulesHook`, hence the `breaking` label.