### PR TITLE
Reduce noise from `WarExtractor`

### DIFF
--- a/src/main/java/org/jenkins/tools/test/util/WarExtractor.java
+++ b/src/main/java/org/jenkins/tools/test/util/WarExtractor.java
@@ -108,7 +108,7 @@ public class WarExtractor {
                 return false;
             }
             if (includedPlugins != null && !includedPlugins.isEmpty() && !includedPlugins.contains(pluginId)) {
-                LOGGER.log(Level.INFO, "Plugin {0} not in included plugins; skipping", pluginId);
+                LOGGER.fine(() -> "Plugin " + pluginId + " not in included plugins; skipping");
                 return false;
             }
             return true;


### PR DESCRIPTION
Similar to https://github.com/jenkinsci/maven-hpi-plugin/pull/770, in this case accounting for 18% of log lines in an entire build with this not-very-relevant message. (The CloudBees CI PCT build runs one plugin at a time, so each PCT invocation on a megawar with 200 plugins in it will print 199 lines about plugins it is _not_ testing.)
