### PR TITLE
[JENKINS-73282] Run PCT with a Jetty 12 EE 8 test harness when core is Jetty 12 EE 8

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/Jetty12Hook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/Jetty12Hook.java
@@ -1,0 +1,66 @@
+package org.jenkins.tools.test.hook;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.VersionNumber;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import org.jenkins.tools.test.model.hook.BeforeExecutionContext;
+import org.jenkins.tools.test.model.hook.PluginCompatTesterHookBeforeExecution;
+import org.kohsuke.MetaInfServices;
+
+/**
+ * Ensure that if the core is on Jetty 12, that the test harness is on Jetty 12 as well.
+ */
+@MetaInfServices(PluginCompatTesterHookBeforeExecution.class)
+public class Jetty12Hook extends PropertyVersionHook {
+
+    @Override
+    public String getProperty() {
+        return "jenkins-test-harness.version";
+    }
+
+    @Override
+    public String getMinimumVersion() {
+        return "2230.v4fa_477b_634f4";
+    }
+
+    @Override
+    public boolean check(@NonNull BeforeExecutionContext context) {
+        VersionNumber winstoneVersion = getWinstoneVersion(context.getConfig().getWar());
+        if (winstoneVersion.getDigitAt(0) < 7) {
+            return false;
+        }
+        return super.check(context);
+    }
+
+    private VersionNumber getWinstoneVersion(File war) {
+        try (JarFile jarFile = new JarFile(war)) {
+            ZipEntry zipEntry = jarFile.getEntry("executable/winstone.jar");
+            if (zipEntry == null) {
+                throw new IllegalArgumentException("Failed to find winstone.jar in " + war);
+            }
+            try (InputStream is = jarFile.getInputStream(zipEntry);
+                    BufferedInputStream bis = new BufferedInputStream(is);
+                    JarInputStream jis = new JarInputStream(bis)) {
+                Manifest manifest = jis.getManifest();
+                if (manifest == null) {
+                    throw new IllegalArgumentException("Failed to read manifest in " + war);
+                }
+                String version = manifest.getMainAttributes().getValue("Implementation-Version");
+                if (version == null) {
+                    throw new IllegalArgumentException("Failed to read Winstone version from manifest in " + war);
+                }
+                return new VersionNumber(version);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read Winstone version in " + war, e);
+        }
+    }
+}


### PR DESCRIPTION
See [JENKINS-73282](https://issues.jenkins.io/browse/JENKINS-73282). This PR has no effect for trunk, but once core adopts Jetty 12, this will dynamically upgrade the test harness to a Jetty 12 test harness (but only if necessary). The minimum test harness release is https://github.com/jenkinsci/jenkins-test-harness/releases/tag/2230.v4fa_477b_634f4 which supports Jetty 12 EE 8 and EE 9. This will allow plugins to be tested on Jetty 12 in PCT without having to upgrade each plugin's parent POM individually. Of course, once the plugin parent POMs are updated, this will have no effect. Eventually this code can be deleted once all plugins are on a plugin parent POM that includes Jetty 12 in its test harness.

### Testing done

Tested with the latest weekly core as well as a Jetty 12 EE 8 core. In the latter case, the test harness was automatically upgraded as expected. Tested interactively in BOM in https://github.com/jenkinsci/bom/pull/3314.