### PR TITLE
Log the plugin name before executing the before checkout hooks

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -124,6 +124,7 @@ public class PluginCompatTester {
              */
             for (Plugin plugin : plugins) {
                 BeforeCheckoutContext c = new BeforeCheckoutContext(coreVersion, plugin, config);
+                LOGGER.log(Level.INFO, "Running BeforeCheckout hooks for {0}", plugin.getName());
                 pcth.runBeforeCheckout(c);
             }
         }


### PR DESCRIPTION
I noticed when testing #530 that any before hook is logged before running but that we do not log the plugin we run it for.

So without this the output is not so helpful, we are running hooks but for which plugin (and if it failed would may not easily be able to tell which plugin was the cause in all cases)

This adds a simple log entry before we call the hooks

before this change

```
...
2023-04-19 15:14:29.852+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-scm-step
2023-04-19 15:14:29.853+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-step-api
2023-04-19 15:14:29.857+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-support
2023-04-19 15:14:29.865+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook
2023-04-19 15:14:29.866+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook
2023-04-19 15:14:29.866+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook
2023-04-19 15:14:29.866+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook
...
```

after this change

```
...
2023-04-19 15:35:43.307+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-scm-step
2023-04-19 15:35:43.309+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-step-api
2023-04-19 15:35:43.312+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-support
2023-04-19 15:35:43.321+0000 [id=1]     INFO    o.j.t.test.PluginCompatTester#testPlugins: Running BeforeCheckout hooks for Jenkins Active Directory plugin
2023-04-19 15:35:43.322+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook
2023-04-19 15:35:43.322+0000 [id=1]     INFO    o.j.t.test.PluginCompatTester#testPlugins: Running BeforeCheckout hooks for Analysis Model API Plugin
2023-04-19 15:35:43.322+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook
2023-04-19 15:35:43.323+0000 [id=1]     INFO    o.j.t.test.PluginCompatTester#testPlugins: Running BeforeCheckout hooks for Ant Plugin
...
```

The alternative is we add the plugin name to the log output when we run any hook, but the other hooks are contextualized by previous logging, and this could make the logs for each individual hook a little less user friendly.


<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
