### PR TITLE
Adapt to jenkinsci/maven-hpi-plugin#461

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
@@ -20,6 +20,6 @@ public class HpiPluginHook extends PropertyVersionHook {
 
     @Override
     public String getMinimumVersion() {
-        return "3.37";
+        return "3.41-rc1404.03cea_d3a_c95e";
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
@@ -20,6 +20,6 @@ public class HpiPluginHook extends PropertyVersionHook {
 
     @Override
     public String getMinimumVersion() {
-        return "3.41-rc1404.03cea_d3a_c95e";
+        return "3.41";
     }
 }


### PR DESCRIPTION
jenkinsci/maven-hpi-plugin#461 removes the `overrideWarAdditions` option, replacing it with default behavior that obviates the need for that option. Before we can remove `overrideWarAdditions` from `jenkinsci/bom`, we need to ensure that we are consistently getting that default behavior. This PR achieves that objective. I tested this PR in context in `jenkinsci/bom`.