### PR TITLE
Simplify core coördinates

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -66,10 +66,7 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
                     (PluginCompatTesterHook<BeforeCheckoutContext>) hook;
             if (checkoutHook instanceof AbstractMultiParentHook
                     && checkoutHook.check(new BeforeCheckoutContext(
-                            context.getPlugin(),
-                            context.getModel(),
-                            context.getCoreCoordinates(),
-                            context.getConfig()))) {
+                            context.getPlugin(), context.getModel(), context.getCoreVersion(), context.getConfig()))) {
                 return true;
             }
         }

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeCheckoutContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeCheckoutContext.java
@@ -3,7 +3,6 @@ package org.jenkins.tools.test.model.hook;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.UpdateSite;
@@ -24,9 +23,9 @@ public final class BeforeCheckoutContext extends StageContext {
     public BeforeCheckoutContext(
             @NonNull UpdateSite.Plugin plugin,
             @NonNull Model model,
-            @NonNull Dependency coreCoordinates,
+            @NonNull String coreVersion,
             @NonNull PluginCompatTesterConfig config) {
-        super(Stage.CHECKOUT, plugin, model, coreCoordinates, config);
+        super(Stage.CHECKOUT, plugin, model, coreVersion, config);
     }
 
     public boolean ranCheckout() {

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeCompilationContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeCompilationContext.java
@@ -3,7 +3,6 @@ package org.jenkins.tools.test.model.hook;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.UpdateSite;
@@ -21,11 +20,11 @@ public final class BeforeCompilationContext extends StageContext {
     public BeforeCompilationContext(
             @NonNull UpdateSite.Plugin plugin,
             @NonNull Model model,
-            @NonNull Dependency coreCoordinates,
+            @NonNull String coreVersion,
             @NonNull PluginCompatTesterConfig config,
             @CheckForNull File pluginDir,
             @CheckForNull String parentFolder) {
-        super(Stage.COMPILATION, plugin, model, coreCoordinates, config);
+        super(Stage.COMPILATION, plugin, model, coreVersion, config);
         this.pluginDir = pluginDir;
         this.parentFolder = parentFolder;
     }

--- a/src/main/java/org/jenkins/tools/test/model/hook/BeforeExecutionContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/BeforeExecutionContext.java
@@ -4,7 +4,6 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.util.List;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.MavenPom;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
@@ -27,13 +26,13 @@ public final class BeforeExecutionContext extends StageContext {
     public BeforeExecutionContext(
             @NonNull UpdateSite.Plugin plugin,
             @NonNull Model model,
-            @NonNull Dependency coreCoordinates,
+            @NonNull String coreVersion,
             @NonNull PluginCompatTesterConfig config,
             @CheckForNull File pluginDir,
             @CheckForNull String parentFolder,
             @NonNull List<String> args,
             @NonNull MavenPom pom) {
-        super(Stage.EXECUTION, plugin, model, coreCoordinates, config);
+        super(Stage.EXECUTION, plugin, model, coreVersion, config);
         this.pluginDir = pluginDir;
         this.parentFolder = parentFolder;
         this.args = args;

--- a/src/main/java/org/jenkins/tools/test/model/hook/StageContext.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/StageContext.java
@@ -1,7 +1,6 @@
 package org.jenkins.tools.test.model.hook;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.UpdateSite;
@@ -18,7 +17,7 @@ public abstract class StageContext {
     private final Model model;
 
     @NonNull
-    private final Dependency coreCoordinates;
+    private final String coreVersion;
 
     @NonNull
     private final PluginCompatTesterConfig config;
@@ -27,12 +26,12 @@ public abstract class StageContext {
             @NonNull Stage stage,
             @NonNull UpdateSite.Plugin plugin,
             @NonNull Model model,
-            @NonNull Dependency coreCoordinates,
+            @NonNull String coreVersion,
             @NonNull PluginCompatTesterConfig config) {
         this.stage = stage;
         this.plugin = plugin;
         this.model = model;
-        this.coreCoordinates = coreCoordinates;
+        this.coreVersion = coreVersion;
         this.config = config;
     }
 
@@ -52,8 +51,8 @@ public abstract class StageContext {
     }
 
     @NonNull
-    public Dependency getCoreCoordinates() {
-        return coreCoordinates;
+    public String getCoreVersion() {
+        return coreVersion;
     }
 
     @NonNull


### PR DESCRIPTION
As observed in #510, the use of core coördinates is overkill when the version will suffice. This will require a trivial adaptation in proprietary code. CC @jtnord