### PR TITLE
Restore repository name to machine-parsable `list-plugins` output

### DIFF
--- a/src/test/java/org/jenkins/tools/test/PluginListerCliTest.java
+++ b/src/test/java/org/jenkins/tools/test/PluginListerCliTest.java
@@ -26,6 +26,6 @@ class PluginListerCliTest {
         assertEquals(retVal, 0);
         assertThat(outputFile, aReadableFile());
         List<String> plugins = Files.readAllLines(outputFile.toPath(), StandardCharsets.UTF_8);
-        assertThat(plugins, is(List.of("text-finder")));
+        assertThat(plugins, is(List.of("jenkinsci/text-finder-plugin\ttext-finder")));
     }
 }


### PR DESCRIPTION
A small refinement to the machine-parsable `list-plugins` output: add the repository name and owner. @jtnord's original version had included the whole Git repository URL here, but I found that unwieldy. This is more practical and has two immediate use case:

- Nicer Pipeline stage view display names for each branch in a BOM/PCT build
- The group name for [Launchable zero-input subsetting](https://www.launchableinc.com/docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/subsetting-with-the-launchable-cli/zero-input-subsetting/using-groups-to-split-subsets/)