### PR TITLE
Switch to Palantir Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,13 +159,11 @@
         <configuration>
           <java>
             <endWithNewline />
-            <googleJavaFormat>
-              <style>AOSP</style>
-            </googleJavaFormat>
             <importOrder />
             <indent>
               <spaces>true</spaces>
             </indent>
+            <palantirJavaFormat />
             <removeUnusedImports />
             <trimTrailingWhitespace />
           </java>

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -86,37 +86,29 @@ public class PluginCompatTester {
 
     public PluginCompatTester(PluginCompatTesterConfig config) {
         this.config = config;
-        runner =
-                new ExternalMavenRunner(
-                        config.getExternalMaven(),
-                        config.getMavenSettings(),
-                        config.getMavenArgs());
+        runner = new ExternalMavenRunner(config.getExternalMaven(), config.getMavenSettings(), config.getMavenArgs());
     }
 
     public void testPlugins() throws PluginCompatibilityTesterException {
         PluginCompatTesterHooks pcth =
-                new PluginCompatTesterHooks(
-                        config.getExternalHooksJars(), config.getExcludeHooks());
+                new PluginCompatTesterHooks(config.getExternalHooksJars(), config.getExcludeHooks());
         // Determine the plugin data
 
         // Scan bundled plugins. If there is any bundled plugin, only these plugins will be taken
         // under the consideration for the PCT run.
-        UpdateSite.Data data =
-                scanWAR(config.getWar(), "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");
+        UpdateSite.Data data = scanWAR(config.getWar(), "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");
         if (!data.plugins.isEmpty()) {
             // Scan detached plugins to recover proper Group IDs for them. At the moment, we are
             // considering that bomfile contains the info about the detached ones.
-            UpdateSite.Data detachedData =
-                    scanWAR(config.getWar(), "WEB-INF/(?:detached-)?plugins/([^/.]+)[.][hj]pi");
+            UpdateSite.Data detachedData = scanWAR(config.getWar(), "WEB-INF/(?:detached-)?plugins/([^/.]+)[.][hj]pi");
 
             // Add detached if and only if no added as normal one
             if (detachedData != null) {
-                detachedData.plugins.forEach(
-                        (key, value) -> {
-                            if (!data.plugins.containsKey(key)) {
-                                data.plugins.put(key, value);
-                            }
-                        });
+                detachedData.plugins.forEach((key, value) -> {
+                    if (!data.plugins.containsKey(key)) {
+                        data.plugins.put(key, value);
+                    }
+                });
             }
         }
 
@@ -164,8 +156,7 @@ public class PluginCompatTester {
                 // Local directory provided for more than one plugin, so each plugin is allocated in
                 // localCheckoutDir/plugin-name. If there is no subdirectory for the plugin, it will
                 // be cloned from SCM.
-                File pomFile =
-                        new File(new File(config.getLocalCheckoutDir(), plugin.name), "pom.xml");
+                File pomFile = new File(new File(config.getLocalCheckoutDir(), plugin.name), "pom.xml");
                 if (pomFile.exists()) {
                     remote = new PluginRemoting(pomFile);
                 } else {
@@ -192,9 +183,7 @@ public class PluginCompatTester {
                             Level.SEVERE,
                             String.format(
                                     "Internal error while executing a test for core %s and plugin %s at version %s.",
-                                    coreCoordinates.getVersion(),
-                                    plugin.getDisplayName(),
-                                    plugin.version),
+                                    coreCoordinates.getVersion(), plugin.getDisplayName(), plugin.version),
                             e);
                 }
             }
@@ -206,9 +195,7 @@ public class PluginCompatTester {
     }
 
     private UpdateSite.Plugin extractFromLocalCheckout() throws PluginSourcesUnavailableException {
-        Model model =
-                new PluginRemoting(new File(config.getLocalCheckoutDir(), "pom.xml"))
-                        .retrieveModel();
+        Model model = new PluginRemoting(new File(config.getLocalCheckoutDir(), "pom.xml")).retrieveModel();
         return new UpdateSite.Plugin(
                 model.getArtifactId(),
                 "" /* version is not required */,
@@ -218,14 +205,12 @@ public class PluginCompatTester {
 
     private static File createBuildLogFile(
             File workDirectory, String pluginName, String pluginVersion, Dependency coreCoords) {
-        return new File(
-                workDirectory.getAbsolutePath()
-                        + File.separator
-                        + createBuildLogFilePathFor(pluginName, pluginVersion, coreCoords));
+        return new File(workDirectory.getAbsolutePath()
+                + File.separator
+                + createBuildLogFilePathFor(pluginName, pluginVersion, coreCoords));
     }
 
-    private static String createBuildLogFilePathFor(
-            String pluginName, String pluginVersion, Dependency coreCoords) {
+    private static String createBuildLogFilePathFor(String pluginName, String pluginVersion, Dependency coreCoords) {
         return String.format(
                 "logs/%s/v%s_against_%s_%s_%s.log",
                 pluginName,
@@ -236,10 +221,7 @@ public class PluginCompatTester {
     }
 
     private void testPluginAgainst(
-            Dependency coreCoordinates,
-            UpdateSite.Plugin plugin,
-            Model model,
-            PluginCompatTesterHooks pcth)
+            Dependency coreCoordinates, UpdateSite.Plugin plugin, Model model, PluginCompatTesterHooks pcth)
             throws PluginCompatibilityTesterException {
         LOGGER.log(
                 Level.INFO,
@@ -254,16 +236,11 @@ public class PluginCompatTester {
                 new Object[] {plugin.name, plugin.version, coreCoordinates});
 
         File pluginCheckoutDir =
-                new File(
-                        config.getWorkingDir().getAbsolutePath()
-                                + File.separator
-                                + plugin.name
-                                + File.separator);
+                new File(config.getWorkingDir().getAbsolutePath() + File.separator + plugin.name + File.separator);
         String parentFolder = null;
 
         // Run any precheckout hooks
-        BeforeCheckoutContext beforeCheckout =
-                new BeforeCheckoutContext(plugin, model, coreCoordinates, config);
+        BeforeCheckoutContext beforeCheckout = new BeforeCheckoutContext(plugin, model, coreCoordinates, config);
         pcth.runBeforeCheckout(beforeCheckout);
 
         if (!beforeCheckout.ranCheckout()) {
@@ -273,26 +250,19 @@ public class PluginCompatTester {
             }
             try {
                 if (Files.isDirectory(pluginCheckoutDir.toPath())) {
-                    LOGGER.log(
-                            Level.INFO,
-                            "Deleting working directory {0}",
-                            pluginCheckoutDir.getAbsolutePath());
+                    LOGGER.log(Level.INFO, "Deleting working directory {0}", pluginCheckoutDir.getAbsolutePath());
                     FileUtils.deleteDirectory(pluginCheckoutDir);
                 }
 
                 Files.createDirectory(pluginCheckoutDir.toPath());
-                LOGGER.log(
-                        Level.INFO,
-                        "Created plugin checkout directory {0}",
-                        pluginCheckoutDir.getAbsolutePath());
+                LOGGER.log(Level.INFO, "Created plugin checkout directory {0}", pluginCheckoutDir.getAbsolutePath());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
 
             if (localCheckoutProvided()) {
                 if (!onlyOnePluginIncluded()) {
-                    File localCheckoutPluginDir =
-                            new File(config.getLocalCheckoutDir(), plugin.name);
+                    File localCheckoutPluginDir = new File(config.getLocalCheckoutDir(), plugin.name);
                     File pomLocalCheckoutPluginDir = new File(localCheckoutPluginDir, "pom.xml");
                     if (pomLocalCheckoutPluginDir.exists()) {
                         LOGGER.log(
@@ -320,16 +290,11 @@ public class PluginCompatTester {
                     // http://docs.oracle.com/javase/tutorial/displayCode.html?code=http://docs.oracle.com/javase/tutorial/essential/io/examples/Copy.java
                     File localCheckoutDir = config.getLocalCheckoutDir();
                     if (localCheckoutDir == null) {
-                        throw new AssertionError(
-                                "Could never happen, but needed to silence SpotBugs");
+                        throw new AssertionError("Could never happen, but needed to silence SpotBugs");
                     }
-                    LOGGER.log(
-                            Level.INFO,
-                            "Copy plugin directory from {0}",
-                            localCheckoutDir.getAbsolutePath());
+                    LOGGER.log(Level.INFO, "Copy plugin directory from {0}", localCheckoutDir.getAbsolutePath());
                     try {
-                        org.codehaus.plexus.util.FileUtils.copyDirectoryStructure(
-                                localCheckoutDir, pluginCheckoutDir);
+                        org.codehaus.plexus.util.FileUtils.copyDirectoryStructure(localCheckoutDir, pluginCheckoutDir);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -353,13 +318,10 @@ public class PluginCompatTester {
             }
             LOGGER.log(
                     Level.INFO,
-                    "The plugin has already been checked out, likely due to a multi-module"
-                            + " situation; continuing");
+                    "The plugin has already been checked out, likely due to a multi-module" + " situation; continuing");
         }
 
-        File buildLogFile =
-                createBuildLogFile(
-                        config.getWorkingDir(), plugin.name, plugin.version, coreCoordinates);
+        File buildLogFile = createBuildLogFile(config.getWorkingDir(), plugin.name, plugin.version, coreCoordinates);
         try {
             FileUtils.forceMkdir(buildLogFile.getParentFile()); // Creating log directory
             FileUtils.touch(buildLogFile); // Creating log file
@@ -369,8 +331,7 @@ public class PluginCompatTester {
 
         // Ran the BeforeCompileHooks
         BeforeCompilationContext beforeCompile =
-                new BeforeCompilationContext(
-                        plugin, model, coreCoordinates, config, pluginCheckoutDir, parentFolder);
+                new BeforeCompilationContext(plugin, model, coreCoordinates, config, pluginCheckoutDir, parentFolder);
         pcth.runBeforeCompilation(beforeCompile);
 
         // First build against the original POM. This defends against source incompatibilities
@@ -392,24 +353,22 @@ public class PluginCompatTester {
         args.add("surefire:test");
 
         // Run preexecution hooks
-        BeforeExecutionContext forExecutionHooks =
-                new BeforeExecutionContext(
-                        plugin,
-                        model,
-                        coreCoordinates,
-                        config,
-                        pluginCheckoutDir,
-                        parentFolder,
-                        args,
-                        new MavenPom(pluginCheckoutDir));
+        BeforeExecutionContext forExecutionHooks = new BeforeExecutionContext(
+                plugin,
+                model,
+                coreCoordinates,
+                config,
+                pluginCheckoutDir,
+                parentFolder,
+                args,
+                new MavenPom(pluginCheckoutDir));
         pcth.runBeforeExecution(forExecutionHooks);
 
         Map<String, String> properties = new LinkedHashMap<>(config.getMavenProperties());
         properties.put("overrideWar", config.getWar().toString());
         properties.put("jenkins.version", coreCoordinates.getVersion());
         properties.put("useUpperBounds", "true");
-        if (new VersionNumber(coreCoordinates.getVersion())
-                .isOlderThan(new VersionNumber("2.382"))) {
+        if (new VersionNumber(coreCoordinates.getVersion()).isOlderThan(new VersionNumber("2.382"))) {
             /*
              * Versions of Jenkins prior to 2.382 are susceptible to JENKINS-68696, in which
              * javax.servlet:servlet-api comes from core at version 0. This is an intentional trick
@@ -422,10 +381,7 @@ public class PluginCompatTester {
 
         // Execute with tests
         runner.run(
-                Collections.unmodifiableMap(properties),
-                pluginCheckoutDir,
-                buildLogFile,
-                args.toArray(new String[0]));
+                Collections.unmodifiableMap(properties), pluginCheckoutDir, buildLogFile, args.toArray(new String[0]));
     }
 
     public static void cloneFromScm(
@@ -434,8 +390,7 @@ public class PluginCompatTester {
         List<String> connectionURLs = new ArrayList<>();
         connectionURLs.add(url);
         if (fallbackGitHubOrganization != null) {
-            connectionURLs =
-                    getFallbackConnectionURL(connectionURLs, url, fallbackGitHubOrganization);
+            connectionURLs = getFallbackConnectionURL(connectionURLs, url, fallbackGitHubOrganization);
         }
 
         PluginSourcesUnavailableException lastException = null;
@@ -449,178 +404,150 @@ public class PluginCompatTester {
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/antisamy-markup-formatter-plugin/pull/106
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/antisamy-markup-formatter-plugin",
-                                "https://github.com/jenkinsci/antisamy-markup-formatter-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/antisamy-markup-formatter-plugin",
+                        "https://github.com/jenkinsci/antisamy-markup-formatter-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/authentication-tokens-plugin/pull/106
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/authentication-tokens-plugin",
-                                "https://github.com/jenkinsci/authentication-tokens-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/authentication-tokens-plugin",
+                        "https://github.com/jenkinsci/authentication-tokens-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/aws-global-configuration-plugin/pull/51
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/aws-global-configuration-plugin",
-                                "https://github.com/jenkinsci/aws-global-configuration-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/aws-global-configuration-plugin",
+                        "https://github.com/jenkinsci/aws-global-configuration-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/blueocean-display-url-plugin/pull/227
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/blueocean-display-url-plugin",
-                                "https://github.com/jenkinsci/blueocean-display-url-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/blueocean-display-url-plugin",
+                        "https://github.com/jenkinsci/blueocean-display-url-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/bootstrap5-api-plugin/commit/8c5f60ab5e21c03b68d696e7b760caa991b25aa9
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/bootstrap5-api-plugin",
-                                "https://github.com/jenkinsci/bootstrap5-api-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/bootstrap5-api-plugin",
+                        "https://github.com/jenkinsci/bootstrap5-api-plugin");
 
                 // TODO pending backport of
                 // https://github.com/jenkinsci/cloudbees-folder-plugin/pull/260
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/cloudbees-folder-plugin",
-                                "https://github.com/jenkinsci/cloudbees-folder-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/cloudbees-folder-plugin",
+                        "https://github.com/jenkinsci/cloudbees-folder-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/configuration-as-code-plugin/pull/2166
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/configuration-as-code-plugin",
-                                "https://github.com/jenkinsci/configuration-as-code-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/configuration-as-code-plugin",
+                        "https://github.com/jenkinsci/configuration-as-code-plugin");
 
                 // TODO pending backport of
                 // https://github.com/jenkinsci/custom-folder-icon-plugin/pull/109
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/custom-folder-icon-plugin",
-                                "https://github.com/jenkinsci/custom-folder-icon-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/custom-folder-icon-plugin",
+                        "https://github.com/jenkinsci/custom-folder-icon-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/data-tables-api-plugin/commit/97dc7555017e6c7ea17f0b67cc292773f1114a54
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/data-tables-api-plugin",
-                                "https://github.com/jenkinsci/data-tables-api-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/data-tables-api-plugin",
+                        "https://github.com/jenkinsci/data-tables-api-plugin");
 
                 // TODO pending backport of
                 // https://github.com/jenkinsci/echarts-api-plugin/commit/d6951a26e6f1c27b82c8308359f7f76e182de3e3
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/echarts-api-plugin",
-                                "https://github.com/jenkinsci/echarts-api-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/echarts-api-plugin",
+                        "https://github.com/jenkinsci/echarts-api-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/file-parameters-plugin/pull/142
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/file-parameters-plugin",
-                                "https://github.com/jenkinsci/file-parameters-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/file-parameters-plugin",
+                        "https://github.com/jenkinsci/file-parameters-plugin");
 
                 // TODO pending release of https://github.com/jenkinsci/github-api-plugin/pull/182
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/github-api-plugin",
-                                "https://github.com/jenkinsci/github-api-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/github-api-plugin",
+                        "https://github.com/jenkinsci/github-api-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/google-kubernetes-engine-plugin/pull/312
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/google-kubernetes-engine-plugin",
-                                "https://github.com/jenkinsci/google-kubernetes-engine-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/google-kubernetes-engine-plugin",
+                        "https://github.com/jenkinsci/google-kubernetes-engine-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/google-metadata-plugin/pull/50
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/google-metadata-plugin",
-                                "https://github.com/jenkinsci/google-metadata-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/google-metadata-plugin",
+                        "https://github.com/jenkinsci/google-metadata-plugin");
 
                 // TODO pending release of https://github.com/jenkinsci/google-oauth-plugin/pull/176
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/google-oauth-plugin",
-                                "https://github.com/jenkinsci/google-oauth-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/google-oauth-plugin",
+                        "https://github.com/jenkinsci/google-oauth-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/37
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/kubernetes-credentials-plugin",
-                                "https://github.com/jenkinsci/kubernetes-credentials-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/kubernetes-credentials-plugin",
+                        "https://github.com/jenkinsci/kubernetes-credentials-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/pull/75
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/kubernetes-credentials-provider-plugin",
-                                "https://github.com/jenkinsci/kubernetes-credentials-provider-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/kubernetes-credentials-provider-plugin",
+                        "https://github.com/jenkinsci/kubernetes-credentials-provider-plugin");
 
                 // TODO pending adoption of https://github.com/jenkinsci/matrix-auth-plugin/pull/131
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/matrix-auth-plugin",
-                                "https://github.com/jenkinsci/matrix-auth-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/matrix-auth-plugin",
+                        "https://github.com/jenkinsci/matrix-auth-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/node-iterator-api-plugin/pull/11
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/node-iterator-api-plugin",
-                                "https://github.com/jenkinsci/node-iterator-api-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/node-iterator-api-plugin",
+                        "https://github.com/jenkinsci/node-iterator-api-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/oauth-credentials-plugin/pull/9
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/oauth-credentials-plugin",
-                                "https://github.com/jenkinsci/oauth-credentials-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/oauth-credentials-plugin",
+                        "https://github.com/jenkinsci/oauth-credentials-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/popper2-api-plugin/commit/bf781e31b072103f3f72d7195e9071863f7f4dd9
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/popper2-api-plugin",
-                                "https://github.com/jenkinsci/popper2-api-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/popper2-api-plugin",
+                        "https://github.com/jenkinsci/popper2-api-plugin");
 
                 // TODO pending release of https://github.com/jenkinsci/pubsub-light-plugin/pull/100
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/pubsub-light-plugin",
-                                "https://github.com/jenkinsci/pubsub-light-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/pubsub-light-plugin",
+                        "https://github.com/jenkinsci/pubsub-light-plugin");
 
                 // TODO pending release of https://github.com/jenkinsci/s3-plugin/pull/243
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/s3-plugin",
-                                "https://github.com/jenkinsci/s3-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/s3-plugin", "https://github.com/jenkinsci/s3-plugin");
 
                 // TODO pending release of https://github.com/jenkinsci/ssh-agent-plugin/pull/116
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/ssh-agent-plugin",
-                                "https://github.com/jenkinsci/ssh-agent-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/ssh-agent-plugin", "https://github.com/jenkinsci/ssh-agent-plugin");
 
                 // TODO pending release of https://github.com/jenkinsci/ssh-slaves-plugin/pull/352
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/ssh-slaves-plugin",
-                                "https://github.com/jenkinsci/ssh-slaves-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/ssh-slaves-plugin",
+                        "https://github.com/jenkinsci/ssh-slaves-plugin");
 
                 // TODO pending release of
                 // https://github.com/jenkinsci/theme-manager-plugin/pull/154
-                connectionURL =
-                        connectionURL.replace(
-                                "git://github.com/jenkinsci/theme-manager-plugin",
-                                "https://github.com/jenkinsci/theme-manager-plugin");
+                connectionURL = connectionURL.replace(
+                        "git://github.com/jenkinsci/theme-manager-plugin",
+                        "https://github.com/jenkinsci/theme-manager-plugin");
             }
             try {
                 cloneImpl(connectionURL, scmTag, checkoutDirectory);
@@ -661,10 +588,7 @@ public class PluginCompatTester {
     @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "intended behavior")
     private static void cloneImpl(String gitUrl, String scmTag, File checkoutDirectory)
             throws IOException, PluginSourcesUnavailableException {
-        LOGGER.log(
-                Level.INFO,
-                "Checking out from git repository {0} at {1}",
-                new Object[] {gitUrl, scmTag});
+        LOGGER.log(Level.INFO, "Checking out from git repository {0} at {1}", new Object[] {gitUrl, scmTag});
 
         /*
          * We previously used the Maven SCM API to clone the repository, which ran the following
@@ -688,12 +612,11 @@ public class PluginCompatTester {
         Files.createDirectories(checkoutDirectory.toPath());
 
         // git init
-        Process p =
-                new ProcessBuilder()
-                        .directory(checkoutDirectory)
-                        .command("git", "init")
-                        .redirectErrorStream(true)
-                        .start();
+        Process p = new ProcessBuilder()
+                .directory(checkoutDirectory)
+                .command("git", "init")
+                .redirectErrorStream(true)
+                .start();
         StreamGobbler gobbler = new StreamGobbler(p.getInputStream());
         gobbler.start();
         try {
@@ -708,12 +631,11 @@ public class PluginCompatTester {
             throw new PluginSourcesUnavailableException("git init was interrupted", e);
         }
 
-        p =
-                new ProcessBuilder()
-                        .directory(checkoutDirectory)
-                        .command("git", "fetch", gitUrl, scmTag)
-                        .redirectErrorStream(true)
-                        .start();
+        p = new ProcessBuilder()
+                .directory(checkoutDirectory)
+                .command("git", "fetch", gitUrl, scmTag)
+                .redirectErrorStream(true)
+                .start();
         gobbler = new StreamGobbler(p.getInputStream());
         gobbler.start();
         try {
@@ -729,12 +651,11 @@ public class PluginCompatTester {
         }
 
         // git checkout FETCH_HEAD
-        p =
-                new ProcessBuilder()
-                        .directory(checkoutDirectory)
-                        .command("git", "checkout", "FETCH_HEAD")
-                        .redirectErrorStream(true)
-                        .start();
+        p = new ProcessBuilder()
+                .directory(checkoutDirectory)
+                .command("git", "checkout", "FETCH_HEAD")
+                .redirectErrorStream(true)
+                .start();
         gobbler = new StreamGobbler(p.getInputStream());
         gobbler.start();
         try {
@@ -743,27 +664,19 @@ public class PluginCompatTester {
             String output = gobbler.getOutput().trim();
             if (exitStatus != 0) {
                 throw new PluginSourcesUnavailableException(
-                        "git checkout FETCH_HEAD failed with exit status "
-                                + exitStatus
-                                + ": "
-                                + output);
+                        "git checkout FETCH_HEAD failed with exit status " + exitStatus + ": " + output);
             }
         } catch (InterruptedException e) {
-            throw new PluginSourcesUnavailableException(
-                    "git checkout FETCH_HEAD was interrupted", e);
+            throw new PluginSourcesUnavailableException("git checkout FETCH_HEAD was interrupted", e);
         }
     }
 
     public static List<String> getFallbackConnectionURL(
-            List<String> connectionURLs,
-            String connectionURLPomData,
-            String fallbackGitHubOrganization) {
+            List<String> connectionURLs, String connectionURLPomData, String fallbackGitHubOrganization) {
         Pattern pattern = Pattern.compile("(.*github.com[:|/])([^/]*)(.*)");
         Matcher matcher = pattern.matcher(connectionURLPomData);
         matcher.find();
-        connectionURLs.add(
-                matcher.replaceFirst(
-                        "scm:git:git@github.com:" + fallbackGitHubOrganization + "$3"));
+        connectionURLs.add(matcher.replaceFirst("scm:git:git@github.com:" + fallbackGitHubOrganization + "$3"));
         pattern = Pattern.compile("(.*github.com[:|/])([^/]*)(.*)");
         matcher = pattern.matcher(connectionURLPomData);
         matcher.find();
@@ -829,8 +742,7 @@ public class PluginCompatTester {
                             version = matcher.group(1);
                         }
                         String url = "jar:" + war.toURI() + "!/" + name;
-                        UpdateSite.Plugin plugin =
-                                new UpdateSite.Plugin(shortName, version, url, longName);
+                        UpdateSite.Plugin plugin = new UpdateSite.Plugin(shortName, version, url, longName);
                         plugins.add(plugin);
                     }
                 }
@@ -841,10 +753,7 @@ public class PluginCompatTester {
         if (core == null) {
             throw new IllegalStateException("no jenkins-core.jar in " + war);
         }
-        LOGGER.log(
-                Level.INFO,
-                "Scanned contents of {0} with {1} plugins",
-                new Object[] {war, plugins.size()});
+        LOGGER.log(Level.INFO, "Scanned contents of {0} with {1} plugins", new Object[] {war, plugins.size()});
         return new UpdateSite.Data(core, plugins);
     }
 
@@ -880,7 +789,8 @@ public class PluginCompatTester {
             if (!StringUtils.startsWith(line.trim(), "<string>")) {
                 continue;
             }
-            String mvnModule = line.replace("<string>", "").replace("</string>", "").trim();
+            String mvnModule =
+                    line.replace("<string>", "").replace("</string>", "").trim();
             if (mvnModule != null && mvnModule.contains(module)) {
                 return mvnModule;
             }

--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -43,8 +43,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "pct",
         mixinStandardHelpOptions = true,
-        description =
-                "Perform a compatibility test for plugins against Jenkins core and other plugins.")
+        description = "Perform a compatibility test for plugins against Jenkins core and other plugins.")
 public class PluginCompatTesterCli implements Callable<Integer> {
 
     static {
@@ -94,8 +93,7 @@ public class PluginCompatTesterCli implements Callable<Integer> {
             split = ",",
             arity = "1",
             paramLabel = "hook",
-            description =
-                    "Comma-separated list of hooks to skip. If not set, all hooks will be executed.")
+            description = "Comma-separated list of hooks to skip. If not set, all hooks will be executed.")
     private List<String> excludeHooks;
 
     @CheckForNull

--- a/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -20,8 +20,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
 
     @Override
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "intended behavior")
-    public void action(@NonNull BeforeCheckoutContext context)
-            throws PluginSourcesUnavailableException {
+    public void action(@NonNull BeforeCheckoutContext context) throws PluginSourcesUnavailableException {
 
         // We should not execute the hook if using localCheckoutDir
         File localCheckoutDir = context.getConfig().getLocalCheckoutDir();
@@ -37,10 +36,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
                 // Checkout to the parent directory. All other processes will be on the child
                 // directory
                 File parentPath =
-                        new File(
-                                context.getConfig().getWorkingDir().getAbsolutePath()
-                                        + "/"
-                                        + getParentFolder());
+                        new File(context.getConfig().getWorkingDir().getAbsolutePath() + "/" + getParentFolder());
 
                 Model model = context.getModel();
                 // Like the call in PluginCompatTester#runHooks but with subdirectories trimmed:
@@ -56,18 +52,15 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
             firstRun = false;
 
             // Change the "download"" directory; after download, it's simply used for reference
-            File childPath =
-                    new File(
-                            context.getConfig().getWorkingDir().getAbsolutePath()
-                                    + "/"
-                                    + getParentFolder()
-                                    + "/"
-                                    + getPluginFolderName(context));
+            File childPath = new File(context.getConfig().getWorkingDir().getAbsolutePath()
+                    + "/"
+                    + getParentFolder()
+                    + "/"
+                    + getPluginFolderName(context));
 
-            LOGGER.log(
-                    Level.INFO,
-                    "Child path for {0}: {1}",
-                    new Object[] {context.getPlugin().getDisplayName(), childPath.getPath()});
+            LOGGER.log(Level.INFO, "Child path for {0}: {1}", new Object[] {
+                context.getPlugin().getDisplayName(), childPath.getPath()
+            });
             context.setCheckoutDir(childPath);
             context.setPluginDir(childPath);
             context.setParentFolder(getParentFolder());
@@ -76,8 +69,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
         }
     }
 
-    protected void configureLocalCheckOut(
-            File localCheckoutDir, @NonNull BeforeCheckoutContext context) {
+    protected void configureLocalCheckOut(File localCheckoutDir, @NonNull BeforeCheckoutContext context) {
         // Do nothing to keep compatibility with pre-existing Hooks
         LOGGER.log(
                 Level.INFO,

--- a/src/main/java/org/jenkins/tools/test/hook/AnalysisPomExecutionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/AnalysisPomExecutionHook.java
@@ -14,17 +14,16 @@ import org.kohsuke.MetaInfServices;
 @MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
 public class AnalysisPomExecutionHook extends PluginWithFailsafeIntegrationTestsHook {
 
-    private static final Set<String> ARTIFACT_IDS =
-            Set.of(
-                    "analysis-model-api",
-                    "bootstrap5-api",
-                    "checks-api",
-                    "echarts-api",
-                    "font-awesome-api",
-                    "forensics-api",
-                    "jquery3-api",
-                    "plugin-util-api",
-                    "popper2-api");
+    private static final Set<String> ARTIFACT_IDS = Set.of(
+            "analysis-model-api",
+            "bootstrap5-api",
+            "checks-api",
+            "echarts-api",
+            "font-awesome-api",
+            "forensics-api",
+            "jquery3-api",
+            "plugin-util-api",
+            "popper2-api");
 
     @Override
     public boolean check(@NonNull BeforeExecutionContext context) {

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineHook.java
@@ -13,12 +13,11 @@ import org.kohsuke.MetaInfServices;
 @MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class DeclarativePipelineHook extends AbstractMultiParentHook {
 
-    private static final Set<String> ARTIFACT_IDS =
-            Set.of(
-                    "pipeline-model-api",
-                    "pipeline-model-definition",
-                    "pipeline-model-extensions",
-                    "pipeline-stage-tags-metadata");
+    private static final Set<String> ARTIFACT_IDS = Set.of(
+            "pipeline-model-api",
+            "pipeline-model-definition",
+            "pipeline-model-extensions",
+            "pipeline-stage-tags-metadata");
 
     @Override
     protected String getParentFolder() {

--- a/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/DeclarativePipelineMigrationHook.java
@@ -15,9 +15,7 @@ import org.kohsuke.MetaInfServices;
 public class DeclarativePipelineMigrationHook extends AbstractMultiParentHook {
 
     private static final Set<String> ARTIFACT_IDS =
-            Set.of(
-                    "declarative-pipeline-migration-assistant",
-                    "declarative-pipeline-migration-assistant-api");
+            Set.of("declarative-pipeline-migration-assistant", "declarative-pipeline-migration-assistant-api");
 
     @Override
     protected String getParentFolder() {

--- a/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/JacocoHook.java
@@ -26,17 +26,15 @@ public class JacocoHook extends PluginCompatTesterHookBeforeExecution {
     @Override
     public void action(@NonNull BeforeExecutionContext context) {
         List<String> args = context.getArgs();
-        int index =
-                IntStream.range(0, args.size())
-                        .filter(i -> args.get(i).startsWith("hpi:"))
-                        .findFirst()
-                        .orElse(-1);
+        int index = IntStream.range(0, args.size())
+                .filter(i -> args.get(i).startsWith("hpi:"))
+                .findFirst()
+                .orElse(-1);
         if (index == -1) {
-            index =
-                    IntStream.range(0, args.size())
-                            .filter(i -> args.get(i).equals("surefire:test"))
-                            .findFirst()
-                            .orElse(-1);
+            index = IntStream.range(0, args.size())
+                    .filter(i -> args.get(i).equals("surefire:test"))
+                    .findFirst()
+                    .orElse(-1);
         }
         if (index != -1) {
             args.add(index, "jacoco:prepare-agent");

--- a/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -43,11 +43,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
         LOGGER.log(Level.INFO, "Executing multi-parent compile hook");
         PluginCompatTesterConfig config = context.getConfig();
 
-        runner =
-                new ExternalMavenRunner(
-                        config.getExternalMaven(),
-                        config.getMavenSettings(),
-                        config.getMavenArgs());
+        runner = new ExternalMavenRunner(config.getExternalMaven(), config.getMavenSettings(), config.getMavenArgs());
 
         File pluginDir = context.getPluginDir();
         LOGGER.log(Level.INFO, "Plugin dir is {0}", pluginDir);
@@ -55,11 +51,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
         // We need to compile before generating effective pom overriding jenkins.version
         // only if the plugin is not already compiled
         if (!context.ranCompile()) {
-            compile(
-                    pluginDir,
-                    config.getLocalCheckoutDir(),
-                    context.getParentFolder(),
-                    context.getPlugin().name);
+            compile(pluginDir, config.getLocalCheckoutDir(), context.getParentFolder(), context.getPlugin().name);
             context.setRanCompile(true);
         }
 
@@ -73,12 +65,11 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
             PluginCompatTesterHook<BeforeCheckoutContext> checkoutHook =
                     (PluginCompatTesterHook<BeforeCheckoutContext>) hook;
             if (checkoutHook instanceof AbstractMultiParentHook
-                    && checkoutHook.check(
-                            new BeforeCheckoutContext(
-                                    context.getPlugin(),
-                                    context.getModel(),
-                                    context.getCoreCoordinates(),
-                                    context.getConfig()))) {
+                    && checkoutHook.check(new BeforeCheckoutContext(
+                            context.getPlugin(),
+                            context.getModel(),
+                            context.getCoreCoordinates(),
+                            context.getConfig()))) {
                 return true;
             }
         }
@@ -94,9 +85,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
             String mavenModule = PluginCompatTester.getMavenModule(pluginName, path, runner);
             if (mavenModule == null || mavenModule.isBlank()) {
                 throw new IllegalStateException(
-                        String.format(
-                                "Unable to retrieve the Maven module for plugin %s on %s",
-                                pluginName, path));
+                        String.format("Unable to retrieve the Maven module for plugin %s on %s", pluginName, path));
             }
             runner.run(
                     Map.of(
@@ -129,8 +118,8 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
      * Checks if a plugin is a multiparent plugin with a SNAPSHOT project.version and without local
      * checkout directory overriden.
      */
-    private boolean isSnapshotMultiParentPlugin(
-            String parentFolder, File path, File localCheckoutDir) throws PomExecutionException {
+    private boolean isSnapshotMultiParentPlugin(String parentFolder, File path, File localCheckoutDir)
+            throws PomExecutionException {
         if (localCheckoutDir != null) {
             return false;
         }
@@ -138,18 +127,16 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
             return false;
         }
         if (!path.getAbsolutePath().contains(parentFolder)) {
-            LOGGER.log(
-                    Level.WARNING,
-                    "Parent folder {0} not present in path {1}",
-                    new Object[] {parentFolder, path.getAbsolutePath()});
+            LOGGER.log(Level.WARNING, "Parent folder {0} not present in path {1}", new Object[] {
+                parentFolder, path.getAbsolutePath()
+            });
             return false;
         }
         File parentFile = path.getParentFile();
         if (!StringUtils.equals(parentFolder, parentFile.getName())) {
-            LOGGER.log(
-                    Level.WARNING,
-                    "{0} is not the parent folder of {1}",
-                    new Object[] {parentFolder, path.getAbsolutePath()});
+            LOGGER.log(Level.WARNING, "{0} is not the parent folder of {1}", new Object[] {
+                parentFolder, path.getAbsolutePath()
+            });
             return false;
         }
 

--- a/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PipelineStageViewHook.java
@@ -10,8 +10,7 @@ import org.kohsuke.MetaInfServices;
 @MetaInfServices(PluginCompatTesterHookBeforeCheckout.class)
 public class PipelineStageViewHook extends AbstractMultiParentHook {
 
-    private static final Set<String> ARTIFACT_IDS =
-            Set.of("pipeline-rest-api", "pipeline-stage-view");
+    private static final Set<String> ARTIFACT_IDS = Set.of("pipeline-rest-api", "pipeline-stage-view");
 
     @Override
     protected String getParentFolder() {

--- a/src/main/java/org/jenkins/tools/test/hook/PluginWithFailsafeIntegrationTestsHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PluginWithFailsafeIntegrationTestsHook.java
@@ -7,8 +7,7 @@ import java.util.List;
  * Workaround for those plugins with integration tests since they need execute the
  * failsafe:integration-test goal before execution.
  */
-public abstract class PluginWithFailsafeIntegrationTestsHook
-        extends PluginWithIntegrationTestsHook {
+public abstract class PluginWithFailsafeIntegrationTestsHook extends PluginWithIntegrationTestsHook {
 
     @Override
     public Collection<String> getGoals() {

--- a/src/main/java/org/jenkins/tools/test/hook/PropertyVersionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PropertyVersionHook.java
@@ -35,16 +35,12 @@ public abstract class PropertyVersionHook extends PluginCompatTesterHookBeforeEx
     public boolean check(@NonNull BeforeExecutionContext context) {
         PluginCompatTesterConfig config = context.getConfig();
         MavenRunner runner =
-                new ExternalMavenRunner(
-                        config.getExternalMaven(),
-                        config.getMavenSettings(),
-                        config.getMavenArgs());
+                new ExternalMavenRunner(config.getExternalMaven(), config.getMavenSettings(), config.getMavenArgs());
         File pluginDir = context.getPluginDir();
         if (pluginDir != null) {
             try {
                 String version = getPropertyVersion(pluginDir, getProperty(), runner);
-                return new VersionNumber(version)
-                        .isOlderThan(new VersionNumber(getMinimumVersion()));
+                return new VersionNumber(version).isOlderThan(new VersionNumber(getMinimumVersion()));
             } catch (PomExecutionException e) {
                 return false;
             }

--- a/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
@@ -16,12 +16,10 @@ public class TagValidationHook extends PluginCompatTesterHookBeforeCheckout {
     }
 
     @Override
-    public void action(@NonNull BeforeCheckoutContext context)
-            throws PluginSourcesUnavailableException {
+    public void action(@NonNull BeforeCheckoutContext context) throws PluginSourcesUnavailableException {
         Model model = context.getModel();
         if (model.getScm().getTag() == null || model.getScm().getTag().equals("HEAD")) {
-            throw new PluginSourcesUnavailableException(
-                    "Failed to check out plugin sources for " + model.getVersion());
+            throw new PluginSourcesUnavailableException("Failed to check out plugin sources for " + model.getVersion());
         }
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/WarningsNGCheckoutHook.java
@@ -37,8 +37,7 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
     }
 
     @Override
-    protected void configureLocalCheckOut(
-            File localCheckoutDir, @NonNull BeforeCheckoutContext context) {
+    protected void configureLocalCheckOut(File localCheckoutDir, @NonNull BeforeCheckoutContext context) {
         File pluginDir = new File(localCheckoutDir, getPluginFolderName(context));
         if (!pluginDir.exists() && !pluginDir.isDirectory()) {
             throw new RuntimeException(
@@ -50,10 +49,9 @@ public class WarningsNGCheckoutHook extends AbstractMultiParentHook {
         firstRun = false;
 
         // Change the "download"" directory; after download, it's simply used for reference
-        LOGGER.log(
-                Level.INFO,
-                "Child path for {0}: {1}",
-                new Object[] {context.getPlugin().getDisplayName(), pluginDir.getPath()});
+        LOGGER.log(Level.INFO, "Child path for {0}: {1}", new Object[] {
+            context.getPlugin().getDisplayName(), pluginDir.getPath()
+        });
         context.setCheckoutDir(pluginDir);
         context.setPluginDir(pluginDir);
     }

--- a/src/main/java/org/jenkins/tools/test/logging/LoggingConfiguration.java
+++ b/src/main/java/org/jenkins/tools/test/logging/LoggingConfiguration.java
@@ -15,8 +15,7 @@ import java.util.logging.LogManager;
 public class LoggingConfiguration {
 
     public LoggingConfiguration() {
-        try (InputStream is =
-                LoggingConfiguration.class.getResourceAsStream("logging.properties")) {
+        try (InputStream is = LoggingConfiguration.class.getResourceAsStream("logging.properties")) {
             if (is == null) {
                 throw new MissingResourceException(
                         "Failed to load logging.properties",
@@ -33,8 +32,6 @@ public class LoggingConfiguration {
 
     private static BiFunction<String, String, String> updateConfiguration() {
         return (oldValue, newValue) ->
-                oldValue == null && newValue == null
-                        ? null
-                        : (newValue == null ? oldValue : newValue);
+                oldValue == null && newValue == null ? null : (newValue == null ? oldValue : newValue);
     }
 }

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -30,11 +30,14 @@ public class ExternalMavenRunner implements MavenRunner {
 
     private static final Logger LOGGER = Logger.getLogger(ExternalMavenRunner.class.getName());
 
-    @CheckForNull private final File externalMaven;
+    @CheckForNull
+    private final File externalMaven;
 
-    @CheckForNull private final File mavenSettings;
+    @CheckForNull
+    private final File mavenSettings;
 
-    @NonNull private final List<String> mavenArgs;
+    @NonNull
+    private final List<String> mavenArgs;
 
     /**
      * Constructor.
@@ -43,9 +46,7 @@ public class ExternalMavenRunner implements MavenRunner {
      *     PATH} will be used
      */
     public ExternalMavenRunner(
-            @CheckForNull File externalMaven,
-            @CheckForNull File mavenSettings,
-            @NonNull List<String> mavenArgs) {
+            @CheckForNull File externalMaven, @CheckForNull File mavenSettings, @NonNull List<String> mavenArgs) {
         this.externalMaven = externalMaven;
         this.mavenSettings = mavenSettings;
         this.mavenArgs = mavenArgs;
@@ -53,8 +54,7 @@ public class ExternalMavenRunner implements MavenRunner {
 
     @Override
     @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "intended behavior")
-    public void run(
-            Map<String, String> properties, File baseDirectory, File buildLogFile, String... args)
+    public void run(Map<String, String> properties, File baseDirectory, File buildLogFile, String... args)
             throws PomExecutionException {
         List<String> cmd = new ArrayList<>();
         if (externalMaven != null) {
@@ -76,19 +76,18 @@ public class ExternalMavenRunner implements MavenRunner {
         cmd.addAll(mavenArgs);
         cmd.addAll(List.of(args));
         if (buildLogFile != null) {
-            LOGGER.log(
-                    Level.INFO,
-                    "Running {0} in {1} >> {2}",
-                    new Object[] {String.join(" ", cmd), baseDirectory, buildLogFile});
+            LOGGER.log(Level.INFO, "Running {0} in {1} >> {2}", new Object[] {
+                String.join(" ", cmd), baseDirectory, buildLogFile
+            });
         } else {
-            LOGGER.log(
-                    Level.INFO,
-                    "Running {0} in {1}",
-                    new Object[] {String.join(" ", cmd), baseDirectory});
+            LOGGER.log(Level.INFO, "Running {0} in {1}", new Object[] {String.join(" ", cmd), baseDirectory});
         }
         Process p;
         try {
-            p = new ProcessBuilder(cmd).directory(baseDirectory).redirectErrorStream(true).start();
+            p = new ProcessBuilder(cmd)
+                    .directory(baseDirectory)
+                    .redirectErrorStream(true)
+                    .start();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -103,19 +102,17 @@ public class ExternalMavenRunner implements MavenRunner {
         }
         if (exitStatus != 0) {
             throw new PomExecutionException(
-                    String.join(" ", cmd)
-                            + " in "
-                            + baseDirectory
-                            + " failed with exit status "
-                            + exitStatus);
+                    String.join(" ", cmd) + " in " + baseDirectory + " failed with exit status " + exitStatus);
         }
     }
 
     private static class MavenGobbler extends Thread {
 
-        @NonNull private final Process p;
+        @NonNull
+        private final Process p;
 
-        @CheckForNull private final File buildLogFile;
+        @CheckForNull
+        private final File buildLogFile;
 
         public MavenGobbler(@NonNull Process p, @Nullable File buildLogFile) {
             this.p = p;
@@ -127,10 +124,9 @@ public class ExternalMavenRunner implements MavenRunner {
             try (InputStream is = p.getInputStream();
                     Reader isr = new InputStreamReader(is, Charset.defaultCharset());
                     BufferedReader r = new BufferedReader(isr);
-                    OutputStream os =
-                            buildLogFile == null
-                                    ? OutputStream.nullOutputStream()
-                                    : new FileOutputStream(buildLogFile, true);
+                    OutputStream os = buildLogFile == null
+                            ? OutputStream.nullOutputStream()
+                            : new FileOutputStream(buildLogFile, true);
                     Writer osw = new OutputStreamWriter(os, Charset.defaultCharset());
                     PrintWriter w = new PrintWriter(osw)) {
                 String line;

--- a/src/main/java/org/jenkins/tools/test/model/MavenPom.java
+++ b/src/main/java/org/jenkins/tools/test/model/MavenPom.java
@@ -145,10 +145,7 @@ public class MavenPom {
 
             Element groupIdElem = mavenDependency.element(GROUP_ID_ELEMENT);
             if (groupIdElem != null && groupId.equalsIgnoreCase(groupIdElem.getText())) {
-                LOGGER.log(
-                        Level.WARNING,
-                        "Removing dependency on {0}:{1}",
-                        new Object[] {groupId, artifactId});
+                LOGGER.log(Level.WARNING, "Removing dependency on {0}:{1}", new Object[] {groupId, artifactId});
                 dependencies.remove(mavenDependency);
             }
         }
@@ -246,15 +243,7 @@ public class MavenPom {
             dependencies = doc.getRootElement().addElement("dependencies");
         }
 
-        manageDependencies(
-                toAdd,
-                toReplace,
-                toAddTest,
-                toReplaceTest,
-                pluginGroupIds,
-                doc,
-                dependencies,
-                true);
+        manageDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, doc, dependencies, true);
         Element profiles = doc.getRootElement().element("profiles");
         if (profiles != null) {
             Map<String, VersionNumber> empty = new HashMap<>();
@@ -266,14 +255,7 @@ public class MavenPom {
                     continue;
                 }
                 manageDependencies(
-                        empty,
-                        toReplace,
-                        empty,
-                        toReplaceTest,
-                        pluginGroupIds,
-                        doc,
-                        profileDependencies,
-                        false);
+                        empty, toReplace, empty, toReplaceTest, pluginGroupIds, doc, profileDependencies, false);
             }
         }
         writeDocument(pom, doc);
@@ -327,7 +309,8 @@ public class MavenPom {
                     String property = version.getTextTrim().replace("${", "").replace("}", "");
                     Element propertyToUpdate = null;
                     for (Element mavenProperty : properties.elements()) {
-                        if (StringUtils.equals(property, mavenProperty.getQName().getName())) {
+                        if (StringUtils.equals(
+                                property, mavenProperty.getQName().getName())) {
                             propertyToUpdate = mavenProperty;
                             break;
                         }
@@ -381,10 +364,7 @@ public class MavenPom {
 
     /** Add the given new plugins to the pom file. */
     private void addPlugins(
-            Map<String, VersionNumber> adding,
-            Map<String, String> pluginGroupIds,
-            Element dependencies,
-            String scope) {
+            Map<String, VersionNumber> adding, Map<String, String> pluginGroupIds, Element dependencies, String scope) {
         for (Map.Entry<String, VersionNumber> dep : adding.entrySet()) {
             Element dependency = dependencies.addElement("dependency");
             String group = pluginGroupIds.get(dep.getKey());

--- a/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginCompatTesterConfig.java
@@ -41,42 +41,54 @@ import java.util.Map;
 public class PluginCompatTesterConfig {
 
     // The megawar
-    @NonNull private final File war;
+    @NonNull
+    private final File war;
 
     // A working directory where the tested plugin's sources will be checked out
-    @NonNull private final File workingDir;
+    @NonNull
+    private final File workingDir;
 
     // List of plugin artifact ids on which tests will be performed
     // If empty, tests will be performed on every plugins retrieved from update center
-    @NonNull private List<String> includePlugins = List.of();
+    @NonNull
+    private List<String> includePlugins = List.of();
 
     // List of plugin artifact ids on which tests will be not performed
     // If empty, tests will be performed on every includePlugins found
-    @NonNull private List<String> excludePlugins = List.of();
+    @NonNull
+    private List<String> excludePlugins = List.of();
 
     // List of hooks that will not be executed
     // If empty, all hooks will be executed
-    @NonNull private List<String> excludeHooks = List.of();
+    @NonNull
+    private List<String> excludeHooks = List.of();
 
     // URL to be used as an alternative to download plugin source from fallback
     // organizations, like your own fork
-    @CheckForNull private String fallbackGitHubOrganization;
+    @CheckForNull
+    private String fallbackGitHubOrganization;
 
-    @CheckForNull private File externalMaven;
+    @CheckForNull
+    private File externalMaven;
 
     // Path for maven settings file where repository will be provided allowing to
     // download jenkins-core artifact (and dependencies)
-    @CheckForNull private File mavenSettings;
+    @CheckForNull
+    private File mavenSettings;
 
-    @NonNull private Map<String, String> mavenProperties = Map.of();
+    @NonNull
+    private Map<String, String> mavenProperties = Map.of();
 
-    @NonNull private List<String> mavenArgs = List.of();
+    @NonNull
+    private List<String> mavenArgs = List.of();
 
     // External hooks jar files path locations
-    @NonNull private List<File> externalHooksJars = List.of();
+    @NonNull
+    private List<File> externalHooksJars = List.of();
 
     // Path for a folder containing a local (possibly modified) clone of a plugin repository
-    @CheckForNull private File localCheckoutDir;
+    @CheckForNull
+    private File localCheckoutDir;
 
     // If multiple plugins are specified, fail the overall run after the first plugin failure occurs
     // rather than continuing to test other plugins.

--- a/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
+++ b/src/main/java/org/jenkins/tools/test/model/PluginRemoting.java
@@ -76,9 +76,7 @@ public class PluginRemoting {
         }
     }
 
-    @SuppressFBWarnings(
-            value = "URLCONNECTION_SSRF_FD",
-            justification = "Only file: URLs are supported")
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Only file: URLs are supported")
     private String retrievePomContentFromHpi() throws IOException {
         URL url = new URL(hpiRemoteUrl);
         if (!url.getProtocol().equals("jar") || !url.getFile().startsWith("file:")) {
@@ -88,8 +86,7 @@ public class PluginRemoting {
                 ZipInputStream zis = new ZipInputStream(is)) {
             ZipEntry ze;
             while ((ze = zis.getNextEntry()) != null) {
-                if (ze.getName().startsWith("META-INF/maven/")
-                        && ze.getName().endsWith("/pom.xml")) {
+                if (ze.getName().startsWith("META-INF/maven/") && ze.getName().endsWith("/pom.xml")) {
                     return new String(zis.readAllBytes(), StandardCharsets.UTF_8);
                 }
             }

--- a/src/main/java/org/jenkins/tools/test/model/UpdateSite.java
+++ b/src/main/java/org/jenkins/tools/test/model/UpdateSite.java
@@ -11,7 +11,8 @@ public final class UpdateSite {
     /** In-memory representation of the update center data. */
     public static final class Data {
         /** The latest jenkins.war. */
-        @NonNull public final Entry core;
+        @NonNull
+        public final Entry core;
 
         /** Plugins in the repository, keyed by their artifact IDs. */
         @NonNull
@@ -27,13 +28,16 @@ public final class UpdateSite {
 
     public static class Entry {
         /** Artifact ID. */
-        @NonNull public final String name;
+        @NonNull
+        public final String name;
 
         /** The version. */
-        @NonNull public final String version;
+        @NonNull
+        public final String version;
 
         /** Download URL. */
-        @NonNull public final String url;
+        @NonNull
+        public final String url;
 
         public Entry(@NonNull String name, @NonNull String version, @NonNull String url) {
             this.name = name;
@@ -44,13 +48,10 @@ public final class UpdateSite {
 
     public static class Plugin extends Entry {
         /** Human readable title of the plugin. */
-        @CheckForNull public final String title;
+        @CheckForNull
+        public final String title;
 
-        public Plugin(
-                @NonNull String name,
-                @NonNull String version,
-                @NonNull String url,
-                @CheckForNull String title) {
+        public Plugin(@NonNull String name, @NonNull String version, @NonNull String url, @CheckForNull String title) {
             super(name, version, url);
             this.title = title;
         }

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeCheckoutContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeCheckoutContext.java
@@ -12,11 +12,14 @@ public final class BeforeCheckoutContext extends StageContext {
 
     private boolean ranCheckout;
 
-    @CheckForNull private File checkoutDir;
+    @CheckForNull
+    private File checkoutDir;
 
-    @CheckForNull private File pluginDir;
+    @CheckForNull
+    private File pluginDir;
 
-    @CheckForNull private String parentFolder;
+    @CheckForNull
+    private String parentFolder;
 
     public BeforeCheckoutContext(
             @NonNull UpdateSite.Plugin plugin,

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeCompilationContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeCompilationContext.java
@@ -10,9 +10,11 @@ import org.jenkins.tools.test.model.UpdateSite;
 
 public final class BeforeCompilationContext extends StageContext {
 
-    @CheckForNull private final File pluginDir;
+    @CheckForNull
+    private final File pluginDir;
 
-    @CheckForNull private final String parentFolder;
+    @CheckForNull
+    private final String parentFolder;
 
     private boolean ranCompile;
 

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeExecutionContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeExecutionContext.java
@@ -12,13 +12,17 @@ import org.jenkins.tools.test.model.UpdateSite;
 
 public final class BeforeExecutionContext extends StageContext {
 
-    @CheckForNull private final File pluginDir;
+    @CheckForNull
+    private final File pluginDir;
 
-    @CheckForNull private final String parentFolder;
+    @CheckForNull
+    private final String parentFolder;
 
-    @NonNull private final List<String> args;
+    @NonNull
+    private final List<String> args;
 
-    @NonNull private final MavenPom pom;
+    @NonNull
+    private final MavenPom pom;
 
     public BeforeExecutionContext(
             @NonNull UpdateSite.Plugin plugin,

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCheckout.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCheckout.java
@@ -6,5 +6,4 @@ package org.jenkins.tools.test.model.hook;
  *
  * <p>This exists simply for the ability to check when a subclass should be implemented.
  */
-public abstract class PluginCompatTesterHookBeforeCheckout
-        extends PluginCompatTesterHook<BeforeCheckoutContext> {}
+public abstract class PluginCompatTesterHookBeforeCheckout extends PluginCompatTesterHook<BeforeCheckoutContext> {}

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCompile.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeCompile.java
@@ -14,5 +14,4 @@ package org.jenkins.tools.test.model.hook;
  * hook that performs the compilation must check before if it has already been performed by another
  * hook and decide on the consequences.
  */
-public abstract class PluginCompatTesterHookBeforeCompile
-        extends PluginCompatTesterHook<BeforeCompilationContext> {}
+public abstract class PluginCompatTesterHookBeforeCompile extends PluginCompatTesterHook<BeforeCompilationContext> {}

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeExecution.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHookBeforeExecution.java
@@ -6,5 +6,4 @@ package org.jenkins.tools.test.model.hook;
  *
  * <p>This exists simply for the ability to check when a subclass should be implemented.
  */
-public abstract class PluginCompatTesterHookBeforeExecution
-        extends PluginCompatTesterHook<BeforeExecutionContext> {}
+public abstract class PluginCompatTesterHookBeforeExecution extends PluginCompatTesterHook<BeforeExecutionContext> {}

--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -32,10 +32,10 @@ public class PluginCompatTesterHooks {
     public static final Map<Stage, List<PluginCompatTesterHook<StageContext>>> hooksByStage =
             new EnumMap<>(Stage.class);
 
-    @NonNull private final List<String> excludeHooks;
+    @NonNull
+    private final List<String> excludeHooks;
 
-    public PluginCompatTesterHooks(
-            @NonNull List<File> externalJars, @NonNull List<String> excludeHooks) {
+    public PluginCompatTesterHooks(@NonNull List<File> externalJars, @NonNull List<String> excludeHooks) {
         this.excludeHooks = excludeHooks;
         setupExternalClassLoaders(externalJars);
         setupHooksByStage();
@@ -62,8 +62,7 @@ public class PluginCompatTesterHooks {
         classLoader = new URLClassLoader(urls.toArray(new URL[0]), classLoader);
     }
 
-    public void runBeforeCheckout(@NonNull BeforeCheckoutContext context)
-            throws PluginCompatibilityTesterException {
+    public void runBeforeCheckout(@NonNull BeforeCheckoutContext context) throws PluginCompatibilityTesterException {
         runHooks(context);
     }
 
@@ -72,8 +71,7 @@ public class PluginCompatTesterHooks {
         runHooks(context);
     }
 
-    public void runBeforeExecution(@NonNull BeforeExecutionContext context)
-            throws PluginCompatibilityTesterException {
+    public void runBeforeExecution(@NonNull BeforeExecutionContext context) throws PluginCompatibilityTesterException {
         runHooks(context);
     }
 
@@ -97,8 +95,7 @@ public class PluginCompatTesterHooks {
     private List<PluginCompatTesterHook<StageContext>> findHooks(
             Class<? extends PluginCompatTesterHook<? extends StageContext>> clazz) {
         List<PluginCompatTesterHook<StageContext>> sortedHooks = new ArrayList<>();
-        for (PluginCompatTesterHook<? extends StageContext> hook :
-                ServiceLoader.load(clazz, classLoader)) {
+        for (PluginCompatTesterHook<? extends StageContext> hook : ServiceLoader.load(clazz, classLoader)) {
             sortedHooks.add((PluginCompatTesterHook<StageContext>) hook);
         }
         sortedHooks.sort(Comparator.comparing(hook -> hook.getClass().getName()));

--- a/src/main/java/org/jenkins/tools/test/model/hook/StageContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/StageContext.java
@@ -8,11 +8,20 @@ import org.jenkins.tools.test.model.UpdateSite;
 
 public abstract class StageContext {
 
-    @NonNull private final Stage stage;
-    @NonNull private final UpdateSite.Plugin plugin;
-    @NonNull private final Model model;
-    @NonNull private final Dependency coreCoordinates;
-    @NonNull private final PluginCompatTesterConfig config;
+    @NonNull
+    private final Stage stage;
+
+    @NonNull
+    private final UpdateSite.Plugin plugin;
+
+    @NonNull
+    private final Model model;
+
+    @NonNull
+    private final Dependency coreCoordinates;
+
+    @NonNull
+    private final PluginCompatTesterConfig config;
 
     public StageContext(
             @NonNull Stage stage,

--- a/src/main/java/org/jenkins/tools/test/util/StreamGobbler.java
+++ b/src/main/java/org/jenkins/tools/test/util/StreamGobbler.java
@@ -11,7 +11,8 @@ import java.nio.charset.Charset;
 
 public class StreamGobbler extends Thread {
 
-    @NonNull private final InputStream is;
+    @NonNull
+    private final InputStream is;
 
     private final StringBuilder output = new StringBuilder();
 

--- a/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
+++ b/src/test/java/org/jenkins/tools/test/PluginCompatTesterTest.java
@@ -60,17 +60,15 @@ class PluginCompatTesterTest {
     @Test
     void smokes(@TempDir File tempDir) throws Exception {
         PluginCompatTesterConfig config =
-                new PluginCompatTesterConfig(
-                        new File("target", "megawar.war").getAbsoluteFile(), tempDir);
+                new PluginCompatTesterConfig(new File("target", "megawar.war").getAbsoluteFile(), tempDir);
         config.setMavenProperties(Map.of("test", "InjectedTest"));
         PluginCompatTester tester = new PluginCompatTester(config);
         tester.testPlugins();
-        Path report =
-                tempDir.toPath()
-                        .resolve("text-finder")
-                        .resolve("target")
-                        .resolve("surefire-reports")
-                        .resolve("TEST-InjectedTest.xml");
+        Path report = tempDir.toPath()
+                .resolve("text-finder")
+                .resolve("target")
+                .resolve("surefire-reports")
+                .resolve("TEST-InjectedTest.xml");
         assertTrue(Files.exists(report));
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
@@ -90,10 +88,8 @@ class PluginCompatTesterTest {
 
     @Test
     void updateSite() {
-        UpdateSite.Data data =
-                PluginCompatTester.scanWAR(
-                        new File("target", "megawar.war").getAbsoluteFile(),
-                        "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");
+        UpdateSite.Data data = PluginCompatTester.scanWAR(
+                new File("target", "megawar.war").getAbsoluteFile(), "WEB-INF/(?:optional-)?plugins/([^/.]+)[.][hj]pi");
         assertEquals("core", data.core.name);
         assertNotNull(data.core.version);
         assertEquals("https://foobar", data.core.url);

--- a/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
@@ -21,8 +21,7 @@ class JacocoHookTest {
         model.setGroupId("org.jenkins-ci.plugins");
         model.setArtifactId("jacoco");
         model.setPackaging("hpi");
-        BeforeExecutionContext context =
-                new BeforeExecutionContext(null, model, null, null, null, null, null, null);
+        BeforeExecutionContext context = new BeforeExecutionContext(null, model, null, null, null, null, null, null);
         assertTrue(hook.check(context));
 
         model.setArtifactId("other-plugin");
@@ -34,11 +33,8 @@ class JacocoHookTest {
     void testAction() {
         final JacocoHook hook = new JacocoHook();
 
-        List<String> args =
-                new ArrayList<>(
-                        List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test"));
-        BeforeExecutionContext context =
-                new BeforeExecutionContext(null, null, null, null, null, null, args, null);
+        List<String> args = new ArrayList<>(List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test"));
+        BeforeExecutionContext context = new BeforeExecutionContext(null, null, null, null, null, null, args, null);
         hook.action(context);
         assertThat(args.size(), is(4));
         assertThat(args.get(0), is("jacoco:prepare-agent"));

--- a/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
@@ -35,11 +35,8 @@ class WarningsNGExecutionHookTest {
     void testAction() {
         final WarningsNGExecutionHook hook = new WarningsNGExecutionHook();
 
-        List<String> args =
-                new ArrayList<>(
-                        List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test"));
-        BeforeExecutionContext context =
-                new BeforeExecutionContext(null, null, null, null, null, null, args, null);
+        List<String> args = new ArrayList<>(List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test"));
+        BeforeExecutionContext context = new BeforeExecutionContext(null, null, null, null, null, null, args, null);
         hook.action(context);
         assertThat(args.size(), is(4));
         assertTrue(args.contains("failsafe:integration-test"));

--- a/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/MavenPomTest.java
@@ -26,158 +26,136 @@ class MavenPomTest {
     void addDependenciesWithTestsClassifier(@TempDir File prj) throws Exception {
         File pom = createPomFileFromResource(prj, "credentials-binding-pom-before.xml");
 
-        Map<String, VersionNumber> toAdd =
-                new HashMap<>(Map.of("trilead-api", new VersionNumber("1.0.8")));
-        Map<String, VersionNumber> toReplace =
-                new HashMap<>(
-                        Map.of(
-                                "credentials",
-                                new VersionNumber("2.3.12"),
-                                "ssh-credentials",
-                                new VersionNumber("1.18.1"),
-                                "plain-credentials",
-                                new VersionNumber("1.7")));
+        Map<String, VersionNumber> toAdd = new HashMap<>(Map.of("trilead-api", new VersionNumber("1.0.8")));
+        Map<String, VersionNumber> toReplace = new HashMap<>(Map.of(
+                "credentials",
+                new VersionNumber("2.3.12"),
+                "ssh-credentials",
+                new VersionNumber("1.18.1"),
+                "plain-credentials",
+                new VersionNumber("1.7")));
         Map<String, VersionNumber> toAddTest = new HashMap<>();
-        Map<String, VersionNumber> toReplaceTest =
-                new HashMap<>(
-                        Map.of(
-                                "workflow-scm-step",
-                                new VersionNumber("2.11"),
-                                "workflow-durable-task-step",
-                                new VersionNumber("2.35"),
-                                "display-url-api",
-                                new VersionNumber("2.3.3"),
-                                "script-security",
-                                new VersionNumber("1.74"),
-                                "workflow-cps",
-                                new VersionNumber("2.83")));
-        toReplaceTest.putAll(
-                Map.of(
-                        "workflow-support",
-                        new VersionNumber("3.5"),
-                        "workflow-job",
-                        new VersionNumber("2.39"),
-                        "workflow-basic-steps",
-                        new VersionNumber("2.20")));
-        Map<String, String> pluginGroupIds =
-                new HashMap<>(
-                        Map.of(
-                                "credentials-binding",
-                                "org.jenkins-ci.plugins",
-                                "pipeline-build-step",
-                                "org.jenkins-ci.plugins",
-                                "credentials",
-                                "org.jenkins-ci.plugins",
-                                "jdk-tool",
-                                "org.jenkins-ci.plugins",
-                                "snakeyaml-api",
-                                "io.jenkins.plugins"));
+        Map<String, VersionNumber> toReplaceTest = new HashMap<>(Map.of(
+                "workflow-scm-step",
+                new VersionNumber("2.11"),
+                "workflow-durable-task-step",
+                new VersionNumber("2.35"),
+                "display-url-api",
+                new VersionNumber("2.3.3"),
+                "script-security",
+                new VersionNumber("1.74"),
+                "workflow-cps",
+                new VersionNumber("2.83")));
+        toReplaceTest.putAll(Map.of(
+                "workflow-support",
+                new VersionNumber("3.5"),
+                "workflow-job",
+                new VersionNumber("2.39"),
+                "workflow-basic-steps",
+                new VersionNumber("2.20")));
+        Map<String, String> pluginGroupIds = new HashMap<>(Map.of(
+                "credentials-binding",
+                "org.jenkins-ci.plugins",
+                "pipeline-build-step",
+                "org.jenkins-ci.plugins",
+                "credentials",
+                "org.jenkins-ci.plugins",
+                "jdk-tool",
+                "org.jenkins-ci.plugins",
+                "snakeyaml-api",
+                "io.jenkins.plugins"));
+        pluginGroupIds.putAll(Map.of(
+                "workflow-step-api",
+                "org.jenkins-ci.plugins.workflow",
+                "plain-credentials",
+                "org.jenkins-ci.plugins",
+                "trilead-api",
+                "org.jenkins-ci.plugins",
+                "command-launcher",
+                "org.jenkins-ci.plugins",
+                "jquery",
+                "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(Map.of(
+                "matrix-project",
+                "org.jenkins-ci.plugins",
+                "jquery-detached",
+                "org.jenkins-ci.ui",
+                "ace-editor",
+                "org.jenkins-ci.ui",
+                "git",
+                "org.jenkins-ci.plugins",
+                "workflow-durable-task-step",
+                "org.jenkins-ci.plugins.workflow"));
+        pluginGroupIds.putAll(Map.of(
+                "git-client",
+                "org.jenkins-ci.plugins",
+                "ssh-credentials",
+                "org.jenkins-ci.plugins",
+                "variant",
+                "org.jenkins-ci.plugins",
+                "cloudbees-folder",
+                "org.jenkins-ci.plugins",
+                "scm-api",
+                "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(Map.of(
+                "pipeline-stage-step",
+                "org.jenkins-ci.plugins",
+                "junit-attachments",
+                "org.jenkins-ci.plugins",
+                "durable-task",
+                "org.jenkins-ci.plugins",
+                "workflow-job",
+                "org.jenkins-ci.plugins.workflow",
+                "workflow-basic-steps",
+                "org.jenkins-ci.plugins.workflow"));
+        pluginGroupIds.putAll(Map.of(
+                "jsch",
+                "org.jenkins-ci.plugins",
+                "timestamper",
+                "org.jenkins-ci.plugins",
+                "junit",
+                "org.jenkins-ci.plugins",
+                "apache-httpcomponents-client-4-api",
+                "org.jenkins-ci.plugins",
+                "structs",
+                "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(Map.of(
+                "workflow-cps-global-lib",
+                "org.jenkins-ci.plugins.workflow",
+                "configuration-as-code",
+                "io.jenkins",
+                "workflow-cps",
+                "org.jenkins-ci.plugins.workflow",
+                "workflow-support",
+                "org.jenkins-ci.plugins.workflow",
+                "ssh-slaves",
+                "org.jenkins-ci.plugins"));
+        pluginGroupIds.putAll(Map.of(
+                "htmlpublisher",
+                "org.jenkins-ci.plugins",
+                "mailer",
+                "org.jenkins-ci.plugins",
+                "ansicolor",
+                "org.jenkins-ci.plugins",
+                "jackson2-api",
+                "org.jenkins-ci.plugins",
+                "workflow-scm-step",
+                "org.jenkins-ci.plugins.workflow"));
+        pluginGroupIds.putAll(Map.of(
+                "display-url-api",
+                "org.jenkins-ci.plugins",
+                "token-macro",
+                "org.jenkins-ci.plugins",
+                "script-security",
+                "org.jenkins-ci.plugins",
+                "pipeline-input-step",
+                "org.jenkins-ci.plugins",
+                "branch-api",
+                "org.jenkins-ci.plugins"));
         pluginGroupIds.putAll(
-                Map.of(
-                        "workflow-step-api",
-                        "org.jenkins-ci.plugins.workflow",
-                        "plain-credentials",
-                        "org.jenkins-ci.plugins",
-                        "trilead-api",
-                        "org.jenkins-ci.plugins",
-                        "command-launcher",
-                        "org.jenkins-ci.plugins",
-                        "jquery",
-                        "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "matrix-project",
-                        "org.jenkins-ci.plugins",
-                        "jquery-detached",
-                        "org.jenkins-ci.ui",
-                        "ace-editor",
-                        "org.jenkins-ci.ui",
-                        "git",
-                        "org.jenkins-ci.plugins",
-                        "workflow-durable-task-step",
-                        "org.jenkins-ci.plugins.workflow"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "git-client",
-                        "org.jenkins-ci.plugins",
-                        "ssh-credentials",
-                        "org.jenkins-ci.plugins",
-                        "variant",
-                        "org.jenkins-ci.plugins",
-                        "cloudbees-folder",
-                        "org.jenkins-ci.plugins",
-                        "scm-api",
-                        "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "pipeline-stage-step",
-                        "org.jenkins-ci.plugins",
-                        "junit-attachments",
-                        "org.jenkins-ci.plugins",
-                        "durable-task",
-                        "org.jenkins-ci.plugins",
-                        "workflow-job",
-                        "org.jenkins-ci.plugins.workflow",
-                        "workflow-basic-steps",
-                        "org.jenkins-ci.plugins.workflow"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "jsch",
-                        "org.jenkins-ci.plugins",
-                        "timestamper",
-                        "org.jenkins-ci.plugins",
-                        "junit",
-                        "org.jenkins-ci.plugins",
-                        "apache-httpcomponents-client-4-api",
-                        "org.jenkins-ci.plugins",
-                        "structs",
-                        "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "workflow-cps-global-lib",
-                        "org.jenkins-ci.plugins.workflow",
-                        "configuration-as-code",
-                        "io.jenkins",
-                        "workflow-cps",
-                        "org.jenkins-ci.plugins.workflow",
-                        "workflow-support",
-                        "org.jenkins-ci.plugins.workflow",
-                        "ssh-slaves",
-                        "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "htmlpublisher",
-                        "org.jenkins-ci.plugins",
-                        "mailer",
-                        "org.jenkins-ci.plugins",
-                        "ansicolor",
-                        "org.jenkins-ci.plugins",
-                        "jackson2-api",
-                        "org.jenkins-ci.plugins",
-                        "workflow-scm-step",
-                        "org.jenkins-ci.plugins.workflow"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "display-url-api",
-                        "org.jenkins-ci.plugins",
-                        "token-macro",
-                        "org.jenkins-ci.plugins",
-                        "script-security",
-                        "org.jenkins-ci.plugins",
-                        "pipeline-input-step",
-                        "org.jenkins-ci.plugins",
-                        "branch-api",
-                        "org.jenkins-ci.plugins"));
-        pluginGroupIds.putAll(
-                Map.of(
-                        "workflow-api",
-                        "org.jenkins-ci.plugins.workflow",
-                        "git-server",
-                        "org.jenkins-ci.plugins"));
+                Map.of("workflow-api", "org.jenkins-ci.plugins.workflow", "git-server", "org.jenkins-ci.plugins"));
         List<String> toConvert = Collections.emptyList();
-        new MavenPom(prj)
-                .addDependencies(
-                        toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
+        new MavenPom(prj).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
 
         assertResourceEqualsXmlFile("credentials-binding-pom-after.xml", pom);
     }
@@ -199,8 +177,7 @@ class MavenPomTest {
     }
 
     @Test
-    void doNotDuplicateDependenciesWhoseVersionsAreProperties(@TempDir File folder)
-            throws Exception {
+    void doNotDuplicateDependenciesWhoseVersionsAreProperties(@TempDir File folder) throws Exception {
         File pomFile = createPomFileFromResource(folder, "demo-plugin-properties-pom-before.xml");
         Map<String, VersionNumber> toAdd = new HashMap<>();
         Map<String, VersionNumber> toReplace = new HashMap<>();
@@ -210,19 +187,14 @@ class MavenPomTest {
         Map<String, String> pluginGroupIds = new HashMap<>();
         pluginGroupIds.put("workflow-step-api", "org.jenkins-ci.plugins.workflow");
         List<String> toConvert = Collections.emptyList();
-        new MavenPom(folder)
-                .addDependencies(
-                        toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
+        new MavenPom(folder).addDependencies(toAdd, toReplace, toAddTest, toReplaceTest, pluginGroupIds, toConvert);
         assertResourceEqualsXmlFile("demo-plugin-properties-pom-after.xml", pomFile);
     }
 
-    private void assertResourceEqualsXmlFile(String resource, File pom)
-            throws IOException, URISyntaxException {
+    private void assertResourceEqualsXmlFile(String resource, File pom) throws IOException, URISyntaxException {
         assertEquals(
-                normalizeXmlString(
-                        Files.readString(
-                                Paths.get(getClass().getResource(resource).toURI()),
-                                StandardCharsets.UTF_8)),
+                normalizeXmlString(Files.readString(
+                        Paths.get(getClass().getResource(resource).toURI()), StandardCharsets.UTF_8)),
                 normalizeXmlString(FileUtils.readFileToString(pom, StandardCharsets.UTF_8)));
     }
 

--- a/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
+++ b/src/test/java/org/jenkins/tools/test/model/PluginRemotingTest.java
@@ -14,19 +14,12 @@ class PluginRemotingTest {
 
     @Test
     void testStringInterpolation() {
-        assertThat(
-                PluginRemoting.interpolateString("${project.artifactId}", "wibble"), is("wibble"));
-        assertThat(
-                PluginRemoting.interpolateString("prefix-${project.artifactId}", "blah"),
-                is("prefix-blah"));
-        assertThat(
-                PluginRemoting.interpolateString("${project.artifactId}suffix", "something"),
-                is("somethingsuffix"));
+        assertThat(PluginRemoting.interpolateString("${project.artifactId}", "wibble"), is("wibble"));
+        assertThat(PluginRemoting.interpolateString("prefix-${project.artifactId}", "blah"), is("prefix-blah"));
+        assertThat(PluginRemoting.interpolateString("${project.artifactId}suffix", "something"), is("somethingsuffix"));
 
         // no interpolation - contains neither ${artifactId} not ${project.artifactId}
-        assertThat(
-                PluginRemoting.interpolateString("${aartifactId}suffix", "something"),
-                is("${aartifactId}suffix"));
+        assertThat(PluginRemoting.interpolateString("${aartifactId}suffix", "something"), is("${aartifactId}suffix"));
         assertThat(
                 PluginRemoting.interpolateString("${projectXartifactId}suffix", "something"),
                 is("${projectXartifactId}suffix"));
@@ -41,9 +34,7 @@ class PluginRemotingTest {
         assertThat(model.getGroupId(), is("com.example.jenkins"));
         assertThat(model.getArtifactId(), is("example"));
         assertThat(model.getPackaging(), is("hpi"));
-        assertThat(
-                model.getScm().getConnection(),
-                is("scm:git:https://jenkins.example.com/example-plugin.git"));
+        assertThat(model.getScm().getConnection(), is("scm:git:https://jenkins.example.com/example-plugin.git"));
         assertThat(model.getScm().getTag(), is("example-4.1"));
     }
 
@@ -58,9 +49,7 @@ class PluginRemotingTest {
         assertThat(model.getGroupId(), nullValue());
         assertThat(model.getArtifactId(), is("example"));
         assertThat(model.getPackaging(), is("hpi"));
-        assertThat(
-                model.getScm().getConnection(),
-                is("scm:git:https://jenkins.example.com/example-plugin.git"));
+        assertThat(model.getScm().getConnection(), is("scm:git:https://jenkins.example.com/example-plugin.git"));
         assertThat(model.getScm().getTag(), is("example-4.1"));
     }
 
@@ -69,8 +58,7 @@ class PluginRemotingTest {
         File pomFile = new File(getClass().getResource("negative/pom.xml").toURI());
         PluginRemoting pluginRemoting = new PluginRemoting(pomFile);
         PluginSourcesUnavailableException e =
-                assertThrows(
-                        PluginSourcesUnavailableException.class, pluginRemoting::retrieveModel);
+                assertThrows(PluginSourcesUnavailableException.class, pluginRemoting::retrieveModel);
         assertThat(e.getMessage(), is("Failed to parse pom.xml"));
     }
 }

--- a/src/test/java/org/jenkins/tools/test/picocli/ExistingFileTypeConverterTest.java
+++ b/src/test/java/org/jenkins/tools/test/picocli/ExistingFileTypeConverterTest.java
@@ -23,9 +23,7 @@ class ExistingFileTypeConverterTest {
     void testMissingFile(@TempDir File f) throws Exception {
         ExistingFileTypeConverter converter = new ExistingFileTypeConverter();
         TypeConversionException tce =
-                assertThrows(
-                        TypeConversionException.class,
-                        () -> converter.convert(new File(f, "whatever").getPath()));
+                assertThrows(TypeConversionException.class, () -> converter.convert(new File(f, "whatever").getPath()));
         assertThat(tce.getMessage(), containsString("whatever"));
     }
 }


### PR DESCRIPTION
Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its [Rectangle Rule](https://github.com/google/google-java-format/wiki/The-Rectangle-Rule) has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.