### PR TITLE
Bump minimum JTH version in `JenkinsTestHarnessHook2`

### DIFF
--- a/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook2.java
+++ b/src/main/java/org/jenkins/tools/test/hook/JenkinsTestHarnessHook2.java
@@ -30,7 +30,7 @@ public class JenkinsTestHarnessHook2 extends PropertyVersionHook {
 
     @Override
     public String getDefaultMinimumVersion() {
-        return "2386.v82359624ea_05";
+        return "2438.v25a_85fb_0328f";
     }
 
     @Override


### PR DESCRIPTION
Updates the test harness for older BOM lines. Should not affect CloudBees CI, as that is not (yet) using `JenkinsTestHarnessHook2`. The older `JenkinsTestHarnessHook` still used by CloudBees CI is unaffected.

### Testing done

Will run BOM with `full-test`.