### PR TITLE
Stop throwing away `MANIFEST.MF` in test setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
                 <delete dir="${project.build.directory}/megawar/WEB-INF/detached-plugins" />
                 <delete file="${project.build.directory}/megawar/META-INF/JENKINS.RSA" />
                 <delete file="${project.build.directory}/megawar/META-INF/JENKINS.SF" />
-                <war destfile="${project.build.directory}/megawar.war">
+                <war destfile="${project.build.directory}/megawar.war" manifest="${project.build.directory}/megawar/META-INF/MANIFEST.MF">
                   <fileset dir="${project.build.directory}/megawar" />
                 </war>
               </target>


### PR DESCRIPTION
Amends #469. Extracted from https://github.com/jenkinsci/plugin-compat-tester/pull/510#discussion_r1157563345. Tested by verifying the test `megawar.war` file now retains the original manifest.