### PR TITLE
Remove unnecessary workarounds

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -292,90 +292,16 @@ public class PluginCompatTester {
             // See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
 
             // TODO pending release of
-            // https://github.com/jenkinsci/antisamy-markup-formatter-plugin/pull/106
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/antisamy-markup-formatter-plugin",
-                    "https://github.com/jenkinsci/antisamy-markup-formatter-plugin");
-
-            // TODO pending release of
-            // https://github.com/jenkinsci/authentication-tokens-plugin/pull/106
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/authentication-tokens-plugin",
-                    "https://github.com/jenkinsci/authentication-tokens-plugin");
-
-            // TODO pending release of
-            // https://github.com/jenkinsci/aws-global-configuration-plugin/pull/51
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/aws-global-configuration-plugin",
-                    "https://github.com/jenkinsci/aws-global-configuration-plugin");
-
-            // TODO pending release of
             // https://github.com/jenkinsci/blueocean-display-url-plugin/pull/227
             gitUrl = gitUrl.replace(
                     "git://github.com/jenkinsci/blueocean-display-url-plugin",
                     "https://github.com/jenkinsci/blueocean-display-url-plugin");
 
             // TODO pending release of
-            // https://github.com/jenkinsci/bootstrap5-api-plugin/commit/8c5f60ab5e21c03b68d696e7b760caa991b25aa9
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/bootstrap5-api-plugin",
-                    "https://github.com/jenkinsci/bootstrap5-api-plugin");
-
-            // TODO pending backport of
-            // https://github.com/jenkinsci/cloudbees-folder-plugin/pull/260
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/cloudbees-folder-plugin",
-                    "https://github.com/jenkinsci/cloudbees-folder-plugin");
-
-            // TODO pending release of
-            // https://github.com/jenkinsci/configuration-as-code-plugin/pull/2166
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/configuration-as-code-plugin",
-                    "https://github.com/jenkinsci/configuration-as-code-plugin");
-
-            // TODO pending backport of
-            // https://github.com/jenkinsci/custom-folder-icon-plugin/pull/109
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/custom-folder-icon-plugin",
-                    "https://github.com/jenkinsci/custom-folder-icon-plugin");
-
-            // TODO pending release of
-            // https://github.com/jenkinsci/data-tables-api-plugin/commit/97dc7555017e6c7ea17f0b67cc292773f1114a54
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/data-tables-api-plugin",
-                    "https://github.com/jenkinsci/data-tables-api-plugin");
-
-            // TODO pending backport of
-            // https://github.com/jenkinsci/echarts-api-plugin/commit/d6951a26e6f1c27b82c8308359f7f76e182de3e3
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/echarts-api-plugin", "https://github.com/jenkinsci/echarts-api-plugin");
-
-            // TODO pending release of
-            // https://github.com/jenkinsci/file-parameters-plugin/pull/142
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/file-parameters-plugin",
-                    "https://github.com/jenkinsci/file-parameters-plugin");
-
-            // TODO pending release of https://github.com/jenkinsci/github-api-plugin/pull/182
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/github-api-plugin", "https://github.com/jenkinsci/github-api-plugin");
-
-            // TODO pending release of
-            // https://github.com/jenkinsci/google-kubernetes-engine-plugin/pull/312
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/google-kubernetes-engine-plugin",
-                    "https://github.com/jenkinsci/google-kubernetes-engine-plugin");
-
-            // TODO pending release of
             // https://github.com/jenkinsci/google-metadata-plugin/pull/50
             gitUrl = gitUrl.replace(
                     "git://github.com/jenkinsci/google-metadata-plugin",
                     "https://github.com/jenkinsci/google-metadata-plugin");
-
-            // TODO pending release of https://github.com/jenkinsci/google-oauth-plugin/pull/176
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/google-oauth-plugin",
-                    "https://github.com/jenkinsci/google-oauth-plugin");
 
             // TODO pending release of
             // https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/37
@@ -389,21 +315,11 @@ public class PluginCompatTester {
                     "git://github.com/jenkinsci/kubernetes-credentials-provider-plugin",
                     "https://github.com/jenkinsci/kubernetes-credentials-provider-plugin");
 
-            // TODO pending adoption of https://github.com/jenkinsci/matrix-auth-plugin/pull/131
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/matrix-auth-plugin", "https://github.com/jenkinsci/matrix-auth-plugin");
-
             // TODO pending release of
             // https://github.com/jenkinsci/node-iterator-api-plugin/pull/11
             gitUrl = gitUrl.replace(
                     "git://github.com/jenkinsci/node-iterator-api-plugin",
                     "https://github.com/jenkinsci/node-iterator-api-plugin");
-
-            // TODO pending release of
-            // https://github.com/jenkinsci/oauth-credentials-plugin/pull/9
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/oauth-credentials-plugin",
-                    "https://github.com/jenkinsci/oauth-credentials-plugin");
 
             // TODO pending release of
             // https://github.com/jenkinsci/popper2-api-plugin/commit/bf781e31b072103f3f72d7195e9071863f7f4dd9
@@ -417,14 +333,6 @@ public class PluginCompatTester {
 
             // TODO pending release of https://github.com/jenkinsci/s3-plugin/pull/243
             gitUrl = gitUrl.replace("git://github.com/jenkinsci/s3-plugin", "https://github.com/jenkinsci/s3-plugin");
-
-            // TODO pending release of https://github.com/jenkinsci/ssh-agent-plugin/pull/116
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/ssh-agent-plugin", "https://github.com/jenkinsci/ssh-agent-plugin");
-
-            // TODO pending release of https://github.com/jenkinsci/ssh-slaves-plugin/pull/352
-            gitUrl = gitUrl.replace(
-                    "git://github.com/jenkinsci/ssh-slaves-plugin", "https://github.com/jenkinsci/ssh-slaves-plugin");
 
             // TODO pending release of
             // https://github.com/jenkinsci/theme-manager-plugin/pull/154


### PR DESCRIPTION
The linked PRs have been merged, released, and adopted, so these workarounds are no longer necessary.