### PR TITLE
reintroduce workaround for kubernetes-credentials-plugin

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -295,6 +295,10 @@ public class PluginCompatTester {
 
         PluginSourcesUnavailableException lastException = null;
         for (String gitUrl : gitUrls) {
+            // TODO pending removal of bom 2.387 line
+            gitUrl = gitUrl.replace(
+                    "git://github.com/jenkinsci/kubernetes-credentials-plugin",
+                    "https://github.com/jenkinsci/kubernetes-credentials-plugin");
             try {
                 cloneImpl(gitUrl, scmTag, checkoutDirectory);
                 return; // checkout was ok


### PR DESCRIPTION
kubernetes-credentials still needs a workaround on old lines.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
