### PR TITLE
Clean up dependency tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/plugin-compat-tester</gitHubRepo>
-    <jenkins.version>2.477</jenkins.version>
+    <jenkins.version>2.476</jenkins.version>
     <picocli.version>4.7.6</picocli.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotless.check.skip>false</spotless.check.skip>
@@ -110,18 +110,6 @@
       <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>${jenkins.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Jenkins core was only ever in the dependency tree so that Dependabot could update it, but Dependabot can now handle updates to dependencies fetched by `maven-dependency-plugin`, so this is no longer needed.

Intentionally downgrading Jenkins core to test that Dependabot can upgrade it again.

### Testing done

`mvn clean verify`