### PR TITLE
Use `Implementation-Build` rather than `Plugin-GitHash`

### DIFF
--- a/src/main/java/org/jenkins/tools/test/model/plugin_metadata/ModernPluginMetadataExtractor.java
+++ b/src/main/java/org/jenkins/tools/test/model/plugin_metadata/ModernPluginMetadataExtractor.java
@@ -24,6 +24,7 @@ public class ModernPluginMetadataExtractor implements PluginMetadataExtractor {
     private static final Attributes.Name PLUGIN_ID = new Attributes.Name("Short-Name");
     private static final Attributes.Name PLUGIN_NAME = new Attributes.Name("Long-Name");
     private static final Attributes.Name PLUGIN_VERSION = new Attributes.Name("Plugin-Version");
+    private static final Attributes.Name IMPLEMENTATION_BUILD = new Attributes.Name("Implementation-Build");
 
     @Override
     public boolean isApplicable(String pluginId, Manifest manifest, Model model) {
@@ -38,12 +39,19 @@ public class ModernPluginMetadataExtractor implements PluginMetadataExtractor {
 
         assert pluginId.equals(mainAttributes.getValue(PLUGIN_ID));
 
+        // TODO simplify once https://github.com/jenkinsci/maven-hpi-plugin/pull/471 is adopted in all multi-module
+        // plugins
+        String gitHash = mainAttributes.getValue(IMPLEMENTATION_BUILD);
+        if (gitHash == null) {
+            gitHash = mainAttributes.getValue(PLUGIN_GIT_HASH);
+        }
+
         return new Plugin.Builder()
                 .withPluginId(mainAttributes.getValue(PLUGIN_ID))
                 .withName(mainAttributes.getValue(PLUGIN_NAME))
                 .withScmConnection(mainAttributes.getValue(PLUGIN_SCM_CONNECTION))
                 .withTag(mainAttributes.getValue(PLUGIN_SCM_TAG))
-                .withGitHash(mainAttributes.getValue(PLUGIN_GIT_HASH))
+                .withGitHash(gitHash)
                 .withModule(mainAttributes.getValue(PLUGIN_MODULE))
                 .withVersion(mainAttributes.getValue(PLUGIN_VERSION))
                 .build();

--- a/src/test/resources/org/jenkins/tools/test/model/plugin_metadata/ModernPluginMetadataExtractorTest/modern/MANIFEST.MF
+++ b/src/test/resources/org/jenkins/tools/test/model/plugin_metadata/ModernPluginMetadataExtractorTest/modern/MANIFEST.MF
@@ -22,6 +22,6 @@ Plugin-ScmConnection: scm:git:https://github.com/jenkinsci/aws-java-sdk-
  plugin.git
 Plugin-ScmTag: 938ad577f750694635f3c0160ac2110db5d6eb98
 Plugin-ScmUrl: https://github.com/jenkinsci/aws-java-sdk-plugin/
-Plugin-GitHash: 938ad577f750694635f3c0160ac2110db5d6eb98
 Plugin-Module: aws-java-sdk-ec2
+Implementation-Build: 938ad577f750694635f3c0160ac2110db5d6eb98
 


### PR DESCRIPTION
See https://github.com/jenkinsci/pom/pull/419 and https://github.com/jenkinsci/maven-hpi-plugin/pull/471. In https://github.com/jenkinsci/pom/pull/419 I am planning to add the default specification and default implementation entries in core and core component `.jar` and `.war` files, consistent with plugin `.jar` and `.hpi` files. In https://github.com/jenkinsci/pom/pull/419 I am also planning to add the Git hash as `Implementation-Build` to core and core component `.jar` and `.war` files, and in https://github.com/jenkinsci/maven-hpi-plugin/pull/471 I am renaming this information from `Plugin-GitHash` (recently added) to `Implementation-Build` for consistency. This PR adapts to https://github.com/jenkinsci/maven-hpi-plugin/pull/471. While I am temporarily supporting `Plugin-GitHash` for now, I plan to rip out `Plugin-GitHash` shortly (in a month or so) once it's no longer used by anything (not much is using it today, just the AWS Java SDK plugin I think).