### PR TITLE
Fixup to #536

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginListerCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginListerCli.java
@@ -29,7 +29,7 @@ import picocli.CommandLine;
         versionProvider = VersionProvider.class)
 public class PluginListerCli implements Callable<Integer> {
 
-    private static final Pattern PATTERN = Pattern.compile("^https://github.com/(.+?)/(.+?)(\\.git)?$");
+    private static final Pattern PATTERN = Pattern.compile("^(https|http|git)://github.com/(.+?)/(.+?)(\\.git)?$");
 
     @CommandLine.Option(
             names = {"-w", "--war"},
@@ -91,9 +91,9 @@ public class PluginListerCli implements Callable<Integer> {
                 for (Map.Entry<String, List<Plugin>> entry : pluginsByRepository.entrySet()) {
                     Matcher matcher = PATTERN.matcher(entry.getKey());
                     if (matcher.find()) {
-                        writer.write(matcher.group(1));
-                        writer.write('/');
                         writer.write(matcher.group(2));
+                        writer.write('/');
+                        writer.write(matcher.group(3));
                     } else {
                         throw new IllegalArgumentException("Invalid GitHub URL: " + entry.getKey());
                     }


### PR DESCRIPTION
Found a small problem when adopting #536 in BOM: `git://` URLs. This PR fixes the bug by supporting all three common URL schemes. Unlike the previous change, I tested this in context in a BOM build locally.