### PR TITLE
Add `serialVersionUID` to exception classes

### DIFF
--- a/src/main/java/org/jenkins/tools/test/exception/PluginCompatibilityTesterException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PluginCompatibilityTesterException.java
@@ -8,6 +8,8 @@ package org.jenkins.tools.test.exception;
  */
 public class PluginCompatibilityTesterException extends Exception {
 
+    private static final long serialVersionUID = 1L;
+
     public PluginCompatibilityTesterException(String message) {
         super(message);
     }

--- a/src/main/java/org/jenkins/tools/test/exception/PluginSourcesUnavailableException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PluginSourcesUnavailableException.java
@@ -33,6 +33,9 @@ package org.jenkins.tools.test.exception;
  * @author Frederic Camblor
  */
 public class PluginSourcesUnavailableException extends PluginCompatibilityTesterException {
+
+    private static final long serialVersionUID = 1L;
+
     public PluginSourcesUnavailableException(String message) {
         super(message);
     }

--- a/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PomExecutionException.java
@@ -33,6 +33,8 @@ package org.jenkins.tools.test.exception;
  */
 public class PomExecutionException extends PluginCompatibilityTesterException {
 
+    private static final long serialVersionUID = 1L;
+
     public PomExecutionException(String message) {
         super(message);
     }

--- a/src/main/java/org/jenkins/tools/test/exception/PomTransformationException.java
+++ b/src/main/java/org/jenkins/tools/test/exception/PomTransformationException.java
@@ -32,6 +32,9 @@ package org.jenkins.tools.test.exception;
  * @author Frederic Camblor
  */
 public class PomTransformationException extends PluginCompatibilityTesterException {
+
+    private static final long serialVersionUID = 1L;
+
     public PomTransformationException(String message) {
         super(message);
     }


### PR DESCRIPTION
Appears to fix an IDE warning. Extracted from #510 where it does not belong because it has nothing to do with multi-module support.