### PR TITLE
Add the plugin name to the hook log

### DIFF
--- a/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
+++ b/src/main/java/org/jenkins/tools/test/model/hook/PluginCompatTesterHooks.java
@@ -58,13 +58,25 @@ public class PluginCompatTesterHooks {
      * @param context relevant information to hooks at various stages.
      */
     private <C extends StageContext> void runHooks(@NonNull C context) throws PluginCompatibilityTesterException {
-        for (PluginCompatTesterHook<C> hook :
-                (List<? extends PluginCompatTesterHook<C>>) hooksByStage.get(context.getStage())) {
+        List<? extends PluginCompatTesterHook<C>> hooks =
+                (List<? extends PluginCompatTesterHook<C>>) hooksByStage.get(context.getStage());
+
+        if (hooks.isEmpty()) {
+            LOGGER.log(Level.INFO, "No hooks registered for stage {0} for {1}", new Object[] {
+                context.getStage(), context.getPlugin().getName()
+            });
+            return;
+        }
+        for (PluginCompatTesterHook<C> hook : hooks) {
             if (!excludeHooks.contains(hook.getClass().getName()) && hook.check(context)) {
-                LOGGER.log(Level.INFO, "Running hook: {0}", hook.getClass().getName());
+                LOGGER.log(Level.INFO, "Running hook: {0} for {1}", new Object[] {
+                    hook.getClass().getName(), context.getPlugin().getName()
+                });
                 hook.action(context);
             } else {
-                LOGGER.log(Level.FINE, "Skipping hook: {0}", hook.getClass().getName());
+                LOGGER.log(Level.FINE, "Skipping hook: {0} for {1}", new Object[] {
+                    hook.getClass().getName(), context.getPlugin().getName()
+                });
             }
         }
     }


### PR DESCRIPTION
without this the output (for the BeforeCheckoutHook) is not so helpful, we are running hooks but for which plugin (and if it failed would may not easily be able to tell which plugin was the cause in all cases)

This also adds a log in the case there are no hooks to run.

Closes #531 

sample output:
```
2023-04-20 12:42:42.669+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-multibranch
2023-04-20 12:42:42.670+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-scm-step
2023-04-20 12:42:42.671+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-step-api
2023-04-20 12:42:42.674+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-support
2023-04-20 12:42:42.685+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook for Jenkins Active Directory plugin
2023-04-20 12:42:42.685+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook for Analysis Model API Plugin
2023-04-20 12:42:42.685+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook for Ant Plugin
2023-04-20 12:42:42.686+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook for OWASP Markup Formatter Plugin
2023-04-20 12:42:42.686+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook for Jenkins Apache HttpComponents Client 4.x API Plugin
2023-04-20 12:42:42.686+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook for Artifact Manager on S3 plugin
2023-04-20 12:42:42.686+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: Running hook: org.jenkins.tools.test.hook.TagValidationHook for Authentication Tokens API Plugin
```

without hooks
```
2023-04-20 12:45:24.202+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-scm-step
2023-04-20 12:45:24.204+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-step-api
2023-04-20 12:45:24.208+0000 [id=1]     INFO    o.j.tools.test.util.WarExtractor#getPlugin: Extracting metadata for workflow-support
2023-04-20 12:45:24.217+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: No hooks registered for stage CHECKOUT for Jenkins Active Directory plugin
2023-04-20 12:45:24.218+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: No hooks registered for stage CHECKOUT for Analysis Model API Plugin
2023-04-20 12:45:24.218+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: No hooks registered for stage CHECKOUT for Ant Plugin
2023-04-20 12:45:24.218+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: No hooks registered for stage CHECKOUT for OWASP Markup Formatter Plugin
2023-04-20 12:45:24.219+0000 [id=1]     INFO    o.j.t.t.m.h.PluginCompatTesterHooks#runHooks: No hooks registered for stage CHECKOUT for Jenkins Apache HttpComponents Client 4.x API Plugin
```

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
