### PR TITLE
Introduce a more useful `ExternalMavenRunner` constructor

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTester.java
@@ -82,7 +82,7 @@ public class PluginCompatTester {
 
     public PluginCompatTester(PluginCompatTesterConfig config) {
         this.config = config;
-        runner = new ExternalMavenRunner(config.getExternalMaven(), config.getMavenSettings(), config.getMavenArgs());
+        runner = new ExternalMavenRunner(config);
     }
 
     @SuppressFBWarnings(

--- a/src/main/java/org/jenkins/tools/test/hook/PropertyVersionHook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/PropertyVersionHook.java
@@ -6,7 +6,6 @@ import org.jenkins.tools.test.exception.PomExecutionException;
 import org.jenkins.tools.test.maven.ExpressionEvaluator;
 import org.jenkins.tools.test.maven.ExternalMavenRunner;
 import org.jenkins.tools.test.maven.MavenRunner;
-import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
 import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
 
@@ -27,9 +26,7 @@ public abstract class PropertyVersionHook extends PluginCompatTesterHookBeforeEx
 
     @Override
     public boolean check(@NonNull BeforeExecutionContext context) {
-        PluginCompatTesterConfig config = context.getConfig();
-        MavenRunner runner =
-                new ExternalMavenRunner(config.getExternalMaven(), config.getMavenSettings(), config.getMavenArgs());
+        MavenRunner runner = new ExternalMavenRunner(context.getConfig());
         ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(
                 context.getCloneDirectory(), context.getPlugin().getModule(), runner);
         try {

--- a/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
+++ b/src/main/java/org/jenkins/tools/test/maven/ExternalMavenRunner.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.lang.SystemUtils;
 import org.jenkins.tools.test.exception.PomExecutionException;
+import org.jenkins.tools.test.model.PluginCompatTesterConfig;
 
 /** Runs external Maven executable. */
 public class ExternalMavenRunner implements MavenRunner {
@@ -50,6 +51,13 @@ public class ExternalMavenRunner implements MavenRunner {
         this.externalMaven = externalMaven;
         this.mavenSettings = mavenSettings;
         this.mavenArgs = mavenArgs;
+    }
+
+    /**
+     * @param config The PCT configuration to extract maven arguments from.
+     */
+    public ExternalMavenRunner(@NonNull PluginCompatTesterConfig config) {
+        this(config.getExternalMaven(), config.getMavenSettings(), config.getMavenArgs());
     }
 
     @Override


### PR DESCRIPTION
In practice, all usages of the `ExternalMavenRunner` constructor I've seen are driven from `PluginCompatTesterConfig`.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
