### PR TITLE
Testing local or embedded plugins is exclusive

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -149,8 +149,9 @@ public class PluginCompatTesterCli implements Callable<Integer> {
     @CheckForNull
     @CommandLine.Option(
             names = "--local-checkout-dir",
-            description =
-                    "Folder containing either a local (possibly modified) clone of a plugin repository or a set of local clones of different plugins.",
+            description = "Folder containing either a local (possibly modified) clone of a single plugin repository,"
+                    + " or a set of local clones of different plugins with a local aggregator project in the root. "
+                    + "If specified then any plugins bundled in the war will not be tested.",
             converter = ExistingFileTypeConverter.class)
     private File localCheckoutDir;
 

--- a/src/main/java/org/jenkins/tools/test/PluginListerCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginListerCli.java
@@ -77,9 +77,6 @@ public class PluginListerCli implements Callable<Integer> {
         ServiceHelper serviceHelper = new ServiceHelper(externalHooksJars);
         WarExtractor warExtractor = new WarExtractor(warFile, serviceHelper, includePlugins, excludePlugins);
         List<Plugin> plugins = warExtractor.extractPlugins();
-        if (plugins.isEmpty()) {
-            throw new MetadataExtractionException("Found no plugins in " + warFile);
-        }
 
         if (output != null) {
             NavigableMap<String, List<Plugin>> pluginsByRepository = WarExtractor.byRepository(plugins);

--- a/src/main/java/org/jenkins/tools/test/util/WarExtractor.java
+++ b/src/main/java/org/jenkins/tools/test/util/WarExtractor.java
@@ -74,6 +74,7 @@ public class WarExtractor {
      * Extract the list of plugins to be tested from the given WAR.
      *
      * @return An unmodifiable list of plugins to be tested, sorted by plugin ID.
+     * @throws MetadataExtractionException if a non-I/O related issue occurs when the list of plugins is extracted or, if after applying filters, no plugins are located.
      */
     public List<Plugin> extractPlugins() throws MetadataExtractionException {
         List<Plugin> plugins = new ArrayList<>();
@@ -87,6 +88,9 @@ public class WarExtractor {
             }
         } catch (IOException e) {
             throw new UncheckedIOException("I/O error occurred whilst extracting plugin metadata from WAR", e);
+        }
+        if (plugins.isEmpty()) {
+            throw new MetadataExtractionException("Found no plugins in " + warFile);
         }
         plugins.sort(Comparator.comparing(Plugin::getPluginId));
         return List.copyOf(plugins);

--- a/src/test/java/org/jenkins/tools/test/util/WarExtractorTest.java
+++ b/src/test/java/org/jenkins/tools/test/util/WarExtractorTest.java
@@ -7,10 +7,12 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.List;
 import java.util.Set;
+import org.jenkins.tools.test.exception.MetadataExtractionException;
 import org.jenkins.tools.test.model.plugin_metadata.Plugin;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +42,12 @@ class WarExtractorTest {
                         hasProperty("tag", startsWith("text-finder-1.")),
                         hasProperty("name", is("Text Finder")),
                         hasProperty("version", startsWith("1."))));
+    }
+
+    @Test
+    void testExtractPluginsWithNoMatches() throws Exception {
+        WarExtractor warExtractor = new WarExtractor(
+                new File("target", "megawar.war"), new ServiceHelper(Set.of()), Set.of("bogus-plugin-id"), Set.of());
+        assertThrows(MetadataExtractionException.class, () -> warExtractor.extractPlugins());
     }
 }


### PR DESCRIPTION
if `--local-checkout-dir` is provided then we only check plugins that are in the directory specified (after filtering any includes/excludes) and ignore any plugins in the war

Also re-introduces a earlier simplification from @basil where the extractors will throw `MetadataExtractionException` if no plugins (after filtering) are found.

fixes #528

Tested manually with `warnigns-ng` both in a local checkout and not. 
the tests are only run from the local sources if `--local-checkout-dir` is provided, and fetches the git sources only if it is omitted.

Also manually tested filtering with a bogus `plugin-id` and a local checkout dir correctly errors in the tool.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
