### PR TITLE
Support testing SNAPSHOTs that have a deterministic git revision

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/HpiPluginHook.java
@@ -5,10 +5,11 @@ import org.kohsuke.MetaInfServices;
 
 /**
  * The {@code overrideWar} option is available in HPI Plugin 3.29 or later, but many plugins under
- * test still use an older plugin parent POM and therefore an older HPI plugin version. As a
- * temporary workaround, we override the HPI plugin version to a recent version. When all plugins in
- * the managed set are using a plugin parent POM with HPI Plugin 3.29 or later (i.e., plugin parent
- * POM 4.44 or later), this can be deleted.
+ * test still use an older plugin parent POM and therefore an older HPI plugin version.
+ * Additionally the code did not work correctly with SNAPSHOT versions until HPI Plugin version 3.44.
+ * As a temporary workaround, we override the HPI plugin version to a recent version. When all plugins in
+ * the managed set are using a plugin parent POM with HPI Plugin 3.44 or later (i.e., plugin parent
+ * POM 4.63 or later), this can be deleted.
  */
 @MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
 public class HpiPluginHook extends PropertyVersionHook {
@@ -20,6 +21,6 @@ public class HpiPluginHook extends PropertyVersionHook {
 
     @Override
     public String getMinimumVersion() {
-        return "3.41";
+        return "3.44";
     }
 }

--- a/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/TagValidationHook.java
@@ -1,6 +1,7 @@
 package org.jenkins.tools.test.hook;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkins.tools.test.exception.PluginSourcesUnavailableException;
 import org.jenkins.tools.test.model.hook.BeforeCheckoutContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeCheckout;
@@ -14,10 +15,14 @@ public class TagValidationHook extends PluginCompatTesterHookBeforeCheckout {
         return context.getConfig().getLocalCheckoutDir() == null;
     }
 
+    @SuppressFBWarnings(
+            value = "UNSAFE_HASH_EQUALS",
+            justification = "We are not used Git SHA comparisons for security")
     @Override
     public void action(@NonNull BeforeCheckoutContext context) throws PluginSourcesUnavailableException {
-        String tag = context.getPlugin().getTag();
-        if (tag == null || tag.equals("HEAD")) {
+        // legacy extractors set the gitHash to the tag - so we just need to check the tag.
+        String gitHash = context.getPlugin().getGitHash();
+        if (gitHash == null || gitHash.equals("HEAD")) {
             throw new PluginSourcesUnavailableException("Failed to check out plugin sources for "
                     + context.getPlugin().getPluginId());
         }

--- a/src/main/java/org/jenkins/tools/test/model/plugin_metadata/Plugin.java
+++ b/src/main/java/org/jenkins/tools/test/model/plugin_metadata/Plugin.java
@@ -66,6 +66,7 @@ public class Plugin {
 
     /**
      * The Git tag for this plugin as reported by Maven; may be {@code null} if Maven is not aware of a tag or for a local checkout.
+     * Code should prefer {@link #getGitHash()} if obtaining a commit to checkout.
      */
     @CheckForNull
     public String getTag() {


### PR DESCRIPTION
If a `SNAPSHOT` build is in the override war and it was built with a version of `maven-hpi-plugin` `3.42` or higher (jenkinsci/maven-hpi-plugin#436) then we have a concrete git sha we can use for checkout of the plugin.

So this relaxes the enforcement of not building non releases by allowing to test a SNAPSHOT also so long as we have a git commit for it.

in the case the commit is HEAD (which is set by the legacy plugin extractors) then we will refuse to test the plugin the same as we do today.

<!-- Please describe your pull request here. -->

### Testing done

* I deployed a unique snapshot of a multi-module project (version number made unique by changing it to `2.25-JTN-SNAPSHOT`
* The deployed version was then used in a custom war (`2.25-JTN-20230512.152321-1`) 
* The war was then run through CloudBees' PCT setup

I manually inspected the resulting logs and ensured that:

* Each plugin from the multi-module project was checked out and had the PCT run against it correctly
* plugins that dependend on any of the plugins deployed in step 1 where correctly updated by `maven-hpi-plugin` to use the  SNAPSHOT version of the dependency

e.g. 
```
[2023-05-12T21:13:02.916Z] [INFO] After resolving,
 updates: {com.cloudbees.jenkins.plugins:cloudbees-casc-items-controller=2.25-JTN-20230512.152321-1, ....
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
