### PR TITLE
Revert "Clean up dependency tree"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/plugin-compat-tester</gitHubRepo>
-    <jenkins.version>2.476</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <picocli.version>4.7.6</picocli.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotless.check.skip>false</spotless.check.skip>
@@ -110,6 +110,18 @@
       <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>${jenkins.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverting jenkinsci/plugin-compat-tester#710 as Dependabot isn't able to update Jenkins core in this case (something about `executable-war` vs `war`, probably a Dependabot bug). Renovate would likely work here, but in the meantime restore the status quo.