### PR TITLE
Adapt to authentication-tokens 1.4 git:// in pom file

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -296,6 +296,13 @@ public class PluginCompatTester {
         for (String gitUrl : gitUrls) {
             // See: https://github.blog/2021-09-01-improving-git-protocol-security-github/
 
+            // TODO pending backport of
+            // https://github.com/jenkinsci/authentication-tokens-plugin/pull/106
+            // to 2.375.x
+            gitUrl = gitUrl.replace(
+                    "git://github.com/jenkinsci/authentication-tokens-plugin",
+                    "https://github.com/jenkinsci/authentication-tokens-plugin");
+
             // TODO pending release of
             // https://github.com/jenkinsci/blueocean-display-url-plugin/pull/227
             gitUrl = gitUrl.replace(


### PR DESCRIPTION
## Adapt to authentication-tokens 1.4 git:// in pom file

https://github.com/jenkinsci/bom/issues/2095 requests the addition of authentication tokens to the managed set in the plugin bill of materials.

https://github.com/jenkinsci/bom/pull/2189 implements that but shows that the addition fails because authentication-tokens plugin 1.4 needs to be pinned for Jenkins 2.375.x and authentication-tokens plugin 1.4 lists its SCM location with a git:// protocol URL instead of an https:// protocol URL.

Use the same workaround that is used for other older plugins.

This can be removed once the 2.375.x line is no longer needed in the plugin bill of materials.

### Testing done

Maven runs successfully on Linux with Java 11.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
