### PR TITLE
Fix `--no-fail-fast` option

### DIFF
--- a/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
+++ b/src/main/java/org/jenkins/tools/test/PluginCompatTesterCli.java
@@ -158,9 +158,11 @@ public class PluginCompatTesterCli implements Callable<Integer> {
     @CommandLine.Option(
             names = "--fail-fast",
             negatable = true,
+            defaultValue = "true",
+            fallbackValue = "true",
             description =
                     "If multiple plugins are specified, fail the overall run after the first plugin failure occurs rather than continuing to test other plugins.")
-    private boolean failFast = true;
+    private boolean failFast;
 
     @Override
     public Integer call() throws PluginCompatibilityTesterException {


### PR DESCRIPTION
While trying to use `--no-fail-fast`, I discovered it didn't actually work. Reading [the documentation](https://picocli.info/#_negatable_options), it says:

> Negatable options that are `true` by default
>
> When a negatable option is `true` by default, give it both a `defaultValue` and a `fallbackValue` of `"true"`.

Doing as the documentation suggested fixed the bug.

### Testing done

Interactively tested with both `--fail-fast` (fails fast), `--no-fail-fast` (now does not fail fast, which is the bug fix), and no option (maintains the existing behavior of failing fast).