### PR TITLE
Fix JUnit 5 tests when overriding test harness

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/Jetty12Hook.java
+++ b/src/main/java/org/jenkins/tools/test/hook/Jetty12Hook.java
@@ -63,4 +63,15 @@ public class Jetty12Hook extends PropertyVersionHook {
             throw new UncheckedIOException("Failed to read Winstone version in " + war, e);
         }
     }
+
+    @Override
+    public void action(@NonNull BeforeExecutionContext context) {
+        super.action(context);
+        /*
+         * The version of JUnit 5 used at runtime must match the version of JUnit 5 used to compile the tests, but the
+         * inclusion of a newer test harness might cause the HPI plugin to try to use a newer version of JUnit 5 at
+         * runtime to satisfy upper bounds checks, so exclude JUnit 5 from upper bounds analysis.
+         */
+        context.getArgs().add("-DupperBoundsExcludes=org.junit.jupiter:junit-jupiter-api");
+    }
 }


### PR DESCRIPTION
After https://github.com/jenkinsci/pom/pull/575 the test harness now depends on a new version of JUnit. When using this new test harness against older plugins that are compiled with an old version of JUnit, upper bounds analysis kicks in and upgrades JUnit 5 at runtime, which now results in a different version of JUnit 5 being used at runtime vs compile time, which causes errors like this:

```
Caused by: java.lang.NoSuchMethodError: 'java.util.stream.Stream org.junit.platform.commons.support.ReflectionSupport.streamNestedClasses(java.lang.Class, java.util.function.Predicate)'
	at org.junit.jupiter.engine.discovery.ClassSelectorResolver.lambda$toResolution$12 (ClassSelectorResolver.java:138)
	at org.junit.platform.engine.support.discovery.SelectorResolver$Match.expand (SelectorResolver.java:668)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.lambda$enqueueAdditionalSelectors$1 (EngineDiscoveryRequestResolution.java:110)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept (ForEachOps.java:183)
	at java.util.stream.ReferencePipeline$2$1.accept (ReferencePipeline.java:179)
	at java.util.Collections$2.tryAdvance (Collections.java:4853)
	at java.util.Collections$2.forEachRemaining (Collections.java:4861)
	at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:509)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:499)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential (ForEachOps.java:150)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential (ForEachOps.java:173)
	at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach (ReferencePipeline.java:596)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.enqueueAdditionalSelectors (EngineDiscoveryRequestResolution.java:109)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolveCompletely (EngineDiscoveryRequestResolution.java:95)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.run (EngineDiscoveryRequestResolution.java:83)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver.resolve (EngineDiscoveryRequestResolver.java:113)
	at org.junit.jupiter.engine.discovery.DiscoverySelectorResolver.resolveSelectors (DiscoverySelectorResolver.java:46)
	at org.junit.jupiter.engine.JupiterTestEngine.discover (JupiterTestEngine.java:69)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot (EngineDiscoveryOrchestrator.java:152)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverSafely (EngineDiscoveryOrchestrator.java:132)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover (EngineDiscoveryOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover (EngineDiscoveryOrchestrator.java:78)
	at org.junit.platform.launcher.core.DefaultLauncher.discover (DefaultLauncher.java:99)
	at org.junit.platform.launcher.core.DefaultLauncher.discover (DefaultLauncher.java:77)
	at org.junit.platform.launcher.core.DelegatingLauncher.discover (DelegatingLauncher.java:42)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.discover (LazyLauncher.java:50)
	at org.apache.maven.surefire.junitplatform.TestPlanScannerFilter.accept (TestPlanScannerFilter.java:52)
	at org.apache.maven.surefire.api.util.DefaultScanResult.applyFilter (DefaultScanResult.java:87)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.scanClasspath (JUnitPlatformProvider.java:142)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.getSuites (JUnitPlatformProvider.java:102)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke (Method.java:568)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray (ReflectionUtils.java:125)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeGetter (ReflectionUtils.java:62)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeGetter (ReflectionUtils.java:57)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.getSuites (ProviderFactory.java:137)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.getSuitesIterator (ForkStarter.java:676)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.runSuitesForkPerTestSet (ForkStarter.java:385)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run (ForkStarter.java:297)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run (ForkStarter.java:250)
	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider (AbstractSurefireMojo.java:1241)
	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked (AbstractSurefireMojo.java:1090)
	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute (AbstractSurefireMojo.java:910)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
	at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
	at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
	at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
	at io.takari.maven.builder.smart.SmartBuilderImpl.buildProject (SmartBuilderImpl.java:206)
	at io.takari.maven.builder.smart.SmartBuilderImpl$ProjectBuildTask.run (SmartBuilderImpl.java:71)
	at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
	at java.util.concurrent.FutureTask.run (FutureTask.java:264)
	at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
	at java.lang.Thread.run (Thread.java:840)
```

This PR fixes the issue by excluding JUnit 5 from upper bounds analysis.

### Testing done

Reproduced the above failure and could no longer reproduce with this PR.