### PR TITLE
Eliminate redundant property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <!-- TODO until a critical mass has migrated to Java 17 -->
     <maven.compiler.release>11</maven.compiler.release>
     <picocli.version>4.7.6</picocli.version>
-    <slf4j.version>2.0.13</slf4j.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotless.check.skip>false</spotless.check.skip>
     <argLine />
@@ -41,7 +40,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
-        <version>${slf4j.version}</version>
+        <version>2.0.16</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -103,7 +102,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
No need to specify a version for `slf4j-jdk14` when it is already defined by the BOM. While I was here I also updated to the latest version.