### PR TITLE
Honor `Add-Opens` directives from the Jenkins WAR under test

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -247,6 +247,7 @@ public class PluginCompatTester {
         List<String> args = new ArrayList<>();
         args.add("hpi:resolve-test-dependencies");
         args.add("hpi:test-hpl");
+        args.add("hpi:test-runtime");
         args.add("surefire:test");
 
         // Run preexecution hooks

--- a/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/hook/JacocoHookTest.java
@@ -37,14 +37,20 @@ class JacocoHookTest {
     void testAction() {
         final JacocoHook hook = new JacocoHook();
 
-        List<String> args = new ArrayList<>(List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test"));
+        List<String> args = new ArrayList<>(
+                List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "hpi:test-runtime", "surefire:test"));
         BeforeExecutionContext context = new BeforeExecutionContext(null, null, null, null, args);
 
         hook.action(context);
         // order is importat
         assertThat(
                 args,
-                contains("jacoco:prepare-agent", "hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test"));
+                contains(
+                        "jacoco:prepare-agent",
+                        "hpi:resolve-test-dependencies",
+                        "hpi:test-hpl",
+                        "hpi:test-runtime",
+                        "surefire:test"));
 
         args = new ArrayList<>(List.of("other-plugin:other-goal", "surefire:test"));
         context = new BeforeExecutionContext(null, null, null, null, args);

--- a/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
+++ b/src/test/java/org/jenkins/tools/test/hook/WarningsNGExecutionHookTest.java
@@ -37,13 +37,18 @@ class WarningsNGExecutionHookTest {
     void testAction() {
         final WarningsNGExecutionHook hook = new WarningsNGExecutionHook();
 
-        List<String> args = new ArrayList<>(List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test"));
+        List<String> args = new ArrayList<>(
+                List.of("hpi:resolve-test-dependencies", "hpi:test-hpl", "hpi:test-runtime", "surefire:test"));
         BeforeExecutionContext context = new BeforeExecutionContext(null, null, null, null, args);
         hook.action(context);
         // failsafe tests after surefire to match a general build.
         assertThat(
                 args,
                 contains(
-                        "hpi:resolve-test-dependencies", "hpi:test-hpl", "surefire:test", "failsafe:integration-test"));
+                        "hpi:resolve-test-dependencies",
+                        "hpi:test-hpl",
+                        "hpi:test-runtime",
+                        "surefire:test",
+                        "failsafe:integration-test"));
     }
 }


### PR DESCRIPTION
In a regular plugin build, the `hpi:test-runtime` mojo is responsible for setting the `Add-Opens` directives as they are contained in the Jenkins WAR under test, but this was not being called from PCT. Instead we were using the fallback code path from https://github.com/jenkinsci/plugin-pom/blob/620115c9dee7ddd9f8c8b42f968f44d54278c671/pom.xml#L65-L66 which works but is fragile, as the `Add-Opens` directives may change in future versions of Jenkins. To test this I ran PCT with these changes and verified that `Add-Opens` from the WAR under test were being honored. I also ran BOM tests here: https://ci.jenkins.io/blue/organizations/jenkins/Tools%2Fbom/detail/PR-2217/1/pipeline