### PR TITLE
Require Java 17 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/plugin-compat-tester</gitHubRepo>
     <jenkins.version>2.475</jenkins.version>
-    <!-- TODO until a critical mass has migrated to Java 17 -->
-    <maven.compiler.release>11</maven.compiler.release>
     <picocli.version>4.7.6</picocli.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
We're rapidly approaching a critical mass on Java 17. Since releases of this component are so rare, it seems fine to merge this PR now and then it can be released whenever. By the time it is released, we should surely be at a Java 17 critical mass.